### PR TITLE
fix(daocond,basedao): a guaranteed render panic, a permanent DAO brick, and NaN escaping the threshold conditions

### DIFF
--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -208,6 +208,12 @@ func (m *MembersStore) RemoveMember(member string) {
 		panic("member does not exist")
 	}
 
+	// A zero-member DAO is unrecoverable: assertCallerIsMember rejects every
+	// entry point, so not even AddMember can be proposed again.
+	if m.MembersCount() <= 1 {
+		panic("cannot remove the last member")
+	}
+
 	memberRolesRaw, ok := m.Members.Get(member)
 	if !ok {
 		panic("should not happen")

--- a/gno/p/basedao/members_removal_test.gno
+++ b/gno/p/basedao/members_removal_test.gno
@@ -1,0 +1,35 @@
+package basedao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+// Removing the final member drops MembersCount to zero, which is an
+// unrecoverable state: every DAO entry point first calls assertCallerIsMember,
+// so nothing — including AddMember — can ever be proposed again, and every
+// threshold evaluates 0/0 = NaN, which is never >= any threshold. Since
+// publishing is immutable, such a DAO is bricked forever.
+func TestRemoveMemberRejectsRemovingLastMember(cur realm, t *testing.T) {
+	solo := testutils.TestAddress("solo").String()
+	store := NewMembersStore(nil, []Member{{Address: solo}})
+
+	urequire.PanicsWithMessage(t, cur, "cannot remove the last member", func() {
+		store.RemoveMember(solo)
+	})
+	urequire.Equal(t, uint64(1), store.MembersCount())
+}
+
+// The guard must not block ordinary removals.
+func TestRemoveMemberAllowsRemovalWhenOthersRemain(cur realm, t *testing.T) {
+	first := testutils.TestAddress("first").String()
+	second := testutils.TestAddress("second").String()
+	store := NewMembersStore(nil, []Member{{Address: first}, {Address: second}})
+
+	urequire.NotPanics(t, cur, func() {
+		store.RemoveMember(first)
+	})
+	urequire.Equal(t, uint64(1), store.MembersCount())
+}

--- a/gno/p/daocond/cond_gnolovedao.gno
+++ b/gno/p/daocond/cond_gnolovedao.gno
@@ -103,13 +103,27 @@ func (c *gnolovDaoCondThreshold) voteRatio(ballot Ballot, vote Vote) float64 {
 	return total / totalPower
 }
 
+// Returns the voter's tier role, or "" when they hold none of this condition's
+// roles.
+//
+// This used to panic. Core.Vote gates on membership only, never on holding a
+// tier role, so a member without one can reach the ballot — as can any member
+// when the condition is built over a subset of the DAO's roles. The panic was
+// raised from inside the ballot walk, so a single such vote made every later
+// Eval, Signal and Render on that proposal panic. On an immutable publish that
+// is permanent, triggered by an ordinary member casting an ordinary vote.
+//
+// A voter with no tier role simply carries no voting power: "" is absent from
+// votingPowersByTier, so the lookup yields 0.0 and they contribute nothing. That
+// is also what the existing test matrix already expects — the "T3 abstaining"
+// case asserts 7/10, which is precisely the tally with the T3 votes excluded.
 func (c *gnolovDaoCondThreshold) getUserRole(userID string) string {
 	for _, role := range c.roles {
 		if c.hasRoleFn(userID, role) {
 			return role
 		}
 	}
-	panic("No role found for user")
+	return ""
 }
 
 func (c *gnolovDaoCondThreshold) computeVotingPowers() (map[string]float64, float64) {

--- a/gno/p/daocond/cond_gnolovedao_test.gno
+++ b/gno/p/daocond/cond_gnolovedao_test.gno
@@ -250,7 +250,15 @@ func TestEval(t *testing.T) {
 			abstainT3:    true,
 			threshold:    0.6,
 			expectedYes:  7.0 / 10.0,
-			panic:        true, // a user with T3 when T3 is abstaining should panic
+			// Was `panic: true`, documenting that a T3 holder voting while T3
+			// abstains blew up the tally. That made the proposal permanently
+			// unevaluable — every later Eval/Signal/Render panicked — which on an
+			// immutable publish is unrecoverable, and it is reachable by an
+			// ordinary member's ordinary vote. A voter outside the condition's
+			// roles now carries zero power instead. Note expectedYes below is
+			// 7/10, i.e. exactly the tally with the T3 votes excluded: this is
+			// the behaviour the case was always written for.
+			panic: false,
 		},
 	}
 

--- a/gno/p/daocond/cond_members_threshold.gno
+++ b/gno/p/daocond/cond_members_threshold.gno
@@ -64,7 +64,13 @@ func (c *membersThresholdCond) RenderWithVotes(ballot Ballot) string {
 var _ Condition = (*membersThresholdCond)(nil)
 
 func (c *membersThresholdCond) voteRatio(ballot Ballot, vote Vote) float64 {
-	return float64(c.totalVote(ballot, vote)) / float64(c.membersCountFn())
+	// See roleThresholdCond.voteRatio: 0/0 is NaN in gno, and NaN leaks into
+	// Eval, Signal and Render. Zero members must read as 0.0, never 1.0.
+	membersCount := c.membersCountFn()
+	if membersCount == 0 {
+		return 0
+	}
+	return float64(c.totalVote(ballot, vote)) / float64(membersCount)
 }
 
 func (c *membersThresholdCond) totalVote(ballot Ballot, vote Vote) uint64 {

--- a/gno/p/daocond/cond_role_treshold.gno
+++ b/gno/p/daocond/cond_role_treshold.gno
@@ -66,7 +66,17 @@ func (c *roleThresholdCond) RenderWithVotes(ballot Ballot) string {
 var _ Condition = (*roleThresholdCond)(nil)
 
 func (c *roleThresholdCond) voteRatio(ballot Ballot, vote Vote) float64 {
-	return float64(c.totalVote(ballot, vote)) / float64(c.usersRoleCountFn(c.role))
+	// The role can reachably have zero holders while the DAO still has members
+	// (RemoveRoleFromMember, RemoveRole, or removing the last holder), so the
+	// minimum-member guard does not cover this. gno's float64 divide has no
+	// zero guard, so 0/0 would yield NaN and leak into Eval, Signal and Render.
+	// Zero must read as 0.0, never 1.0 — a vacuous-truth reading would let a
+	// proposal pass with nobody entitled to vote on it.
+	roleCount := c.usersRoleCountFn(c.role)
+	if roleCount == 0 {
+		return 0
+	}
+	return float64(c.totalVote(ballot, vote)) / float64(roleCount)
 }
 
 func (c *roleThresholdCond) totalVote(ballot Ballot, vote Vote) uint32 {

--- a/gno/p/daocond/cond_role_treshold.gno
+++ b/gno/p/daocond/cond_role_treshold.gno
@@ -56,7 +56,7 @@ func (c *roleThresholdCond) Render() string {
 // Example output: "60% of admin members with role admin must vote yes\n\nYes: 1/2 = 50%"
 func (c *roleThresholdCond) RenderWithVotes(ballot Ballot) string {
 	s := ""
-	s += ufmt.Sprintf("%g%% of %s members with role %s must vote yes\n\n", c.threshold*100, c.role)
+	s += ufmt.Sprintf("%g%% of %s members with role %s must vote yes\n\n", c.threshold*100, c.role, c.role)
 	s += ufmt.Sprintf("Yes: %d/%d = %g%%\n\n", c.totalVote(ballot, VoteYes), c.usersRoleCountFn(c.role), c.voteRatio(ballot, VoteYes)*100)
 	s += ufmt.Sprintf("No: %d/%d = %g%%\n\n", c.totalVote(ballot, VoteNo), c.usersRoleCountFn(c.role), c.voteRatio(ballot, VoteNo)*100)
 	s += ufmt.Sprintf("Abstain: %d/%d = %g%%\n\n", c.totalVote(ballot, VoteAbstain), c.usersRoleCountFn(c.role), c.voteRatio(ballot, VoteAbstain)*100)

--- a/gno/p/daocond/cond_role_treshold_test.gno
+++ b/gno/p/daocond/cond_role_treshold_test.gno
@@ -1,0 +1,31 @@
+package daocond_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/daocond"
+)
+
+// RenderWithVotes is reachable from every proposal-detail render
+// (basedao/view_proposal_detail_page.gno). gno's ufmt panics on an argument
+// shortfall rather than emitting Go's cosmetic "%!s(MISSING)", so an arity
+// mismatch here bricks proposal rendering for any DAO using a RoleThreshold.
+func TestRoleThresholdRenderWithVotes(t *testing.T) {
+	hasRole := func(memberId string, role string) bool {
+		return memberId == "alice" && role == "admin"
+	}
+	roleCount := func(role string) uint32 { return 2 }
+
+	cond := daocond.RoleThreshold(0.6, "admin", hasRole, roleCount)
+
+	ballot := daocond.NewBallot()
+	ballot.Vote("alice", daocond.VoteYes)
+
+	want := "60% of admin members with role admin must vote yes\n\n" +
+		"Yes: 1/2 = 50%\n\n" +
+		"No: 0/2 = 0%\n\n" +
+		"Abstain: 0/2 = 0%\n\n"
+
+	urequire.Equal(t, want, cond.RenderWithVotes(ballot))
+}

--- a/gno/p/daocond/roleless_voter_test.gno
+++ b/gno/p/daocond/roleless_voter_test.gno
@@ -1,0 +1,41 @@
+package daocond
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// Core.Vote gates on membership only, never on holding one of the tier roles,
+// so a member with no tier role can land in the ballot. getUserRole then found
+// no match and panicked — and because the panic is raised from inside the
+// ballot walk, every subsequent Eval, Signal and Render on that proposal
+// panicked too. On an immutable publish that is permanent, and it is triggered
+// by an ordinary member casting an ordinary vote.
+//
+// A voter with no tier role has no voting power; they must contribute zero,
+// not abort the tally.
+func TestGnoloveDAOCondToleratesARolelessVoter(t *testing.T) {
+	roles := []string{"T1", "T2"}
+	hasRole := func(userID string, role string) bool {
+		return userID == "t1voter" && role == "T1"
+	}
+	usersWithRoleCount := func(role string) uint32 {
+		if role == "T1" {
+			return 1
+		}
+		return 0
+	}
+
+	cond := GnoloveDAOCondThreshold(0.5, roles, hasRole, usersWithRoleCount)
+
+	ballot := NewBallot()
+	ballot.Vote("t1voter", VoteYes)
+	ballot.Vote("roleless", VoteYes)
+
+	// The roleless voter carries no power, so the T1 voter alone still decides.
+	urequire.True(t, cond.Eval(ballot), "the roleless voter must not abort the tally")
+
+	signal := cond.Signal(ballot)
+	urequire.False(t, signal != signal, "Signal must not be NaN")
+}

--- a/gno/p/daocond/zero_divisor_test.gno
+++ b/gno/p/daocond/zero_divisor_test.gno
@@ -1,0 +1,73 @@
+package daocond_test
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/daocond"
+)
+
+// A threshold condition divides the yes-votes by the size of its electorate.
+// When that electorate is empty the division is 0/0, and gno's float64 divide
+// has no zero guard (unlike the integer cases), so it yields NaN. NaN then
+// leaks out of Eval, Signal and RenderWithVotes — Signal in particular is a
+// display/progress value, and math.Min(NaN/threshold, 1) is NaN, not 1.
+//
+// The electorate is reachably empty while the DAO still has members, so the
+// RemoveMember minimum-member guard does not cover it: RemoveRoleFromMember
+// (a default-registered governance action), RemoveRole, and removing the last
+// holder of a role while others remain all get there.
+//
+// Zero must resolve to 0.0, never 1.0: a vacuous-truth reading would let a
+// proposal pass with nobody entitled to vote on it.
+
+func TestRoleThresholdWithNoRoleHoldersIsNotNaN(t *testing.T) {
+	noHolders := func(memberId string, role string) bool { return false }
+	zeroCount := func(role string) uint32 { return 0 }
+
+	cond := daocond.RoleThreshold(0.6, "admin", noHolders, zeroCount)
+	ballot := daocond.NewBallot()
+
+	signal := cond.Signal(ballot)
+	// NaN is the only value that is not equal to itself.
+	urequire.False(t, signal != signal, "Signal must not be NaN")
+	urequire.Equal(t, 0.0, signal)
+	urequire.False(t, cond.Eval(ballot), "an empty electorate must not satisfy the threshold")
+}
+
+func TestMembersThresholdWithNoMembersIsNotNaN(t *testing.T) {
+	noMembers := func(memberId string) bool { return false }
+	zeroCount := func() uint64 { return 0 }
+
+	cond := daocond.MembersThreshold(0.6, noMembers, zeroCount)
+	ballot := daocond.NewBallot()
+
+	signal := cond.Signal(ballot)
+	urequire.False(t, signal != signal, "Signal must not be NaN")
+	urequire.Equal(t, 0.0, signal)
+	urequire.False(t, cond.Eval(ballot), "an empty electorate must not satisfy the threshold")
+}
+
+// Render output is surfaced on every proposal-detail page; a NaN there is a
+// permanent cosmetic defect on an immutable publish.
+func TestEmptyElectorateRendersNoNaN(t *testing.T) {
+	noHolders := func(memberId string, role string) bool { return false }
+	zeroCount := func(role string) uint32 { return 0 }
+
+	cond := daocond.RoleThreshold(0.6, "admin", noHolders, zeroCount)
+	rendered := cond.RenderWithVotes(daocond.NewBallot())
+
+	urequire.False(t, contains(rendered, "NaN"), "render must not contain NaN: "+rendered)
+}
+
+func contains(haystack, needle string) bool {
+	if len(needle) > len(haystack) {
+		return false
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Three defects that become **permanent** the moment we publish to topaz-1. All three are in exported public API, all three were reproduced by a failing test before being fixed, and none is covered by the existing suite.

Based on `feat/topaz-v2-rename` (#65) rather than `main`, because that is the source the ceremony publishes and because `main` is pre-interrealm-v2 — its unsuffixed `p/nt/*` imports cannot resolve on topaz-1 at all. Each fix is independent of the others.

### 1. `RoleThreshold` proposals panic instead of rendering

`cond_role_treshold.gno:59` consumed three format verbs (`%g`, `%s`, `%s`) while passing two arguments. gno's `ufmt` **panics** on an argument shortfall rather than emitting Go's cosmetic `%!s(MISSING)`, so every proposal-detail render for a DAO whose condition contains a `RoleThreshold` panicked — permanently.

Reproduced: `panic: ufmt: not enough arguments` at `ufmt.gno:199`, raised from `cond_role_treshold.gno:59`.

Why the suite never caught it: `daocond_test.gno:175` calls `RenderWithVotes` only inside its *failure* branch, so a passing run never executes the line. The new test exercises it directly. (`%%` is a literal percent and consumes no argument — the verb count is genuinely 3.)

### 2. Removing the last member bricks the DAO permanently

`RemoveMember` checked only `IsMember`, so a single-member DAO could remove itself — 1/1 = 100% clears any threshold. The resulting zero-member DAO is unrecoverable: `assertCallerIsMember` rejects every entry point, so not even `AddMember` can be proposed again.

Reproduced: `Panic value: nil` — the removal succeeded silently. The control case (removal with others remaining) passes before and after, so the test discriminates rather than blanket-refusing.

### 3. An empty electorate yields NaN, not an unmet condition

Both threshold conditions divide yes-votes by the size of their electorate. gno's float64 divide has **no zero guard** — unlike every integer case, which raises `division by zero` — so an empty electorate produces `0/0 = NaN`. NaN then escapes through `Eval`, `Signal` and `RenderWithVotes`; `Signal` is a progress value and `math.Min(NaN/threshold, 1)` is NaN, not 1.

The minimum-member guard in (2) does **not** cover this: a role can reach zero holders while the DAO still has members, via `RemoveRoleFromMember` (a default-registered governance action), `RemoveRole`, or removing the last holder of a role while others remain. Zero resolves to `0.0`, never `1.0` — reading an empty electorate as vacuous truth would let a proposal pass with nobody entitled to vote on it. This mirrors the guard `gnolovDaoCondThreshold.voteRatio` already carries for its zero-power case.

## Test plan

- 6/6 packages `ok`, lint clean, `gno fmt` zero diff — run fully offline against a vendored dependency closure including the `p/samcrew/avl` fork.
- Each test watched fail first, for the expected reason.
- `merge-tree` verified clean against `fix/realm-identity-hardening` (#66).

⚠️ **CI on this repo is red for environmental reasons unrelated to this branch** — `gno lint`/`gno test` resolve dependencies from `rpc.gno.land`, which CNAMEs to a mutable testnet serving *pre*-interrealm-v2 sources, so a hermetically pinned compiler is fed by a live unversioned source. Bumping the toolchain pin does not fix it. Vendoring the dependency closure does, and is proven end-to-end offline — but the vendor set must be pinned to the **fork** (`p/samcrew/avl`), not to `examples/` at the pin, or the green signal would be compiled against the two-value avl that topaz-1 does not have. That is a separate PR and it depends on #65.

### 4. A roleless voter permanently bricks a gnolove DAO proposal

`cond_gnolovedao.gno:112` `getUserRole` panicked when a voter held none of the condition's tier roles. `Core.Vote` gates on membership only, never on holding a tier role, so such a voter can reach the ballot — as can any member when the condition is built over a *subset* of the DAO's roles, which is exactly what the "T3 abstaining" case models. The panic was raised from inside the ballot walk, so one such vote made every later `Eval`, `Signal` and `Render` on that proposal panic. Unrecoverable once published, and reached by an ordinary member casting an ordinary vote.

A voter outside the condition's roles now carries no voting power.

**This changes a deliberately asserted behaviour, so it deserves scrutiny.** The matrix case carried `panic: true` *alongside* `expectedYes: 7.0/10.0` — and 7/10 is precisely the tally with the T3 votes excluded, i.e. the number the case produces under this change. The panic flag documented what the code *did*; the expectation recorded what it was *meant* to do. With the flag removed, that case now genuinely evaluates `Eval(ballot) == true` instead of passing through the recover path, so the assertion is exercised for the first time.

## Test plan

- 6/6 packages `ok`, lint clean, `gno fmt` zero diff — run fully offline against the vendored closure.
- Each test watched fail first, for the expected reason.
- Stacked on #68, so CI is green: gno-lint, gno-test and vendored-provenance all pass.
