### PR TITLE
fix: Correctly add/remove Member from Memberstore -> Members -> Role

### DIFF
--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -173,6 +173,9 @@ func (m *MembersStore) AddMember(member string, roles []string) {
 			panic("role: " + role + " does not exist")
 		}
 		membersRoles.Set(role, struct{}{})
+		roleDataRaw, _ := m.Roles.Get(role)
+		roleData := roleDataRaw.(*Role)
+		roleData.Members.Set(member, struct{}{})
 	}
 	m.Members.Set(member, membersRoles)
 
@@ -204,7 +207,7 @@ func (m *MembersStore) RemoveMember(member string) {
 		if !ok {
 			panic("a value of memberstore.roles is not a Role, should not happen")
 		}
-		role.Members.Remove(role.Name)
+		role.Members.Remove(member)
 		return false
 	})
 	m.Members.Remove(member)


### PR DESCRIPTION
## Issue (How to reproduce)
### AddMember
Here: https://github.com/WaDadidou/gnodaokit/blob/fix-add-remove-member/gno/r/daodemo/simple_dao/simple_dao.gno#L64

Add `memberStore.GetMembersWithRole("admin")` 
-> You get an empty slice. It shouldn't be

### RemoveMember (After fixing AddMember)
Here: https://github.com/WaDadidou/gnodaokit/blob/fix-add-remove-member/gno/r/daodemo/simple_dao/simple_dao.gno#L64

Add 
```
memberStore.RemoveMember("g126gx6p6d3da4ymef35ury6874j6kys044r7zlg")
memberStore.GetMembersWithRole("admin")
```
-> You get a slice containing `"g126gx6p6d3da4ymef35ury6874j6kys044r7zlg"` as `"admin"`. It shouldn't be

## The fix
### AddMember
In addition to fill `Memberstore Members`, we also add the new member in `Role Members`

### RemoveMember
To correctly remove the member from `Role Members`, we use `member` as key instead of `role.Name`
