### PR TITLE
fix(basedao): reject empty member ids and use the constructor's realm

### DIFF
--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -419,10 +419,9 @@ func Post(cur realm, title, content string) {
 }
 ```
 
-`Post` is a crossing function so that `cur.Previous()` names the realm or
-account that actually called it. Reading the caller from
-`unsafe.PreviousRealm()` in a non-crossing function walks the stack instead,
-which names the outermost crossing realm rather than the immediate caller.
+`Post` is a crossing function so `cur.Previous()` names its immediate caller.
+`unsafe.PreviousRealm()` in a non-crossing function names the outermost
+crossing realm instead.
 
 The extension is automatically registered when you create a DAO with `basedao.New()`.
 

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -400,23 +400,29 @@ if ext.IsMember("g1user...") {
 package my_content
 
 import (
-    "chain/runtime/unsafe"
-
     "gno.land/p/samcrew/basedao"
     "gno.land/r/some/dao"
 )
 
-func Post(title, content string) {
-    caller := unsafe.PreviousRealm().Address()
+func Post(cur realm, title, content string) {
+    if !cur.IsCurrent() {
+        panic("spoofed realm")
+    }
+    caller := cur.Previous().Address()
     ext := basedao.MustGetMembersViewExtension(dao.DAO)
-    
+
     if !ext.IsMember(caller.String()) {
         panic("Only DAO members can post")
     }
-    
+
     createPost(title, content)
 }
 ```
+
+`Post` is a crossing function so that `cur.Previous()` names the realm or
+account that actually called it. Reading the caller from
+`unsafe.PreviousRealm()` in a non-crossing function walks the stack instead,
+which names the outermost crossing realm rather than the immediate caller.
 
 The extension is automatically registered when you create a DAO with `basedao.New()`.
 

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -125,7 +125,7 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 		Core:             core,
 		Members:          members,
 		GetProfileString: conf.GetProfileString,
-		Realm:            unsafe.CurrentRealm(),
+		Realm:            runtime.NewRealm(rlm.Address(), rlm.PkgPath()),
 		RenderFn:         conf.RenderFn,
 		CallerID:         conf.CallerID,
 		InitialConfig:    conf,

--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -182,6 +182,12 @@ func (m *MembersStore) setMembers(members []Member) {
 }
 
 func (m *MembersStore) AddMember(member string, roles []string) {
+	// An empty id would match the identity CallerID resolves to when it
+	// cannot name the caller, letting unidentified callers pass the
+	// member gate.
+	if member == "" {
+		panic("member id must not be empty")
+	}
 	if m.IsMember(member) {
 		panic("member already exists")
 	}

--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -182,9 +182,7 @@ func (m *MembersStore) setMembers(members []Member) {
 }
 
 func (m *MembersStore) AddMember(member string, roles []string) {
-	// An empty id would match the identity CallerID resolves to when it
-	// cannot name the caller, letting unidentified callers pass the
-	// member gate.
+	// "" is what CallerID resolves to when it cannot name the caller.
 	if member == "" {
 		panic("member id must not be empty")
 	}

--- a/gno/p/basedao/members_test.gno
+++ b/gno/p/basedao/members_test.gno
@@ -1,0 +1,34 @@
+package basedao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// An empty member id is what CallerID resolves to when it cannot name the
+// caller, so storing one would let unidentified callers pass the member gate.
+func TestAddMemberRejectsEmptyID(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, nil)
+
+	urequire.PanicsWithMessage(t, cur, "member id must not be empty", func() {
+		store.AddMember("", nil)
+	})
+	urequire.False(t, store.IsMember(""), "empty id must not be stored")
+	urequire.Equal(t, uint64(0), store.MembersCount())
+}
+
+func TestNewMembersStoreRejectsEmptyInitialMember(cur realm, t *testing.T) {
+	urequire.PanicsWithMessage(t, cur, "member id must not be empty", func() {
+		NewMembersStore(nil, []Member{{Address: "", Roles: []string{}}})
+	})
+}
+
+func TestAddMemberAcceptsNonEmptyID(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, nil)
+
+	urequire.NotPanics(t, cur, func() {
+		store.AddMember(alice.String(), nil)
+	})
+	urequire.True(t, store.IsMember(alice.String()))
+}

--- a/gno/p/basedao/members_test.gno
+++ b/gno/p/basedao/members_test.gno
@@ -6,8 +6,7 @@ import (
 	"gno.land/p/nt/urequire/v0"
 )
 
-// An empty member id is what CallerID resolves to when it cannot name the
-// caller, so storing one would let unidentified callers pass the member gate.
+// "" is what CallerID resolves to when it cannot name the caller.
 func TestAddMemberRejectsEmptyID(cur realm, t *testing.T) {
 	store := NewMembersStore(nil, nil)
 


### PR DESCRIPTION
Stacked on #65 and targeting its branch.

A DAO cannot identify a caller from another realm, so `CallerID` resolves to the empty string there. `AddMember` accepted `""` as a member id, so one such member let any unidentified cross-realm caller pass the member gate and propose, vote and execute. Rejecting it closes that, including the `NewMembersStore` path. `New` now records the realm it was handed instead of reading `unsafe.CurrentRealm()`, which returns the borrower, and the member-only README example reads `cur.Previous()` under an `IsCurrent` guard instead of stack-walking in a non-crossing function.

Verified at the topaz-1 launch tip `fc4052651`: packages and demo realms green, lint clean, three new tests, and the fixture that previously let a foreign realm write through the DAO now fails at construction. The `Execute` realm threading and the lambda handler are untouched, since both change public interfaces.