### PR TITLE
chore(ci): bump pinned gno toolchain (includes upstream #5357)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GNOVERSION=4e80c37e8d1870aa5d3b01966ed4c5dfa18a7566
+GNOVERSION=5111dbc2287377990a1366cd369971cb299a1c43
 GNO=go run github.com/gnolang/gno/gnovm/cmd/gno@${GNOVERSION}
 
 .PHONY: dev


### PR DESCRIPTION
## Summary

Bumps `GNOVERSION` in the Makefile from `4e80c37e` (gno @ 2025-09-29) to `5111dbc2` (gno master HEAD @ 2026-05-11).

## Root cause

Every branch's CI was failing with:

```
amino: unrecognized concrete type full name vm.InvalidPackageError
```

This is fixed upstream by gno PR [#5357](https://github.com/gnolang/gno/pull/5357) (commit `6d40b3207`, 2026-03-25), which registers `vm.InvalidPackageError` / `vm.InvalidFileError` in the gno CLI's amino codec. Before that, the CLI couldn't decode the typed errors that `vm.QueryFile` started returning after #4410 (gnomod.toml v2 introduced typed errors in `vm/qfile` ABCI responses).

Last green CI on `main` was 2025-11-12 (run `19292629043`/`19292629044`); no main commits since masked the rot.

## Why this specific commit (and not v1.1.0)

I tried `96264d21d` (`v1.1.0` / `chain/gnoland1.1`, 2026-04-01) first — that's the gno commit running on `gnoland1`, so it mirrors deployed-chain behaviour. **It did not work** ([CI run](https://github.com/samouraiworld/gnodaokit/actions/runs/25683444549)). Reason: the v1.1.0 release branch is for the chain runtime, not the CLI tooling. PR #5357 fixed a CLI/codec issue and was not backported to the v1.1 release line — only master has it.

`5111dbc2` = gno `master` HEAD as of today (2026-05-11). Includes #5357 plus 6 weeks of stabilization. Subject: `fix(tm2): add duplicate peer protection (#5319)`.

Trade-off vs picking a tagged release:
- master HEAD isn't a release tag, so it could shift if we re-bumped naively. The pin is a 40-char SHA, so it's immutable in practice.
- If/when gno ships a release line that backports #5357 (e.g. `v1.1.1` or `v1.2.0`), switch to that for stability symmetry with the chain.

## Diff

```diff
-GNOVERSION=4e80c37e8d1870aa5d3b01966ed4c5dfa18a7566
+GNOVERSION=5111dbc2287377990a1366cd369971cb299a1c43
```

One-line change.

## Test plan
- [ ] `gno-lint` job green on this PR
- [ ] `gno-test` job green on this PR
- [ ] After merge, rebase gnodaokit#62 (security audit v5 realm fixes) onto new main and confirm its CI goes green too

## History
- v1: `4e80c37e` → `96264d21d` (v1.1.0). Failed: lacks #5357.
- v2 (current): `4e80c37e` → `5111dbc2` (master HEAD with #5357). Force-pushed.

## Notes
- Marked **Draft** to mirror the Memba v7.1 Phase 1 drafts-only-first protocol. Pure CI/tooling change, no realm code touched — review surface is one byte string.