### PR TITLE
feat: Display link to role in conditions renders

### DIFF
--- a/gno/p/basedao/utils.gno
+++ b/gno/p/basedao/utils.gno
@@ -34,6 +34,15 @@ func RenderAddressLink(addr string) string {
 	return md.Link(TruncateMiddle(addr), ufmt.Sprintf("/u/%s", addr))
 }
 
+// RenderWithRolesLinks replaces all occurrences of roles in the given string with clickable links in Markdown.
+func (d *DAOPrivate) RenderWithRolesLinks(s string) string {
+	roles := d.Members.GetRoles()
+	for _, role := range roles {
+		s = strings.ReplaceAll(s, role, d.RenderRoleLink(role))
+	}
+	return s
+}
+
 // RenderRoleLink formats a role as a clickable link in Markdown.
 func (d *DAOPrivate) RenderRoleLink(role string) string {
 	pkgPath := d.Realm.PkgPath()

--- a/gno/p/basedao/view_config_page.gno
+++ b/gno/p/basedao/view_config_page.gno
@@ -43,7 +43,7 @@ func (d *DAOPrivate) ConfigResourcesView() string {
 		// TODO: add doc to handler and print here
 		s += ufmt.Sprintf("  - **Name:** %s\n", resource.DisplayName)
 		s += ufmt.Sprintf("  - **Description:** %s\n", resource.Description)
-		s += ufmt.Sprintf("  - **Condition:** %s\n\n", resource.Condition.Render())
+		s += ufmt.Sprintf("  - **Condition:** %s\n\n", d.RenderWithRolesLinks(resource.Condition.Render()))
 		i += 1
 		return false
 	})

--- a/gno/p/basedao/view_proposal_detail_page.gno
+++ b/gno/p/basedao/view_proposal_detail_page.gno
@@ -17,9 +17,12 @@ func (d *DAOPrivate) ProposalDetailPageView(idu uint64) string {
 }
 
 func (d *DAOPrivate) ProposalDetailHeaderView() string {
+	pkgPath := d.Realm.PkgPath()
+	linkPath := getLinkPath(pkgPath)
 	name := d.GetProfileString(d.Realm.Address(), "DisplayName", "DAO")
 	s := ""
 	s += ufmt.Sprintf("# %s - Proposal Detail\n\n", name)
+	s += md.Link("> Go to Proposals", linkPath+":"+PROPOSALS_PATH) + "\n"
 	s += ufmt.Sprintf("\n--------------------------------\n")
 	return s
 }
@@ -34,7 +37,7 @@ func (d *DAOPrivate) ProposalDetailView(idu uint64) string {
 	resource := d.Core.Resources.Get(proposal.Action.Type())
 	s += ufmt.Sprintf("  - **Name:** %s\n", resource.DisplayName)
 	s += ufmt.Sprintf("  - **Description:** %s\n", resource.Description)
-	s += ufmt.Sprintf("  - **Condition:** %s\n\n", resource.Condition.Render())
+	s += ufmt.Sprintf("  - **Condition:** %s\n\n", d.RenderWithRolesLinks(resource.Condition.Render()))
 	s += ("---\n\n")
 	s += proposal.Action.String() + "\n\n"
 	s += ("---\n\n")
@@ -56,7 +59,7 @@ func (d *DAOPrivate) ProposalDetailView(idu uint64) string {
 
 	s += ufmt.Sprintf("> proposed by %s 👤\n\n", proposal.ProposerID)
 	s += ufmt.Sprintf("\n--------------------------------\n")
-	s += ufmt.Sprintf("## Votes 🗳️\n\n%s\n\n", proposal.Condition.RenderWithVotes(proposal.Ballot))
+	s += ufmt.Sprintf("## Votes 🗳️\n\n%s\n\n", d.RenderWithRolesLinks(proposal.Condition.RenderWithVotes(proposal.Ballot)))
 	s += ufmt.Sprintf("\n--------------------------------\n")
 	return s
 }


### PR DESCRIPTION
Fixes https://github.com/samouraiworld/gnodaokit/issues/21
> Have a link when displaying a role to the details of that role, might be quite useful in the rendering of conditions that use roles to know who to contact to get a proposal passed.

## Purpose
- Add a function to parse a string by searching the roles and replace them by `RenderRoleLink` usage
- Use it in two pages


## This change is visible here:
####  `/r/samcrew/daodemo/simple_dao:config`
<img width="439" height="38" alt="image" src="https://github.com/user-attachments/assets/e05501e0-908c-4421-956f-880d7a858943" />


#### `/r/samcrew/daodemo/simple_dao:proposal/16`
<img width="439" height="38" alt="image" src="https://github.com/user-attachments/assets/df0beb64-36bd-495e-a2ab-78629510a0c5" />
<img width="601" height="268" alt="image" src="https://github.com/user-attachments/assets/0dbc10a2-fdca-482c-bc2e-5ab8f844efb6" />
