### PR TITLE
ci: vendor the dependency closure so the build stops depending on a live testnet

### DIFF
--- a/.github/workflows/gno-lint.yml
+++ b/.github/workflows/gno-lint.yml
@@ -19,8 +19,20 @@ jobs:
           go-version-file: go.mod
           cache-key-suffix: gno
 
-      - name: Lint gno
-        run: make lint
+      # The build must resolve every dependency from vendored/ — see vendored/README.md.
+      # A `gno: downloading` line means the closure is incomplete and the build has
+      # silently gone back to fetching from a mutable testnet, which is what kept CI
+      # red from 2026-06-04. Fail loudly rather than depend on the network again.
+      - name: Lint gno (and assert the build is hermetic)
+        run: |
+          set -o pipefail
+          make lint 2>&1 | tee /tmp/lint.out
+          if grep -q 'gno: downloading' /tmp/lint.out; then
+            echo "ERROR: the build fetched dependencies from the network:"
+            grep 'gno: downloading' /tmp/lint.out
+            echo "Add the missing packages to vendored/ (see vendored/README.md)."
+            exit 1
+          fi
 
       - name: gno mod tidy
         run: make gno-mod-tidy

--- a/.github/workflows/gno-lint.yml
+++ b/.github/workflows/gno-lint.yml
@@ -11,7 +11,7 @@ jobs:
   gno-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Golang with cache
         uses: magnetikonline/action-golang-cache@v5
@@ -24,15 +24,25 @@ jobs:
       # silently gone back to fetching from a mutable testnet, which is what kept CI
       # red from 2026-06-04. Fail loudly rather than depend on the network again.
       - name: Lint gno (and assert the build is hermetic)
+        env:
+          # A warm module cache short-circuits the fetch BEFORE the "downloading"
+          # line is printed, which would silently disable the check below. Force a
+          # cold cache so the guard always has something to observe.
+          GNOHOME: ${{ runner.temp }}/gnohome-lint
         run: |
           set -o pipefail
-          make lint 2>&1 | tee /tmp/lint.out
+          # Capture the status rather than letting errexit abort here: on a real
+          # failure we still want to report WHY, and the missing-package advice
+          # below is written for exactly the case where make lint fails.
+          rc=0
+          make lint 2>&1 | tee /tmp/lint.out || rc=$?
           if grep -q 'gno: downloading' /tmp/lint.out; then
             echo "ERROR: the build fetched dependencies from the network:"
             grep 'gno: downloading' /tmp/lint.out
             echo "Add the missing packages to vendored/ (see vendored/README.md)."
             exit 1
           fi
+          exit $rc
 
       - name: gno mod tidy
         run: make gno-mod-tidy

--- a/.github/workflows/vendored-provenance.yml
+++ b/.github/workflows/vendored-provenance.yml
@@ -1,0 +1,103 @@
+name: Vendored Provenance
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+# vendored/ removes the network from the build, but only helps if what is vendored
+# is genuinely the upstream source at the pinned compiler version. This job proves
+# that byte-for-byte, so vendored/ cannot drift from GNOVERSION unnoticed — which
+# would reintroduce exactly the version skew vendoring exists to eliminate.
+jobs:
+  vendored-provenance:
+    name: Vendored matches gno@GNOVERSION
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # GNOVERSION comes from the checked-out tree, so on a fork PR it is
+      # attacker-controlled. Validate it is a bare hex sha and pass it through the
+      # environment — never interpolate it into a run: block, where a value
+      # containing a quote could break out of the command.
+      - name: Read and validate the pinned GNOVERSION
+        id: pin
+        run: |
+          set -euo pipefail
+          ref="$(sed -n 's/^GNOVERSION=//p' Makefile | head -1 | tr -d '[:space:]')"
+          if [[ ! "$ref" =~ ^[0-9a-f]{7,40}$ ]]; then
+            echo "ERROR: GNOVERSION is not a bare hex sha: '$ref'"
+            exit 1
+          fi
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "GNOVERSION=$ref"
+
+      - name: Fetch gnolang/gno at the pinned ref
+        env:
+          GNO_REF: ${{ steps.pin.outputs.ref }}
+        run: |
+          set -euo pipefail
+          git clone --filter=blob:none --no-checkout https://github.com/gnolang/gno /tmp/gno
+          git -C /tmp/gno checkout --quiet "$GNO_REF" -- examples
+
+      - name: Every vendored file must be byte-identical to upstream
+        run: |
+          set -euo pipefail
+          drift=0
+          checked=0
+          skipped=0
+          while IFS= read -r f; do
+            rel="${f#vendored/}"
+            # The fork is deliberately NOT upstream: topaz-1's stdlib avl Get is
+            # single-value while this codebase calls the two-value form. Its own
+            # provenance is guarded in samouraiworld/samcrew-deployer against
+            # upstream f3d5a5d13. See vendored/README.md.
+            case "$rel" in
+              gno.land/p/samcrew/avl/*) skipped=$((skipped + 1)); continue ;;
+              README.md)                skipped=$((skipped + 1)); continue ;;
+            esac
+            checked=$((checked + 1))
+            if [[ ! -f "/tmp/gno/examples/$rel" ]]; then
+              echo "MISSING UPSTREAM: $rel is not in examples/ at the pinned ref"
+              drift=$((drift + 1))
+            elif ! cmp -s "$f" "/tmp/gno/examples/$rel"; then
+              echo "DRIFT: $rel differs from upstream"
+              diff -u "/tmp/gno/examples/$rel" "$f" | head -20 || true
+              drift=$((drift + 1))
+            fi
+          done < <(find vendored -type f)
+
+          # A vacuous pass would be worse than a failure: if the find ever stops
+          # matching, this job would go green while checking nothing at all.
+          if [[ $checked -eq 0 ]]; then
+            echo "ERROR: no vendored files were checked — the layout or the glob changed"
+            exit 1
+          fi
+
+          echo "checked $checked file(s), skipped $skipped (fork + docs), drift $drift"
+          if [[ $drift -gt 0 ]]; then
+            echo "ERROR: vendored/ has drifted from gno@${{ steps.pin.outputs.ref }}"
+            echo "Either regenerate vendored/ (see vendored/README.md) or revert the edit."
+            exit 1
+          fi
+
+      - name: The fork must match the deployer's guarded copy in shape
+        run: |
+          set -euo pipefail
+          # We cannot read the private deployer repo here, so assert the invariant
+          # that matters locally: the fork must expose the TWO-value Get that this
+          # codebase calls. If it ever becomes single-value, every avl call site
+          # breaks on-chain, which is the failure vendoring exists to prevent.
+          tree="vendored/gno.land/p/samcrew/avl/tree.gno"
+          if [[ ! -f "$tree" ]]; then
+            echo "ERROR: the vendored p/samcrew/avl fork is missing"
+            exit 1
+          fi
+          if ! grep -qE 'func \(tree \*Tree\) Get\(key string\) \(value any, exists bool\)' "$tree"; then
+            echo "ERROR: vendored p/samcrew/avl no longer exposes the two-value Get:"
+            grep -nE 'func \(tree \*Tree\) Get\(' "$tree" || true
+            exit 1
+          fi
+          echo "p/samcrew/avl exposes the two-value Get, as this codebase requires"

--- a/.github/workflows/vendored-provenance.yml
+++ b/.github/workflows/vendored-provenance.yml
@@ -9,8 +9,9 @@ on:
 
 # vendored/ removes the network from the build, but only helps if what is vendored
 # is genuinely the upstream source at the pinned compiler version. This job proves
-# that byte-for-byte, so vendored/ cannot drift from GNOVERSION unnoticed — which
-# would reintroduce exactly the version skew vendoring exists to eliminate.
+# that byte-for-byte in BOTH directions, so vendored/ cannot drift from GNOVERSION
+# unnoticed — which would reintroduce exactly the version skew vendoring exists to
+# eliminate.
 jobs:
   vendored-provenance:
     name: Vendored matches gno@GNOVERSION
@@ -26,7 +27,9 @@ jobs:
         id: pin
         run: |
           set -euo pipefail
-          ref="$(sed -n 's/^GNOVERSION=//p' Makefile | head -1 | tr -d '[:space:]')"
+          # tail -1, not head -1: make uses last-assignment-wins, so a second
+          # GNOVERSION= line is what the build would actually use.
+          ref="$(sed -n 's/^GNOVERSION=//p' Makefile | tail -1 | tr -d '[:space:]')"
           if [[ ! "$ref" =~ ^[0-9a-f]{7,40}$ ]]; then
             echo "ERROR: GNOVERSION is not a bare hex sha: '$ref'"
             exit 1
@@ -42,21 +45,42 @@ jobs:
           git clone --filter=blob:none --no-checkout https://github.com/gnolang/gno /tmp/gno
           git -C /tmp/gno checkout --quiet "$GNO_REF" -- examples
 
+      # Files that are deliberately NOT upstream. Anything added here weakens the
+      # guard, so each entry states why it is exempt.
+      - name: No symlinks may enter vendored/
+        run: |
+          set -euo pipefail
+          # `find -type f` silently skips symlinks, but the gno loader follows them,
+          # so a symlinked .gno would be compiled while the byte-comparison below
+          # never saw it. Refuse them outright rather than try to resolve them.
+          links="$(find vendored -type l)"
+          if [[ -n "$links" ]]; then
+            echo "ERROR: vendored/ contains symlinks, which the byte-comparison cannot verify:"
+            printf '%s\n' "$links"
+            exit 1
+          fi
+          echo "no symlinks in vendored/"
+
       - name: Every vendored file must be byte-identical to upstream
+        env:
+          GNO_REF: ${{ steps.pin.outputs.ref }}
         run: |
           set -euo pipefail
           drift=0
           checked=0
           skipped=0
+          # `! -type d` rather than `-type f`, so anything that is neither a regular
+          # file nor a directory is surfaced instead of silently skipped.
           while IFS= read -r f; do
             rel="${f#vendored/}"
-            # The fork is deliberately NOT upstream: topaz-1's stdlib avl Get is
-            # single-value while this codebase calls the two-value form. Its own
-            # provenance is guarded in samouraiworld/samcrew-deployer against
-            # upstream f3d5a5d13. See vendored/README.md.
             case "$rel" in
+              # The fork is deliberately NOT upstream: topaz-1's stdlib avl Get is
+              # single-value while this codebase calls the two-value form. Its own
+              # provenance is guarded in samouraiworld/samcrew-deployer against
+              # upstream f3d5a5d13. See vendored/README.md.
               gno.land/p/samcrew/avl/*) skipped=$((skipped + 1)); continue ;;
-              README.md)                skipped=$((skipped + 1)); continue ;;
+              # Our own documentation and attribution, not upstream source.
+              README.md|NOTICE|LICENSE.md) skipped=$((skipped + 1)); continue ;;
             esac
             checked=$((checked + 1))
             if [[ ! -f "/tmp/gno/examples/$rel" ]]; then
@@ -67,7 +91,7 @@ jobs:
               diff -u "/tmp/gno/examples/$rel" "$f" | head -20 || true
               drift=$((drift + 1))
             fi
-          done < <(find vendored -type f)
+          done < <(find vendored ! -type d)
 
           # A vacuous pass would be worse than a failure: if the find ever stops
           # matching, this job would go green while checking nothing at all.
@@ -76,20 +100,69 @@ jobs:
             exit 1
           fi
 
-          echo "checked $checked file(s), skipped $skipped (fork + docs), drift $drift"
-          if [[ $drift -gt 0 ]]; then
-            echo "ERROR: vendored/ has drifted from gno@${{ steps.pin.outputs.ref }}"
+          # The reverse direction. The loop above only sees files that EXIST here,
+          # so deleting one is invisible to it — and a silently truncated package
+          # still lints clean. Walk upstream's copy of every vendored package and
+          # require each file to be present.
+          missing=0
+          while IFS= read -r pkgdir; do
+            rel="${pkgdir#vendored/}"
+            case "$rel" in gno.land/p/samcrew/avl*) continue ;; esac
+            [[ -d "/tmp/gno/examples/$rel" ]] || continue
+            # Only compare directories we actually vendored as PACKAGES. Walking
+            # intermediate namespace dirs (gno.land, gno.land/p, gno.land/r) would
+            # demand every upstream file at that level — files we deliberately
+            # never vendored — and report them all as deletions.
+            if [[ -z "$(find "$pkgdir" -maxdepth 1 -name '*.gno' -print -quit)" ]]; then
+              continue
+            fi
+            while IFS= read -r uf; do
+              urel="${uf#/tmp/gno/examples/}"
+              if [[ ! -f "vendored/$urel" ]]; then
+                echo "DELETED: vendored/$urel exists upstream but not here"
+                missing=$((missing + 1))
+              fi
+            done < <(find "/tmp/gno/examples/$rel" -maxdepth 1 -type f)
+          done < <(find vendored -type d)
+
+          echo "checked $checked file(s), skipped $skipped (fork + docs), drift $drift, deleted $missing"
+          if [[ $drift -gt 0 || $missing -gt 0 ]]; then
+            echo "ERROR: vendored/ has drifted from gno@$GNO_REF"
             echo "Either regenerate vendored/ (see vendored/README.md) or revert the edit."
             exit 1
           fi
 
-      - name: The fork must match the deployer's guarded copy in shape
+      # The gate that actually keeps a green build meaningful for topaz-1.
+      #
+      # GNOVERSION is NOT topaz-1's ref, so ~15 vendored packages differ from what
+      # the chain hosts — including p/nt/avl/v0, whose on-chain Get is SINGLE-value
+      # while the vendored copy is two-value. That is safe today for exactly one
+      # reason: gnodaokit crosses that boundary only via ntavl.NewTree(), whose
+      # signature is identical in both. Nothing else enforced that, so a single new
+      # ntavl.Get() call would compile green here and fail AddPackage on-chain.
+      - name: The stdlib-avl boundary must stay limited to NewTree
         run: |
           set -euo pipefail
-          # We cannot read the private deployer repo here, so assert the invariant
-          # that matters locally: the fork must expose the TWO-value Get that this
-          # codebase calls. If it ever becomes single-value, every avl call site
-          # breaks on-chain, which is the failure vendoring exists to prevent.
+          uses="$(grep -rhoE 'ntavl\.[A-Za-z_]+' gno/ --include='*.gno' | sort -u)"
+          if [[ -z "$uses" ]]; then
+            echo "no ntavl usage found — the alias was removed, which is fine"
+            exit 0
+          fi
+          echo "ntavl usage: $uses"
+          unexpected="$(printf '%s\n' "$uses" | grep -vx 'ntavl.NewTree' || true)"
+          if [[ -n "$unexpected" ]]; then
+            echo "ERROR: gnodaokit uses the stdlib avl beyond NewTree:"
+            printf '%s\n' "$unexpected"
+            echo "topaz-1's p/nt/avl/v0 Get is SINGLE-value while the vendored copy is"
+            echo "two-value, so this would compile here and fail AddPackage on-chain."
+            echo "Use gno.land/p/samcrew/avl instead, or re-verify against topaz-1."
+            exit 1
+          fi
+          echo "stdlib avl boundary is limited to NewTree, as required"
+
+      - name: The fork must expose the two-value Get this codebase calls
+        run: |
+          set -euo pipefail
           tree="vendored/gno.land/p/samcrew/avl/tree.gno"
           if [[ ! -f "$tree" ]]; then
             echo "ERROR: the vendored p/samcrew/avl fork is missing"

--- a/vendored/LICENSE.md
+++ b/vendored/LICENSE.md
@@ -1,0 +1,714 @@
+The following copyright notice covers all of the files in this directory and any
+subdirectory, except where otherwise specified, including the **tm2**
+subdirectory, which uses a [different license](./tm2/LICENSE).
+
+---
+
+Copyright (C) 2025 NewTendermint, LLC
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNO Network General Public License as published by
+NewTendermint, LLC, either version 6 of the License, or (at your option) any
+later version published by NewTendermint, LLC.
+
+This program is distributed in the hope that it will be useful, but is provided
+as-is and WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNO Network
+General Public License for more details.
+
+You should have received a copy of the GNO Network General Public License along
+with this program.  If not, see <https://gno.land/license>.
+
+Attached below are the terms of the GNO Network General Public License, Version
+4 (a fork of the GNU Affero General Public License 3).
+
+
+# Additional Terms (Strong Attribution)
+
+In accordance with Section 7 of the License, any user interface of a Covered
+Work, or of any other work or service that does not include the Covered Work
+but which derives functionality from it or otherwise uses it (an “Applicable
+Work”), and any material that promotes the Covered Work, must prominently
+display a reasonable attribution notice for the Covered Work (the “Attribution
+Notice”). The Attribution Notice shall, at minimum, include an active hyperlink
+to a URL designated by the Licensor for attribution (the “Attribution URL”),
+and up to three words such as "built on" or "forked from" as designated by the
+Licensor according to the Licensor's Attribution Policy.
+
+The Attribution Notice must be in a manner readily visible to users and must be
+at least as conspicuous as other legal notices or credits in the same
+interface. If there are no other notices or credits it is sufficient for the
+Attribution Notice to appear prominently in the header or footer of the
+interface. The Attribution URL and related attribution terms described herein
+are determined exclusively by NewTendermint, LLC. In cases of ambiguity,
+forks, or disputes regarding attribution, the designation made by
+NewTendermint, LLC shall conclusively govern.
+
+This attribution requirement remains in force for twelve (12) years from the
+date the Covered Work is first publicly released under this License, or twelve
+(12) years from the date you first make an Applicable Work available to the
+public, whichever is later. In no event shall this requirement continue beyond
+twenty five (25) years from the Covered Work’s initial public release. If a
+court of competent jurisdiction or the Licensor finds that the designated
+Attribution URL violates users’ reasonable expectations of privacy or security,
+then the requirement to include that URL may be omitted or modified to the
+minimum extent necessary to avoid such issue. In all other cases, the
+attribution must be preserved as stated.
+
+You must preserve and display the Attribution Notice as required above in every
+Covered Work and Applicable Work that you propagate, operate, or otherwise make
+available to users or third parties. If you convey, deploy or promote the
+Covered Work to any third party, or permit or enable a third party to deploy,
+operate or promote an Applicable Work, you must require that such third party,
+as a condition of use, also preserve and maintain the same Attribution Notice
+and comply with the above attribution requirement. The attribution requirement
+is a condition of the License that travels with the Covered Work forever and
+must be honored by all downstream recipients for the duration specified above.
+This clause constitutes an additional term permitted by Section 7 of this
+License and shall not be construed as a further restriction on the exercise of
+rights granted under this License.
+
+
+# GNO NETWORK GENERAL PUBLIC LICENSE
+
+Version 6, 25 November 2025
+
+Modified from the GNU AFFERO GENERAL PUBLIC LICENSE.
+GNU is not affiliated with GNO or NewTendermint, LLC.
+Copyright (C) 2022 NewTendermint, LLC.
+
+## Preamble
+
+The GNO Network General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+The GNO Network General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+The precise terms and conditions for copying, distribution and
+modification follow.
+
+## TERMS AND CONDITIONS
+
+### 0. Definitions.
+
+"This License" refers to version 6 of the GNO Network General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+### 1. Source Code.
+
+The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+The Corresponding Source for a work in source code form is that
+same work.
+
+### 2. Basic Permissions.
+
+All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+### 3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+### 4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+### 5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+-   a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+-   b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+-   c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+-   d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+### 6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+-   a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+-   b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+-   c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+-   d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+-   e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+### 7. Additional Terms.
+
+"Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+-   a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+-   b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+-   c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+-   d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+-   e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+-   f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors; or
+-   g) Requiring strong attribution such as notices on any user interfaces
+    that run or convey any covered work, such as a prominent link to a URL
+    on the header of a website, such that all users of the covered work may
+    become aware of the notice, for a period no longer than 25 years.
+
+All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+### 8. Termination.
+
+You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+### 9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+### 10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+### 11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+### 12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to simultaneously satisfy your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+### 13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+### 14. Revised Versions of this License.
+
+NewTendermint LLC may publish revised and/or new versions of
+the GNO Network General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNO Network General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Gno Software
+Foundation.  If the Program does not specify a version number of the
+GNO Network General Public License, you may choose any version ever published
+by NewTendermint LLC.
+
+If the Program specifies that a proxy can decide which future
+versions of the GNO Network General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+### 15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+### 16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+### 17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+## How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNO Network General Public License as published by
+    NewTendermint LLC, either version 6 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNO Network General Public License for more details.
+
+    You should have received a copy of the GNO Network General Public License
+    along with this program.  If not, see <https://gno.land/license>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.

--- a/vendored/NOTICE
+++ b/vendored/NOTICE
@@ -1,0 +1,33 @@
+Third-party source vendored into this repository
+================================================
+
+Everything under `vendored/`, except where noted below, is redistributed
+verbatim from:
+
+    Project:  gnolang/gno
+    Source:   https://github.com/gnolang/gno  (examples/)
+    Commit:   2c7f1abe324e8fa6fac6dc71a36635cc4e92a0be
+    Licence:  GNO Network General Public License — see vendored/LICENSE.md
+
+`LICENSE.md` in this directory is upstream's, copied verbatim from that same
+commit. Per its own terms it "covers all of the files in this directory and any
+subdirectory, except where otherwise specified", which includes `examples/`.
+
+Two vendored packages carry their own upstream licence files, preserved in
+place: `gno.land/p/onbloc/json/LICENSE` and `gno.land/p/nt/cford32/v0/LICENSE`.
+
+The commit above is the `GNOVERSION` pinned in the repository `Makefile`. CI
+re-derives this claim on every run (`.github/workflows/vendored-provenance.yml`)
+and fails if any vendored file differs from that commit, in either direction, so
+this notice cannot silently fall out of date.
+
+Not from gnolang/gno
+--------------------
+
+    gno.land/p/samcrew/avl/
+
+is a FORK, not upstream, and is excluded from the provenance comparison. It is
+byte-identical to `deps/avl` in `samouraiworld/samcrew-deployer`, which carries
+its own guard pinning it to upstream `f3d5a5d13`. It exists because topaz-1's
+stdlib `p/nt/avl/v0` exposes a single-value `Get` while this codebase calls the
+two-value form. See `vendored/README.md`.

--- a/vendored/README.md
+++ b/vendored/README.md
@@ -1,0 +1,60 @@
+# `vendored/` — the pinned dependency closure
+
+`gno lint` and `gno test` do **not** resolve dependencies from a lockfile. They derive the source
+from the pkgpath domain (`rpcpkgfetcher.go`: `https://rpc.%s:443`), and `rpc.gno.land` CNAMEs to
+betanet — a **mutable testnet**. So a hermetically pinned compiler was being fed by a live,
+unversioned dependency source, and any upstream redeploy retroactively broke every branch, including
+already-merged history.
+
+That is why CI went red on 2026-06-04 and stayed red. Two independent failure classes:
+
+1. **Syntax skew** — the chain serves *pre*-interrealm-v2 sources, i.e. the deps are **older** than
+   the pinned compiler. Bumping `GNOVERSION` moves *further* away, not closer.
+2. **Packages simply gone** — `r/demo/profile` returns a server-side "package is not available". The
+   failed fetch leaves the cache directory uncreated, which then resurfaces as a *misleading*
+   `open …/p/onbloc/json: no such file or directory` — a masked download failure, not cache
+   corruption.
+
+Vendoring removes the network from the build, which is the only thing that closes both classes.
+`load.go` short-circuits the fetch on any workspace-local match.
+
+## Placement is load-bearing
+
+This directory sits at the **repository root**, deliberately not under `gno/`. `make lint`, `make
+test` and `make fmt` all target `./gno/...`, so vendored third-party code is resolved but never
+linted, tested or reformatted. Moving it under `gno/` would pull every vendored package into those
+targets.
+
+## Provenance
+
+Every file except `gno.land/p/samcrew/avl/` is copied **byte-for-byte** from `examples/` in
+`gnolang/gno` at the `GNOVERSION` pinned in the `Makefile`, so the dependencies are version-matched
+to the compiler by construction. CI re-checks this on every run (`vendored-provenance`), so the two
+cannot drift apart silently.
+
+`gno.land/p/samcrew/avl/` is the **fork**, not upstream. It is byte-identical to `deps/avl` in
+`samouraiworld/samcrew-deployer`, which carries its own CI guard pinning it to upstream `f3d5a5d13`.
+
+### Why the fork, and why this matters
+
+topaz-1's stdlib `p/nt/avl/v0` exposes a **single-value** `Get`, while this codebase calls the
+**two-value** form. Vendoring upstream `p/nt/avl/v0` for the data-structure role would produce a
+**green build compiled against an ABI the target chain does not have** — a false green in exactly
+the place the gate exists to prevent one. So the fork is vendored for that role.
+
+The one remaining `gno.land/p/nt/avl/v0` import, in `gno/p/basedao/utils.gno`, is deliberate:
+`svg.Canvas.Style` is a `*nt/avl/v0.Tree`, so the stdlib ABI must be matched exactly at that
+boundary. It only calls `NewTree()`, never `Get`, so it carries no arity exposure.
+
+## Regenerating
+
+```sh
+GNOVERSION=$(sed -n '1s/GNOVERSION=//p' Makefile)
+git clone https://github.com/gnolang/gno /tmp/gno && git -C /tmp/gno checkout "$GNOVERSION"
+# copy each package listed below from /tmp/gno/examples/<pkgpath> to vendored/<pkgpath>
+# then restore the fork:
+cp -R ../samcrew-deployer/deps/avl vendored/gno.land/p/samcrew/avl
+```
+
+Add a package when the build reports `gno: downloading <path>`; the CI hermeticity guard fails the
+build if any such line appears, so the closure cannot silently become incomplete.

--- a/vendored/README.md
+++ b/vendored/README.md
@@ -42,9 +42,29 @@ topaz-1's stdlib `p/nt/avl/v0` exposes a **single-value** `Get`, while this code
 **green build compiled against an ABI the target chain does not have** — a false green in exactly
 the place the gate exists to prevent one. So the fork is vendored for that role.
 
-The one remaining `gno.land/p/nt/avl/v0` import, in `gno/p/basedao/utils.gno`, is deliberate:
-`svg.Canvas.Style` is a `*nt/avl/v0.Tree`, so the stdlib ABI must be matched exactly at that
-boundary. It only calls `NewTree()`, never `Get`, so it carries no arity exposure.
+### ⚠️ A green build here does not by itself prove "publishable on topaz-1"
+
+`GNOVERSION` is **not** topaz-1's ref. The chain runs `fc4052651`; the `Makefile` pins `2c7f1abe`.
+Roughly 15 vendored packages therefore differ from what the chain actually hosts — **including
+`p/nt/avl/v0`, whose on-chain `Get` is single-value while the vendored copy is two-value.**
+
+Do not read the vendored tree as a mirror of topaz-1. It is version-matched to the **compiler**, and
+that is all the provenance job proves.
+
+What makes it safe today is narrower and worth stating exactly: gnodaokit crosses the stdlib-avl
+boundary in exactly one place — `ntavl` in `gno/p/basedao/utils.gno`, because `svg.Canvas.Style` is
+a `*nt/avl/v0.Tree` — and it calls only `NewTree()`, whose signature is identical in both. A single
+new `ntavl.Get()` call would compile green here and fail `AddPackage` on-chain.
+
+CI enforces precisely that invariant (`vendored-provenance.yml`, "The stdlib-avl boundary must stay
+limited to NewTree"). Widening the boundary, or bumping `GNOVERSION`, means re-checking the exported
+surface of every skewed package against the chain — not just re-running the build.
+
+### Sequencing
+
+`p/samcrew/avl` (and its `pager`/`rotree`) exist on **no chain yet** — the deployer publishes them
+first in the ceremony. So a green build here still cannot deploy gnodaokit to topaz-1 until that
+dependency step has run.
 
 ## Regenerating
 

--- a/vendored/gno.land/p/demo/svg/doc.gno
+++ b/vendored/gno.land/p/demo/svg/doc.gno
@@ -1,0 +1,30 @@
+/*
+Package svg is a minimalist and extensible SVG generation library for Gno.
+
+It provides a structured way to create and compose SVG elements such as rectangles, circles, text, paths, and more. The package is designed to be modular and developer-friendly, enabling optional attributes and method chaining for ease of use.
+
+Each SVG element embeds a BaseAttrs struct, which supports common SVG attributes like `id`, `class`, `style`, `fill`, `stroke`, and `transform`.
+
+Canvas objects represent the root SVG container and support global dimensions, viewBox configuration, embedded styles, and element composition.
+
+Example:
+
+	import "gno.land/p/demo/svg"
+
+	func Foo() string {
+		canvas := svg.NewCanvas(200, 200).WithViewBox(0, 0, 200, 200)
+		canvas.AddStyle(".my-rect", "stroke:black;stroke-width:2")
+		canvas.Append(
+			svg.NewRectangle(60, 40, 100, 50, "red").WithClass("my-rect"),
+			svg.NewCircle(50, 80, 40, "blue"),
+			&svg.Path{D: `M 10,30
+			A 20,20 0,0,1 50,30
+				A 20,20 0,0,1  90,30
+				Q 90,60 50,90
+				Q 10,60 10,30 z`, Fill: "magenta"},
+			svg.NewText(20, 50, "Hello SVG", "black"),
+		)
+		mysvg := canvas.Base64()
+	}
+*/
+package svg // import "gno.land/p/demo/svg"

--- a/vendored/gno.land/p/demo/svg/filetests/z0_filetest.gno
+++ b/vendored/gno.land/p/demo/svg/filetests/z0_filetest.gno
@@ -1,0 +1,20 @@
+// PKGPATH: gno.land/p/demo/svg_test
+package svg_test
+
+import "gno.land/p/demo/svg"
+
+func main() {
+	canvas := svg.Canvas{Width: 500, Height: 500}
+	canvas.Append(
+		svg.Rectangle{X: 50, Y: 50, Width: 100, Height: 100, Fill: "red"},
+		svg.Circle{CX: 100, CY: 100, R: 50, Fill: "blue"},
+		svg.Text{X: 100, Y: 100, Text: "hello world!", Fill: "magenta"},
+	)
+	canvas.Append(
+		svg.NewCircle(100, 100, 50, "blue").WithClass("toto"),
+	)
+	println(canvas)
+}
+
+// Output:
+// <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox=""><rect x="50" y="50" width="100" height="100" rx="0" ry="0" fill="red" /><circle cx="100" cy="100" r="50" fill="blue" /><text x="100" y="100" dx="0" dy="0" rotate="" fill="magenta" >hello world!</text><circle cx="100" cy="100" r="50" fill="blue" class="toto"/></svg>

--- a/vendored/gno.land/p/demo/svg/filetests/z1_filetest.gno
+++ b/vendored/gno.land/p/demo/svg/filetests/z1_filetest.gno
@@ -1,0 +1,19 @@
+// PKGPATH: gno.land/p/demo/svg_test
+package svg_test
+
+import "gno.land/p/demo/svg"
+
+func main() {
+	canvas := svg.Canvas{
+		Width: 500, Height: 500,
+		Elems: []svg.Elem{
+			svg.Rectangle{X: 50, Y: 50, Width: 100, Height: 100, Fill: "red"},
+			svg.Circle{CX: 50, CY: 50, R: 100, Fill: "red"},
+			svg.Text{X: 100, Y: 100, Text: "hello world!", Fill: "magenta"},
+		},
+	}
+	println(canvas)
+}
+
+// Output:
+// <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox=""><rect x="50" y="50" width="100" height="100" rx="0" ry="0" fill="red" /><circle cx="50" cy="50" r="100" fill="red" /><text x="100" y="100" dx="0" dy="0" rotate="" fill="magenta" >hello world!</text></svg>

--- a/vendored/gno.land/p/demo/svg/gnomod.toml
+++ b/vendored/gno.land/p/demo/svg/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/demo/svg"
+gno = "0.9"

--- a/vendored/gno.land/p/demo/svg/svg.gno
+++ b/vendored/gno.land/p/demo/svg/svg.gno
@@ -1,0 +1,316 @@
+package svg
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+type Canvas struct {
+	Width, Height int
+	ViewBox       string
+	Elems         []Elem
+	Style         *avl.Tree
+}
+
+type Elem interface{ String() string }
+
+func NewCanvas(width, height int) *Canvas {
+	return &Canvas{
+		Width:  width,
+		Height: height,
+		Style:  nil,
+	}
+}
+
+func (c *Canvas) AddStyle(key, value string) *Canvas {
+	if c.Style == nil {
+		c.Style = avl.NewTree()
+	}
+	c.Style.Set(key, value)
+	return c
+}
+
+func (c *Canvas) WithViewBox(x, y, width, height int) *Canvas {
+	c.ViewBox = ufmt.Sprintf("%d %d %d %d", x, y, width, height)
+	return c
+}
+
+// Render renders your canvas
+func (c Canvas) Render(alt string) string {
+	base64SVG := base64.StdEncoding.EncodeToString([]byte(c.String()))
+	return ufmt.Sprintf("![%s](data:image/svg+xml;base64,%s)", alt, base64SVG)
+}
+
+func (c Canvas) String() string {
+	out := ""
+	out += ufmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="%s">`, c.Width, c.Height, c.ViewBox)
+	if c.Style != nil {
+		out += "<style>"
+		c.Style.Iterate("", "", func(k string, val interface{}) bool {
+			v := val.(string)
+			out += ufmt.Sprintf("%s{%s}", k, v)
+			return false
+		})
+		out += "</style>"
+	}
+	for _, elem := range c.Elems {
+		out += elem.String()
+	}
+	out += "</svg>"
+	return out
+}
+
+func (c Canvas) Base64() string {
+	out := c.String()
+	return base64.StdEncoding.EncodeToString([]byte(out))
+}
+
+func (c *Canvas) Append(elem ...Elem) {
+	c.Elems = append(c.Elems, elem...)
+}
+
+type BaseAttrs struct {
+	ID          string
+	Class       string
+	Style       string
+	Stroke      string
+	StrokeWidth string
+	Opacity     string
+	Transform   string
+	Visibility  string
+}
+
+func (b BaseAttrs) String() string {
+	var elems []string
+
+	if b.ID != "" {
+		elems = append(elems, `id="`+b.ID+`"`)
+	}
+	if b.Class != "" {
+		elems = append(elems, `class="`+b.Class+`"`)
+	}
+	if b.Style != "" {
+		elems = append(elems, `style="`+b.Style+`"`)
+	}
+	if b.Stroke != "" {
+		elems = append(elems, `stroke="`+b.Stroke+`"`)
+	}
+	if b.StrokeWidth != "" {
+		elems = append(elems, `stroke-width="`+b.StrokeWidth+`"`)
+	}
+	if b.Opacity != "" {
+		elems = append(elems, `opacity="`+b.Opacity+`"`)
+	}
+	if b.Transform != "" {
+		elems = append(elems, `transform="`+b.Transform+`"`)
+	}
+	if b.Visibility != "" {
+		elems = append(elems, `visibility="`+b.Visibility+`"`)
+	}
+	if len(elems) == 0 {
+		return ""
+	}
+	return strings.Join(elems, " ")
+}
+
+type Circle struct {
+	CX   int // center X
+	CY   int // center Y
+	R    int // radius
+	Fill string
+	Attr BaseAttrs
+}
+
+func (c Circle) String() string {
+	return ufmt.Sprintf(`<circle cx="%d" cy="%d" r="%d" fill="%s" %s/>`, c.CX, c.CY, c.R, c.Fill, c.Attr.String())
+}
+
+func NewCircle(cx, cy, r int, fill string) *Circle {
+	return &Circle{
+		CX:   cx,
+		CY:   cy,
+		R:    r,
+		Fill: fill,
+	}
+}
+
+func (c *Circle) WithClass(class string) *Circle {
+	c.Attr.Class = class
+	return c
+}
+
+type Ellipse struct {
+	CX   int // center X
+	CY   int // center Y
+	RX   int // radius X
+	RY   int // radius Y
+	Fill string
+	Attr BaseAttrs
+}
+
+func (e Ellipse) String() string {
+	return ufmt.Sprintf(`<ellipse cx="%d" cy="%d" rx="%d" ry="%d" fill="%s" %s/>`, e.CX, e.CY, e.RX, e.RY, e.Fill, e.Attr.String())
+}
+
+func NewEllipse(cx, cy int, fill string) *Ellipse {
+	return &Ellipse{
+		CX:   cx,
+		CY:   cy,
+		Fill: fill,
+	}
+}
+
+func (e *Ellipse) WithClass(class string) *Ellipse {
+	e.Attr.Class = class
+	return e
+}
+
+type Rectangle struct {
+	X, Y, Width, Height int
+	RX, RY              int // corner radiuses
+	Fill                string
+	Attr                BaseAttrs
+}
+
+func (r Rectangle) String() string {
+	return ufmt.Sprintf(`<rect x="%d" y="%d" width="%d" height="%d" rx="%d" ry="%d" fill="%s" %s/>`, r.X, r.Y, r.Width, r.Height, r.RX, r.RY, r.Fill, r.Attr.String())
+}
+
+func NewRectangle(x, y, width, height int, fill string) *Rectangle {
+	return &Rectangle{
+		X:      x,
+		Y:      y,
+		Width:  width,
+		Height: height,
+		Fill:   fill,
+	}
+}
+
+func (r *Rectangle) WithClass(class string) *Rectangle {
+	r.Attr.Class = class
+	return r
+}
+
+type Path struct {
+	D    string
+	Fill string
+	Attr BaseAttrs
+}
+
+func (p Path) String() string {
+	return ufmt.Sprintf(`<path d="%s" fill="%s" %s/>`, p.D, p.Fill, p.Attr.String())
+}
+
+func NewPath(d, fill string) *Path {
+	return &Path{
+		D:    d,
+		Fill: fill,
+	}
+}
+
+func (p *Path) WithClass(class string) *Path {
+	p.Attr.Class = class
+	return p
+}
+
+type Polygon struct { // closed shape
+	Points string
+	Fill   string
+	Attr   BaseAttrs
+}
+
+func (p Polygon) String() string {
+	return ufmt.Sprintf(`<polygon points="%s" fill="%s" %s/>`, p.Points, p.Fill, p.Attr.String())
+}
+
+func NewPolygon(points, fill string) *Polygon {
+	return &Polygon{
+		Points: points,
+		Fill:   fill,
+	}
+}
+
+func (p *Polygon) WithClass(class string) *Polygon {
+	p.Attr.Class = class
+	return p
+}
+
+type Polyline struct { // polygon but not necessarily closed
+	Points string
+	Fill   string
+	Attr   BaseAttrs
+}
+
+func (p Polyline) String() string {
+	return ufmt.Sprintf(`<polyline points="%s" fill="%s" %s/>`, p.Points, p.Fill, p.Attr.String())
+}
+
+func NewPolyline(points, fill string) *Polyline {
+	return &Polyline{
+		Points: points,
+		Fill:   fill,
+	}
+}
+
+func (p *Polyline) WithClass(class string) *Polyline {
+	p.Attr.Class = class
+	return p
+}
+
+type Text struct {
+	X, Y       int
+	DX, DY     int // shift text pos horizontally/ vertically
+	Rotate     string
+	Text, Fill string
+	Attr       BaseAttrs
+}
+
+func (c Text) String() string {
+	return ufmt.Sprintf(`<text x="%d" y="%d" dx="%d" dy="%d" rotate="%s" fill="%s" %s>%s</text>`, c.X, c.Y, c.DX, c.DY, c.Rotate, c.Fill, c.Attr.String(), c.Text)
+}
+
+func NewText(x, y int, text, fill string) *Text {
+	return &Text{
+		X:    x,
+		Y:    y,
+		Text: text,
+		Fill: fill,
+	}
+}
+
+func (c *Text) WithClass(class string) *Text {
+	c.Attr.Class = class
+	return c
+}
+
+type Group struct {
+	Elems []Elem
+	Fill  string
+	Attr  BaseAttrs
+}
+
+func (g Group) String() string {
+	out := ""
+	for _, e := range g.Elems {
+		out += e.String()
+	}
+	return ufmt.Sprintf(`<g fill="%s" %s>%s</g>`, g.Fill, g.Attr.String(), out)
+}
+
+func NewGroup(fill string) *Group {
+	return &Group{
+		Fill: fill,
+	}
+}
+
+func (g *Group) Append(elem ...Elem) {
+	g.Elems = append(g.Elems, elem...)
+}
+
+func (g *Group) WithClass(class string) *Group {
+	g.Attr.Class = class
+	return g
+}

--- a/vendored/gno.land/p/mason/md/gnomod.toml
+++ b/vendored/gno.land/p/mason/md/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/mason/md"
+gno = "0.9"

--- a/vendored/gno.land/p/mason/md/md.gno
+++ b/vendored/gno.land/p/mason/md/md.gno
@@ -1,0 +1,48 @@
+package md
+
+import (
+	"strings"
+)
+
+type MD struct {
+	elements []string
+}
+
+func New() *MD {
+	return &MD{elements: []string{}}
+}
+
+func (m *MD) H1(text string) {
+	m.elements = append(m.elements, "# "+text)
+}
+
+func (m *MD) H3(text string) {
+	m.elements = append(m.elements, "### "+text)
+}
+
+func (m *MD) P(text string) {
+	m.elements = append(m.elements, text)
+}
+
+func (m *MD) Code(text string) {
+	m.elements = append(m.elements, "  ```\n"+text+"\n```\n")
+}
+
+func (m *MD) Im(path string, caption string) {
+	m.elements = append(m.elements, "!["+caption+"]("+path+" \""+caption+"\")")
+}
+
+func (m *MD) Bullet(point string) {
+	m.elements = append(m.elements, "- "+point)
+}
+
+func Link(text, url string, title ...string) string {
+	if len(title) > 0 && title[0] != "" {
+		return "[" + text + "](" + url + " \"" + title[0] + "\")"
+	}
+	return "[" + text + "](" + url + ")"
+}
+
+func (m *MD) Render() string {
+	return strings.Join(m.elements, "\n\n")
+}

--- a/vendored/gno.land/p/moul/md/filetests/z1_filetest.gno
+++ b/vendored/gno.land/p/moul/md/filetests/z1_filetest.gno
@@ -1,0 +1,188 @@
+package main
+
+import "gno.land/p/moul/md"
+
+func main() {
+	println(md.H1("Header 1"))
+	println(md.H2("Header 2"))
+	println(md.H3("Header 3"))
+	println(md.H4("Header 4"))
+	println(md.H5("Header 5"))
+	println(md.H6("Header 6"))
+	println(md.Bold("bold"))
+	println(md.Italic("italic"))
+	println(md.Strikethrough("strikethrough"))
+	println(md.BulletList([]string{
+		"Item 1",
+		"Item 2\nMore details for item 2",
+	}))
+	println(md.OrderedList([]string{"Step 1", "Step 2"}))
+	println(md.TodoList([]string{"Task 1", "Task 2\nSubtask 2"}, []bool{true, false}))
+	println(md.Nested(md.BulletList([]string{"Parent Item", md.OrderedList([]string{"Child 1", "Child 2"})}), "  "))
+	println(md.Blockquote("This is a blockquote\nSpanning multiple lines"))
+	println(md.InlineCode("inline `code`"))
+	println(md.CodeBlock("line1\nline2"))
+	println(md.LanguageCodeBlock("go", "func main() {\nprintln(\"Hello, world!\")\n}"))
+	println(md.HorizontalRule())
+	println(md.Link("Gno", "http://gno.land"))
+	println(md.Image("Alt Text", "http://example.com/image.png"))
+	println(md.InlineImageWithLink("Alt Text", "http://example.com/image.png", "http://example.com"))
+	println(md.FootnoteDefinition("ref", "This is a footnote"))
+	println(md.LinkReferenceDefinition("r-example", "/r/example", ""))
+	println(md.Paragraph("This is a paragraph."))
+
+	println("4 columns in one gno-columns tag:")
+	println(md.Columns([]string{
+		"Column1\ncontent1",
+		"Column2\ncontent2",
+		"Column3\ncontent3",
+		"Column4\ncontent4",
+	}, true))
+
+	// Should be automatically placed in multiple column tags
+	println("3 cols per row without padding:")
+	println(md.ColumnsN([]string{
+		"Row1Column1\ncontent1",
+		"Row1Column2\ncontent2",
+		"Row1Column3\ncontent3",
+		"Row2Column1\ncontent1",
+		"Row2Column2\ncontent2",
+		"Row2Column3\ncontent3",
+		"Row3Column1\ncontent1",
+		"Row3Column2\ncontent2",
+		"Row3Column3\ncontent3",
+	}, 3, false))
+
+	// Should be padded, up to 4 cols
+	println("2 padded to 4:")
+	println(md.ColumnsN([]string{
+		"Column1\ncontent1",
+		"Column2\ncontent2",
+	}, 4, true))
+
+}
+
+// Output:
+// # Header 1
+//
+// ## Header 2
+//
+// ### Header 3
+//
+// #### Header 4
+//
+// ##### Header 5
+//
+// ###### Header 6
+//
+// **bold**
+// *italic*
+// ~~strikethrough~~
+// - Item 1
+// - Item 2
+//   More details for item 2
+//
+// 1. Step 1
+// 2. Step 2
+//
+// - [x] Task 1
+// - [ ] Task 2
+//   Subtask 2
+//
+//   - Parent Item
+//   - 1. Child 1
+//     2. Child 2
+//
+//
+//
+// > This is a blockquote
+// > Spanning multiple lines
+//
+//
+// `` inline `code` ``
+// ```
+// line1
+// line2
+// ```
+//
+// ```go
+// func main() {
+// println("Hello, world!")
+// }
+// ```
+//
+// ---
+//
+// [Gno](http://gno.land)
+// ![Alt Text](http://example.com/image.png)
+// [![Alt Text](http://example.com/image.png)](http://example.com)
+// [^ref]:
+//     This is a footnote
+//
+//
+//
+// [r-example]: /r/example
+//
+//
+// This is a paragraph.
+//
+//
+// 4 columns in one gno-columns tag:
+// <gno-columns>
+// Column1
+// content1
+// <gno-columns-sep>
+// Column2
+// content2
+// <gno-columns-sep>
+// Column3
+// content3
+// <gno-columns-sep>
+// Column4
+// content4
+// </gno-columns>
+//
+// 3 cols per row without padding:
+// <gno-columns>
+// Row1Column1
+// content1
+// <gno-columns-sep>
+// Row1Column2
+// content2
+// <gno-columns-sep>
+// Row1Column3
+// content3
+// </gno-columns>
+// <gno-columns>
+// Row2Column1
+// content1
+// <gno-columns-sep>
+// Row2Column2
+// content2
+// <gno-columns-sep>
+// Row2Column3
+// content3
+// </gno-columns>
+// <gno-columns>
+// Row3Column1
+// content1
+// <gno-columns-sep>
+// Row3Column2
+// content2
+// <gno-columns-sep>
+// Row3Column3
+// content3
+// </gno-columns>
+//
+// 2 padded to 4:
+// <gno-columns>
+// Column1
+// content1
+// <gno-columns-sep>
+// Column2
+// content2
+// <gno-columns-sep>
+//
+// <gno-columns-sep>
+//
+// </gno-columns>

--- a/vendored/gno.land/p/moul/md/gnomod.toml
+++ b/vendored/gno.land/p/moul/md/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/moul/md"
+gno = "0.9"
+
+[addpkg]
+  creator = "g1manfred47kzduec920z88wfr64ylksmdcedlf5"

--- a/vendored/gno.land/p/moul/md/md.gno
+++ b/vendored/gno.land/p/moul/md/md.gno
@@ -1,0 +1,504 @@
+// Package md provides helper functions for generating Markdown content programmatically.
+//
+// It includes utilities for text formatting, creating lists, blockquotes, code blocks,
+// links, images, and more.
+//
+// Highlights:
+// - Supports basic Markdown syntax such as bold, italic, strikethrough, headers, and lists.
+// - Manages multiline support in lists (e.g., bullet, ordered, and todo lists).
+// - Includes advanced helpers like inline images with links and nested list prefixes.
+//
+// For a comprehensive example of how to use these helpers, see:
+// https://gno.land/r/docs/moul_md
+//
+// # Sanitization contract
+//
+// Some helpers in this package sanitize their user-derived arguments
+// INTERNALLY (via p/nt/markdown/sanitize/v0). When using these, pass
+// raw user input — do NOT pre-wrap with sanitize.*, or you will
+// double-wrap (the escapers are not idempotent and double-wrap is a
+// bug):
+//
+//	Link, UserLink, Image, InlineImageWithLink, FootnoteDefinition,
+//	LinkReferenceDefinition, CollapsibleSection (title only),
+//	InlineCode, CodeBlock, LanguageCodeBlock, Blockquote
+//
+// The other helpers DO NOT sanitize — they are pure builders that
+// wrap their input in markdown chrome. User-derived input reaches
+// the output unmodified, so callers MUST wrap with sanitize.* at the
+// call site:
+//
+//	Bold, Italic, Strikethrough, H1-H6, BulletList, BulletItem,
+//	OrderedList, TodoList, TodoItem, Nested, Paragraph, Columns,
+//	ColumnsN, HorizontalRule
+//
+// Examples:
+//
+//	// Sanitizing helper — pass raw:
+//	out += md.Link(post.Title, post.URL)                                 // good
+//	out += md.Link(sanitize.InlineText(post.Title), sanitize.URL(post.URL)) // BAD: double-wrap
+//
+//	// Non-sanitizing helper — wrap once:
+//	out += md.H2(sanitize.InlineText(post.Title))                        // good
+//	out += md.H2(post.Title)                                             // BAD: raw user input
+//	out += md.H2(sanitize.InlineText(sanitize.InlineText(post.Title)))   // BAD: double-wrap
+//
+// Composition: outputs of sanitizing helpers are safe markdown chrome
+// and can be embedded inside non-sanitizing helpers freely:
+//
+//	out += md.H2(md.Link(post.Title, post.URL))   // good — H2 doesn't re-escape Link's output
+//
+// The reverse is unsafe: do NOT embed a non-sanitizing helper's
+// markdown chrome inside a sanitizing helper's arg, or the inner
+// markdown gets re-escaped:
+//
+//	out += md.Link(md.Bold(post.Title), post.URL) // BAD: Link's internal sanitize
+//	                                              // escapes the ** chars from md.Bold
+package md
+
+import (
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/markdown/sanitize/v0"
+)
+
+// Bold returns bold text for markdown.
+// Example: Bold("foo") => "**foo**"
+func Bold(text string) string {
+	return "**" + text + "**"
+}
+
+// Italic returns italicized text for markdown.
+// Example: Italic("foo") => "*foo*"
+func Italic(text string) string {
+	return "*" + text + "*"
+}
+
+// Strikethrough returns strikethrough text for markdown.
+// Example: Strikethrough("foo") => "~~foo~~"
+func Strikethrough(text string) string {
+	return "~~" + text + "~~"
+}
+
+// H1 returns a level 1 header for markdown.
+// Example: H1("foo") => "# foo\n"
+func H1(text string) string {
+	return "# " + text + "\n"
+}
+
+// H2 returns a level 2 header for markdown.
+// Example: H2("foo") => "## foo\n"
+func H2(text string) string {
+	return "## " + text + "\n"
+}
+
+// H3 returns a level 3 header for markdown.
+// Example: H3("foo") => "### foo\n"
+func H3(text string) string {
+	return "### " + text + "\n"
+}
+
+// H4 returns a level 4 header for markdown.
+// Example: H4("foo") => "#### foo\n"
+func H4(text string) string {
+	return "#### " + text + "\n"
+}
+
+// H5 returns a level 5 header for markdown.
+// Example: H5("foo") => "##### foo\n"
+func H5(text string) string {
+	return "##### " + text + "\n"
+}
+
+// H6 returns a level 6 header for markdown.
+// Example: H6("foo") => "###### foo\n"
+func H6(text string) string {
+	return "###### " + text + "\n"
+}
+
+// BulletList returns a bullet list for markdown.
+// Example: BulletList([]string{"foo", "bar"}) => "- foo\n- bar\n"
+func BulletList(items []string) string {
+	var sb strings.Builder
+	for _, item := range items {
+		sb.WriteString(BulletItem(item))
+	}
+	return sb.String()
+}
+
+// BulletItem returns a bullet item for markdown.
+// Example: BulletItem("foo") => "- foo\n"
+func BulletItem(item string) string {
+	var sb strings.Builder
+	lines := strings.Split(item, "\n")
+	sb.WriteString("- " + lines[0] + "\n")
+	for _, line := range lines[1:] {
+		sb.WriteString("  " + line + "\n")
+	}
+	return sb.String()
+}
+
+// OrderedList returns an ordered list for markdown.
+// Example: OrderedList([]string{"foo", "bar"}) => "1. foo\n2. bar\n"
+func OrderedList(items []string) string {
+	var sb strings.Builder
+	for i, item := range items {
+		lines := strings.Split(item, "\n")
+		sb.WriteString(strconv.Itoa(i+1) + ". " + lines[0] + "\n")
+		for _, line := range lines[1:] {
+			sb.WriteString("   " + line + "\n")
+		}
+	}
+	return sb.String()
+}
+
+// TodoList returns a list of todo items with checkboxes for markdown.
+// Example: TodoList([]string{"foo", "bar\nmore bar"}, []bool{true, false}) => "- [x] foo\n- [ ] bar\n  more bar\n"
+func TodoList(items []string, done []bool) string {
+	var sb strings.Builder
+	for i, item := range items {
+		sb.WriteString(TodoItem(item, done[i]))
+	}
+	return sb.String()
+}
+
+// TodoItem returns a todo item with checkbox for markdown.
+// Example: TodoItem("foo", true) => "- [x] foo\n"
+func TodoItem(item string, done bool) string {
+	var sb strings.Builder
+	checkbox := " "
+	if done {
+		checkbox = "x"
+	}
+	lines := strings.Split(item, "\n")
+	sb.WriteString("- [" + checkbox + "] " + lines[0] + "\n")
+	for _, line := range lines[1:] {
+		sb.WriteString("  " + line + "\n")
+	}
+	return sb.String()
+}
+
+// Nested prefixes each line with a given prefix, enabling nested lists.
+// Example: Nested("- foo\n- bar", "  ") => "  - foo\n  - bar\n"
+func Nested(content, prefix string) string {
+	lines := strings.Split(content, "\n")
+	for i := range lines {
+		if strings.TrimSpace(lines[i]) != "" {
+			lines[i] = prefix + lines[i]
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Blockquote returns the text as a CommonMark blockquote.
+// Example: Blockquote("foo\nbar") => "\n> foo\n> bar\n\n"
+//
+// Delegates to sanitize.Blockquote, which cleans the content (bidi-strip,
+// CR/CRLF/U+2028/U+2029/NEL line-ending normalize, LRD strip, ref-link
+// escape, block-marker escape, fence auto-close), line-prefixes each
+// line with "> ", and wraps with "\n" / "\n\n" so the quote opens
+// cleanly and cannot pull appended chrome into the quote via CM §5.2
+// lazy continuation. Callers do NOT need to pre-wrap the input.
+func Blockquote(text string) string {
+	return sanitize.Blockquote(text)
+}
+
+// InlineCode wraps the given text as a CommonMark inline code span.
+// Example: InlineCode("foo") => "`foo`"
+//
+// Delegates to sanitize.InlineCode, which cleans the input (bidi-strip,
+// CR/CRLF + NEL + U+2028/U+2029 folded to single space, NUL→U+FFFD)
+// and picks a backtick-run length that outscans any internal backticks.
+// Callers do NOT need to pre-wrap the input.
+func InlineCode(code string) string {
+	return sanitize.InlineCode(code)
+}
+
+// CodeBlock creates a markdown code block.
+// Example: CodeBlock("foo") => "```\nfoo\n```"
+//
+// Delegates to sanitize.CodeBlock, which cleans the content (bidi-strip,
+// CR/CRLF normalize, NEL/U+2028/U+2029 fold, NUL→U+FFFD) and picks a
+// fence wide enough to outscan any backticks in content. Callers do NOT
+// need to pre-wrap content with another sanitize helper.
+func CodeBlock(content string) string {
+	return sanitize.CodeBlock(content)
+}
+
+// LanguageCodeBlock creates a markdown code block with language-specific syntax highlighting.
+// Example: LanguageCodeBlock("go", "foo") => "```go\nfoo\n```"
+//
+// Delegates to sanitize.LanguageCodeBlock, which validates the language
+// tag (charset ^[a-zA-Z0-9_+-]{1,32}$, falling back to a tagless fence
+// if invalid) and cleans the content as CodeBlock does. Callers do NOT
+// need to pre-wrap either argument.
+func LanguageCodeBlock(language, content string) string {
+	return sanitize.LanguageCodeBlock(language, content)
+}
+
+// HorizontalRule returns a horizontal rule for markdown.
+// Example: HorizontalRule() => "---\n"
+func HorizontalRule() string {
+	return "---\n"
+}
+
+// Link returns a hyperlink for markdown.
+// Example: Link("foo", "http://example.com") => "[foo](http://example.com)"
+//
+// The text and url args are sanitized internally — text via
+// sanitize.InlineText, url via sanitize.URL (allowlists http/https/
+// mailto/relative/fragment; rejects javascript:, data:, blob:, etc.).
+// Callers do NOT need to pre-wrap either argument; double-wrapping is
+// a bug (the inline-text escaper is non-idempotent).
+//
+// If the URL fails the scheme allowlist, the href is rendered empty —
+// the link becomes inert rather than carrying a malicious destination.
+func Link(text, url string) string {
+	return "[" + sanitize.InlineText(text) + "](" + sanitize.URL(url) + ")"
+}
+
+// UserLink returns a user profile link for markdown.
+// Example: UserLink("moul") => "[@moul](/u/moul)"
+// Example: UserLink("g1blah...") => "[g1blah...](/u/g1blah...)"
+//
+// Validates the user identifier — if it matches the gno bech32 address
+// pattern (g1...), produces an address-style link; otherwise tries the
+// r/sys/users-charset username and produces an @-style link. Returns
+// "" if the identifier matches neither — callers should treat "" as
+// "skip the user mention" rather than emit a broken link.
+func UserLink(user string) string {
+	if addr := sanitize.BechString(user, "g"); addr != "" {
+		return "[" + addr + "](/u/" + addr + ")"
+	}
+	if name := sanitize.UserName(user); name != "" {
+		return "[@" + name + "](/u/" + name + ")"
+	}
+	return ""
+}
+
+// InlineImageWithLink creates an inline image wrapped in a hyperlink for markdown.
+// Example: InlineImageWithLink("alt text", "image-url", "link-url") => "[![alt text](image-url)](link-url)"
+//
+// altText and imageUrl are sanitized via Image (sanitize.InlineText +
+// sanitize.ImageURL); linkUrl is sanitized via sanitize.URL. Callers
+// do NOT need to pre-wrap any argument.
+func InlineImageWithLink(altText, imageUrl, linkUrl string) string {
+	return "[" + Image(altText, imageUrl) + "](" + sanitize.URL(linkUrl) + ")"
+}
+
+// Image returns an image for markdown.
+// Example: Image("foo", "http://example.com") => "![foo](http://example.com)"
+//
+// altText is sanitized via sanitize.InlineText, url via
+// sanitize.ImageURL (allowlists http/https/relative + data:image/*;
+// rejects mailto:, javascript:, data:text/html, etc.). Callers do NOT
+// need to pre-wrap either argument.
+func Image(altText, url string) string {
+	return "![" + sanitize.InlineText(altText) + "](" + sanitize.ImageURL(url) + ")"
+}
+
+// FootnoteDefinition emits a GFM footnote definition — `[^name]: body` —
+// for a footnote that is referenced elsewhere in the document by
+// `[^name]`.
+//
+// Example: FootnoteDefinition("note1", "Long form of the citation.")
+// renders as:
+//
+//	[^note1]:
+//	    Long form of the citation.
+//
+// The `name` is validated as a FootnoteLabel (^[A-Za-z0-9_-]{1,64}$);
+// `text` is user-supplied multi-paragraph prose, sanitized via Block.
+// An invalid name or empty body returns "".
+//
+// Delegates to sanitize.FootnoteDefinition. Callers do NOT need to
+// pre-wrap either argument.
+func FootnoteDefinition(name, text string) string {
+	return sanitize.FootnoteDefinition(name, text)
+}
+
+// LinkReferenceDefinition emits a CommonMark link reference definition
+// (CM §4.7) — `[label]: url "title"` — for a reference link that is
+// invoked elsewhere by `[text][label]` or by the shortcut form
+// `[label]`.
+//
+// Example: LinkReferenceDefinition("r/docs/help", "/r/docs/help", "")
+// renders as:
+//
+//	[r/docs/help]: /r/docs/help
+//
+// The `label` is validated as a FootnoteLabel (^[A-Za-z0-9_-]{1,64}$);
+// `url` is sanitized via URL (allowlist); `title` is sanitized via
+// LinkTitle. An invalid label or rejected URL returns "".
+//
+// Realms should choose a namespaced label using dashes
+// (e.g. `r-myrealm-help`) so that shortcut-reference invocations from
+// user content can't collide with bare words a user is likely to write.
+// `/` is not in the FootnoteLabel charset.
+//
+// Delegates to sanitize.LinkReferenceDefinition. Callers do NOT need to
+// pre-wrap any argument.
+func LinkReferenceDefinition(label, url, title string) string {
+	return sanitize.LinkReferenceDefinition(label, url, title)
+}
+
+// Paragraph wraps the given text in a Markdown paragraph.
+// Example: Paragraph("foo") => "foo\n"
+func Paragraph(content string) string {
+	return content + "\n\n"
+}
+
+// CollapsibleSection creates a collapsible section for markdown using
+// HTML <details> and <summary> tags.
+// Example:
+// CollapsibleSection("Click to expand", "Hidden content")
+// =>
+// <details><summary>Click to expand</summary>
+//
+// Hidden content
+// </details>
+//
+// The title argument is sanitized via sanitize.HTMLEscape (it lands in
+// an HTML element body inside <summary>, not a markdown context — so
+// HTML entity escaping is the correct policy, not markdown backslash
+// escaping). The content argument is passed through unchanged because
+// <details> with a blank-line-separated body allows markdown inside
+// (CM §4.6); callers must pre-wrap content with sanitize.Block if it
+// derives from user input.
+func CollapsibleSection(title, content string) string {
+	return "<details><summary>" + sanitize.HTMLEscape(title) + "</summary>\n\n" + content + "\n</details>\n"
+}
+
+// EscapeURL escapes characters in a URL for use in markdown link syntax.
+//
+// Deprecated: use sanitize.URL (for link href) or sanitize.ImageURL
+// (for image src) directly. EscapeURL previously only percent-encoded
+// ( and ) and did not validate the URL scheme — a security footgun
+// (EscapeURL("javascript:alert(1)") returned a working XSS payload).
+// It now delegates to sanitize.URL, which allowlists schemes (rejects
+// javascript:, data:text/html, vbscript:, blob:, etc.) and
+// percent-encodes all unsafe bytes (including the ( ) this function
+// handled). The other helpers in this package (Link, UserLink, Image,
+// InlineImageWithLink) sanitize their URL args internally now, so you
+// rarely need to call any URL-escape helper directly.
+//
+// Behavior change vs. the original implementation: invalid schemes
+// now return "" instead of passing through with ( ) escaped. Non-ASCII
+// bytes get percent-encoded to standard RFC 3986 wire form instead of
+// passing through as raw UTF-8.
+func EscapeURL(url string) string {
+	return sanitize.URL(url)
+}
+
+// EscapeText escapes special Markdown characters in regular text for
+// use in inline contexts.
+//
+// Deprecated: use sanitize.InlineText directly. EscapeText was
+// INCOMPLETE — it missed \, #, <, & and did not strip bidi/zero-width
+// characters, replace NUL with U+FFFD, or normalize line endings.
+// User input could inject backslash escapes (\* cancels neighboring
+// escapes), autolinks (<https://x>), raw HTML (<script>), HTML entity
+// references (&amp;), and bidi spoofing (RLO before an address). It
+// now delegates to sanitize.InlineText. The other helpers in this
+// package (Link, UserLink, Image, InlineImageWithLink, CollapsibleSection)
+// sanitize their text args internally now, so you rarely need to call
+// any inline-text-escape helper directly.
+//
+// Behavior change vs. the original implementation: \, #, <, & are now
+// escaped; | is no longer escaped (the original was over-escaping —
+// outside GFM table-cell context, | is markdown-inert; for table
+// cells use sanitize.TableCell which adds the | escape on top of the
+// inline-text set). Bidi controls are stripped, NUL becomes U+FFFD,
+// and line endings normalize.
+func EscapeText(text string) string {
+	return sanitize.InlineText(text)
+}
+
+// Columns returns a formatted row of columns using the Gno syntax.
+// If you want a specific number of columns per row (<=4), use ColumnsN.
+// Check /r/docs/markdown#columns for more info.
+// If padded=true & the final <gno-columns> tag is missing column content, an empty
+// column element will be placed to keep the cols per row constant.
+// Padding works only with colsPerRow > 0.
+//
+// Example:
+//
+//	Columns([]string{"A", "B"}, false)
+//	// Returns:
+//	// <gno-columns>
+//	// A
+//	// <gno-columns-sep>
+//	// B
+//	// </gno-columns>
+func Columns(contentByColumn []string, padded bool) string {
+	if len(contentByColumn) == 0 {
+		return ""
+	}
+	maxCols := 4
+	if padded && len(contentByColumn)%maxCols != 0 {
+		missing := maxCols - len(contentByColumn)%maxCols
+		contentByColumn = append(contentByColumn, make([]string, missing)...)
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<gno-columns>\n")
+
+	for i, column := range contentByColumn {
+		if i > 0 {
+			sb.WriteString("<gno-columns-sep>\n")
+		}
+		sb.WriteString(column + "\n")
+	}
+
+	sb.WriteString("</gno-columns>\n")
+	return sb.String()
+}
+
+const maxColumnsPerRow = 4
+
+// ColumnsN splits content into multiple rows of N columns each and formats them.
+// If colsPerRow <= 0, all items are placed in one <gno-columns> block.
+// If padded=true & the final <gno-columns> tag is missing column content, an empty
+// column element will be placed to keep the cols per row constant.
+// Padding works only with colsPerRow > 0.
+// Note: On standard-size screens, gnoweb handles a max of 4 cols per row.
+//
+// Example:
+//
+//	ColumnsN([]string{"A", "B", "C"}, 2, false)
+//	// Returns:
+//	// <gno-columns>
+//	// A
+//	// <gno-columns-sep>
+//	// B
+//	// </gno-columns>
+//	// <gno-columns>
+//	// C
+//	// </gno-columns>
+func ColumnsN(content []string, colsPerRow int, padded bool) string {
+	if len(content) == 0 {
+		return ""
+	}
+	if colsPerRow <= 0 {
+		return Columns(content, padded)
+	}
+
+	var sb strings.Builder
+	// Case 2: Multiple blocks with max 4 columns
+	for i := 0; i < len(content); i += colsPerRow {
+		end := i + colsPerRow
+		if end > len(content) {
+			end = len(content)
+		}
+		row := content[i:end]
+
+		// Add padding if needed
+		if padded && len(row) < colsPerRow {
+			row = append(row, make([]string, colsPerRow-len(row))...)
+		}
+
+		sb.WriteString(Columns(row, false))
+	}
+	return sb.String()
+}

--- a/vendored/gno.land/p/moul/md/md_test.gno
+++ b/vendored/gno.land/p/moul/md/md_test.gno
@@ -1,0 +1,374 @@
+package md_test
+
+import (
+	"testing"
+
+	"gno.land/p/moul/md"
+)
+
+func TestHelpers(t *testing.T) {
+	tests := []struct {
+		name     string
+		function func() string
+		expected string
+	}{
+		{"Bold", func() string { return md.Bold("foo") }, "**foo**"},
+		{"Italic", func() string { return md.Italic("foo") }, "*foo*"},
+		{"Strikethrough", func() string { return md.Strikethrough("foo") }, "~~foo~~"},
+		{"H1", func() string { return md.H1("foo") }, "# foo\n"},
+		{"HorizontalRule", md.HorizontalRule, "---\n"},
+		{"InlineCode", func() string { return md.InlineCode("foo") }, "`foo`"},
+		{"CodeBlock", func() string { return md.CodeBlock("foo") }, "```\nfoo\n```\n"},
+		{"LanguageCodeBlock", func() string { return md.LanguageCodeBlock("go", "foo") }, "```go\nfoo\n```\n"},
+		{"Link", func() string { return md.Link("foo", "http://example.com") }, "[foo](http://example.com)"},
+		{"UserLink", func() string { return md.UserLink("moul") }, "[@moul](/u/moul)"},
+		{"Image", func() string { return md.Image("foo", "http://example.com") }, "![foo](http://example.com)"},
+		{"InlineImageWithLink", func() string {
+			return md.InlineImageWithLink("alt", "http://img.example.com/x.png", "http://link.example.com")
+		}, "[![alt](http://img.example.com/x.png)](http://link.example.com)"},
+		{"FootnoteDefinition", func() string { return md.FootnoteDefinition("foo", "bar") }, "[^foo]:\n    bar\n"},
+		{"LinkReferenceDefinition", func() string {
+			return md.LinkReferenceDefinition("foo", "http://example.com", "")
+		}, "\n\n[foo]: http://example.com\n\n"},
+		{"Paragraph", func() string { return md.Paragraph("foo") }, "foo\n\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.function()
+			if result != tt.expected {
+				t.Errorf("%s() = %q, want %q", tt.name, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestLists(t *testing.T) {
+	t.Run("BulletList", func(t *testing.T) {
+		items := []string{"foo", "bar"}
+		expected := "- foo\n- bar\n"
+		result := md.BulletList(items)
+		if result != expected {
+			t.Errorf("BulletList(%q) = %q, want %q", items, result, expected)
+		}
+	})
+
+	t.Run("OrderedList", func(t *testing.T) {
+		items := []string{"foo", "bar"}
+		expected := "1. foo\n2. bar\n"
+		result := md.OrderedList(items)
+		if result != expected {
+			t.Errorf("OrderedList(%q) = %q, want %q", items, result, expected)
+		}
+	})
+
+	t.Run("TodoList", func(t *testing.T) {
+		items := []string{"foo", "bar\nmore bar"}
+		done := []bool{true, false}
+		expected := "- [x] foo\n- [ ] bar\n  more bar\n"
+		result := md.TodoList(items, done)
+		if result != expected {
+			t.Errorf("TodoList(%q, %q) = %q, want %q", items, done, result, expected)
+		}
+	})
+}
+
+func TestUserLink(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"username", "moul", "[@moul](/u/moul)"},
+		// "g1blah" data part is too short for a bech32 address (min 6
+		// chars after "1"); UserLink validates as a username instead.
+		{"short g1-prefixed string treated as username", "g1blah", "[@g1blah](/u/g1blah)"},
+		// "user_name" is a valid username (charset includes _ and -);
+		// the validator returns it verbatim, so no markdown escape of _.
+		{"username with underscore", "user_name", "[@user_name](/u/user_name)"},
+		// "g1abc123" has a 6-char data part — valid bech32 shape.
+		{"address with 6-char data", "g1abc123", "[g1abc123](/u/g1abc123)"},
+		// invalid identifier (spaces, uppercase, etc.) → empty.
+		{"rejected: spaces", "hello world", ""},
+		{"rejected: uppercase first char", "Alice", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := md.UserLink(tt.input)
+			if result != tt.expected {
+				t.Errorf("UserLink(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNested(t *testing.T) {
+	t.Run("Nested Single Level", func(t *testing.T) {
+		content := "- foo\n- bar"
+		expected := "  - foo\n  - bar"
+		result := md.Nested(content, "  ")
+		if result != expected {
+			t.Errorf("Nested(%q) = %q, want %q", content, result, expected)
+		}
+	})
+
+	t.Run("Nested Double Level", func(t *testing.T) {
+		content := "  - foo\n  - bar"
+		expected := "    - foo\n    - bar"
+		result := md.Nested(content, "  ")
+		if result != expected {
+			t.Errorf("Nested(%q) = %q, want %q", content, result, expected)
+		}
+	})
+}
+
+func TestColumns(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		padded   bool
+		expected string
+	}{
+		{
+			name:     "no columns",
+			input:    []string{},
+			padded:   false,
+			expected: "",
+		},
+		{
+			name:     "no columns padded",
+			input:    []string{},
+			padded:   true,
+			expected: "",
+		},
+		{
+			name:   "one column",
+			input:  []string{"Column 1"},
+			padded: false,
+			expected: `<gno-columns>
+Column 1
+</gno-columns>
+`,
+		},
+		{
+			name:   "one column padded",
+			input:  []string{"Column 1"},
+			padded: true,
+			expected: `<gno-columns>
+Column 1
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+</gno-columns>
+`,
+		},
+		{
+			name:   "two columns",
+			input:  []string{"Column 1", "Column 2"},
+			padded: false,
+			expected: `<gno-columns>
+Column 1
+<gno-columns-sep>
+Column 2
+</gno-columns>
+`,
+		},
+		{
+			name:   "two columns padded",
+			input:  []string{"Column 1", "Column 2"},
+			padded: true,
+			expected: `<gno-columns>
+Column 1
+<gno-columns-sep>
+Column 2
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+</gno-columns>
+`,
+		},
+		{
+			name:   "four columns",
+			input:  []string{"A", "B", "C", "D"},
+			padded: false,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+<gno-columns-sep>
+C
+<gno-columns-sep>
+D
+</gno-columns>
+`,
+		},
+		{
+			name:   "four columns padded",
+			input:  []string{"A", "B", "C", "D"},
+			padded: true,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+<gno-columns-sep>
+C
+<gno-columns-sep>
+D
+</gno-columns>
+`,
+		},
+		{
+			name:   "more than four columns",
+			input:  []string{"1", "2", "3", "4", "5"},
+			padded: false,
+			expected: `<gno-columns>
+1
+<gno-columns-sep>
+2
+<gno-columns-sep>
+3
+<gno-columns-sep>
+4
+<gno-columns-sep>
+5
+</gno-columns>
+`,
+		},
+		{
+			name:   "more than four columns padded",
+			input:  []string{"1", "2", "3", "4", "5"},
+			padded: true,
+			expected: `<gno-columns>
+1
+<gno-columns-sep>
+2
+<gno-columns-sep>
+3
+<gno-columns-sep>
+4
+<gno-columns-sep>
+5
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+</gno-columns>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := md.Columns(tt.input, tt.padded)
+			if result != tt.expected {
+				t.Errorf("Columns(%v, %v) =\n%q\nwant:\n%q", tt.input, tt.padded, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestColumnsN(t *testing.T) {
+	tests := []struct {
+		name       string
+		content    []string
+		colsPerRow int
+		padded     bool
+		expected   string
+	}{
+		{
+			name:       "empty input",
+			content:    []string{},
+			colsPerRow: 2,
+			padded:     false,
+			expected:   "",
+		},
+		{
+			name:       "colsPerRow <= 0",
+			content:    []string{"A", "B", "C"},
+			colsPerRow: 0,
+			padded:     false,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+<gno-columns-sep>
+C
+</gno-columns>
+`,
+		},
+		{
+			name:       "exact full row, no padding",
+			content:    []string{"A", "B"},
+			colsPerRow: 2,
+			padded:     false,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+</gno-columns>
+`,
+		},
+		{
+			name:       "partial last row, no padding",
+			content:    []string{"A", "B", "C"},
+			colsPerRow: 2,
+			padded:     false,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+</gno-columns>
+<gno-columns>
+C
+</gno-columns>
+`,
+		},
+		{
+			name:       "partial last row, with padding",
+			content:    []string{"A", "B", "C"},
+			colsPerRow: 2,
+			padded:     true,
+			expected: `<gno-columns>
+A
+<gno-columns-sep>
+B
+</gno-columns>
+<gno-columns>
+C
+<gno-columns-sep>
+
+</gno-columns>
+`,
+		},
+		{
+			name:       "padded with more empty cells",
+			content:    []string{"X"},
+			colsPerRow: 3,
+			padded:     true,
+			expected: `<gno-columns>
+X
+<gno-columns-sep>
+
+<gno-columns-sep>
+
+</gno-columns>
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := md.ColumnsN(tt.content, tt.colsPerRow, tt.padded)
+			if result != tt.expected {
+				t.Errorf("ColumnsN(%v, %d, %v) =\n%q\nwant:\n%q", tt.content, tt.colsPerRow, tt.padded, result, tt.expected)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/moul/txlink/gnomod.toml
+++ b/vendored/gno.land/p/moul/txlink/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/moul/txlink"
+gno = "0.9"
+
+[addpkg]
+  creator = "g1manfred47kzduec920z88wfr64ylksmdcedlf5"

--- a/vendored/gno.land/p/moul/txlink/txlink.gno
+++ b/vendored/gno.land/p/moul/txlink/txlink.gno
@@ -1,0 +1,171 @@
+// Package txlink provides utilities for creating transaction-related links
+// compatible with Gnoweb, Gnobro, and other clients within the Gno ecosystem.
+//
+// This package is optimized for generating lightweight transaction links with
+// flexible arguments, allowing users to build dynamic links that integrate
+// seamlessly with various Gno clients.
+//
+// The package offers a way to generate clickable transaction MD links
+// for the current "relative realm":
+//
+//  Using a builder pattern for more structured URLs:
+//     txlink.NewLink("MyFunc").
+//         AddArgs("k1", "v1", "k2", "v2"). // or multiple at once
+//         SetSend("1000000ugnot").
+//         URL()
+//
+// The builder pattern (TxBuilder) provides a fluent interface for constructing
+// transaction URLs in the current "relative realm". Like Call, it supports both
+// local realm paths and fully qualified paths through the underlying Call
+// implementation.
+//
+// The Call function remains the core implementation, used both directly and
+// internally by the builder pattern to generate the final URLs.
+//
+// This package is a streamlined alternative to helplink, providing similar
+// functionality for transaction links without the full feature set of helplink.
+
+package txlink
+
+import (
+	"chain/runtime"
+	"chain/runtime/unsafe"
+	"net/url"
+	"strings"
+)
+
+var chainDomain = runtime.ChainDomain()
+
+// Realm represents a specific realm for generating tx links.
+type Realm string
+
+// TxBuilder provides a fluent interface for building transaction URLs
+type TxBuilder struct {
+	fn        string   // function name
+	args      []string // key-value pairs
+	send      string   // optional send amount
+	realm_XXX Realm    // realm for the URL
+}
+
+// NewLink creates a transaction link builder for the specified function in the current realm.
+func NewLink(fn string) *TxBuilder {
+	return Realm("").NewLink(fn)
+}
+
+// NewLink creates a transaction link builder for the specified function in this realm.
+func (r Realm) NewLink(fn string) *TxBuilder {
+	if fn == "" {
+		return nil
+	}
+	return &TxBuilder{fn: fn, realm_XXX: r}
+}
+
+// addArg adds a key-value argument pair. Returns the builder for chaining.
+func (b *TxBuilder) addArg(key, value string) *TxBuilder {
+	if b == nil {
+		return nil
+	}
+	if key == "" {
+		return b
+	}
+
+	// Special case: "." prefix is for reserved keywords.
+	if strings.HasPrefix(key, ".") {
+		panic("invalid key")
+	}
+
+	b.args = append(b.args, key, value)
+	return b
+}
+
+// AddArgs adds multiple key-value pairs at once. Arguments should be provided
+// as pairs: AddArgs("key1", "value1", "key2", "value2").
+func (b *TxBuilder) AddArgs(args ...string) *TxBuilder {
+	if b == nil {
+		return nil
+	}
+	if len(args)%2 != 0 {
+		panic("odd number of arguments")
+	}
+	// Add key-value pairs
+	for i := 0; i < len(args); i += 2 {
+		key := args[i]
+		value := args[i+1]
+		b.addArg(key, value)
+	}
+	return b
+}
+
+// SetSend adds a send amount. (Only one send amount can be specified.)
+func (b *TxBuilder) SetSend(amount string) *TxBuilder {
+	if b == nil {
+		return nil
+	}
+	if amount == "" {
+		return b
+	}
+	b.send = amount
+	return b
+}
+
+// URL generates the final URL using the standard $help&func=name format.
+func (b *TxBuilder) URL() string {
+	if b == nil || b.fn == "" {
+		return ""
+	}
+	args := b.args
+	if b.send != "" {
+		args = append(args, ".send", b.send)
+	}
+	return b.realm_XXX.Call(b.fn, args...)
+}
+
+// Call returns a URL for the specified function with optional key-value
+// arguments, for the current realm.
+func Call(fn string, args ...string) string {
+	return Realm("").Call(fn, args...)
+}
+
+// prefix returns the URL prefix for the realm.
+func (r Realm) prefix() string {
+	// relative
+	if r == "" {
+		curPath := unsafe.CurrentRealm().PkgPath()
+		return strings.TrimPrefix(curPath, chainDomain)
+	}
+
+	// local realm -> /realm
+	rlm := string(r)
+	if strings.HasPrefix(rlm, chainDomain) {
+		return strings.TrimPrefix(rlm, chainDomain)
+	}
+
+	// remote realm -> https://remote.land/realm
+	return "https://" + string(r)
+}
+
+// Call returns a URL for the specified function with optional key-value
+// arguments.
+func (r Realm) Call(fn string, args ...string) string {
+	if len(args) == 0 {
+		return r.prefix() + "$help&func=" + fn
+	}
+
+	// Create url.Values to properly encode parameters.
+	// But manage &func=fn as a special case to keep it as the first argument.
+	values := url.Values{}
+
+	// Check if args length is even
+	if len(args)%2 != 0 {
+		panic("odd number of arguments")
+	}
+	// Add key-value pairs to values
+	for i := 0; i < len(args); i += 2 {
+		key := args[i]
+		value := args[i+1]
+		values.Add(key, value)
+	}
+
+	// Build the base URL and append encoded query parameters
+	return r.prefix() + "$help&func=" + fn + "&" + values.Encode()
+}

--- a/vendored/gno.land/p/moul/txlink/txlink_test.gno
+++ b/vendored/gno.land/p/moul/txlink/txlink_test.gno
@@ -1,0 +1,244 @@
+package txlink
+
+import (
+	"chain/runtime"
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+func TestCall(t *testing.T) {
+	cd := runtime.ChainDomain()
+
+	tests := []struct {
+		fn        string
+		args      []string
+		want      string
+		realm_XXX Realm
+	}{
+		{"foo", []string{"bar", "1", "baz", "2"}, "/p/moul/txlink$help&func=foo&bar=1&baz=2", ""},
+		{"testFunc", []string{"key", "value"}, "/p/moul/txlink$help&func=testFunc&key=value", ""},
+		{"noArgsFunc", []string{}, "/p/moul/txlink$help&func=noArgsFunc", ""},
+		{"oddArgsFunc", []string{"key"}, "/p/moul/txlink$help&func=oddArgsFunc&error=odd+number+of+arguments", ""},
+		{"foo", []string{"bar", "1", "baz", "2"}, "/r/lorem/ipsum$help&func=foo&bar=1&baz=2", Realm(cd + "/r/lorem/ipsum")},
+		{"testFunc", []string{"key", "value"}, "/r/lorem/ipsum$help&func=testFunc&key=value", Realm(cd + "/r/lorem/ipsum")},
+		{"noArgsFunc", []string{}, "/r/lorem/ipsum$help&func=noArgsFunc", Realm(cd + "/r/lorem/ipsum")},
+		{"oddArgsFunc", []string{"key"}, "/r/lorem/ipsum$help&func=oddArgsFunc&error=odd+number+of+arguments", Realm(cd + "/r/lorem/ipsum")},
+		{"foo", []string{"bar", "1", "baz", "2"}, "https://gno.world/r/lorem/ipsum$help&func=foo&bar=1&baz=2", "gno.world/r/lorem/ipsum"},
+		{"testFunc", []string{"key", "value"}, "https://gno.world/r/lorem/ipsum$help&func=testFunc&key=value", "gno.world/r/lorem/ipsum"},
+		{"noArgsFunc", []string{}, "https://gno.world/r/lorem/ipsum$help&func=noArgsFunc", "gno.world/r/lorem/ipsum"},
+		{"oddArgsFunc", []string{"key"}, "https://gno.world/r/lorem/ipsum$help&func=oddArgsFunc&error=odd+number+of+arguments", "gno.world/r/lorem/ipsum"},
+		{"test", []string{"key", "hello world"}, "/p/moul/txlink$help&func=test&key=hello+world", ""},
+		{"test", []string{"key", "a&b=c"}, "/p/moul/txlink$help&func=test&key=a%26b%3Dc", ""},
+		{"test", []string{"key", ""}, "/p/moul/txlink$help&func=test&key=", ""},
+		{"testSend", []string{"key", "hello world", ".send", "1000000ugnot"}, "/p/moul/txlink$help&func=testSend&.send=1000000ugnot&key=hello+world", ""},
+	}
+
+	for _, tt := range tests {
+		title := string(tt.realm_XXX) + "_" + tt.fn
+		t.Run(title, func(t *testing.T) {
+			if tt.fn == "oddArgsFunc" {
+				defer func() {
+					if r := recover(); r != nil {
+						if r != "odd number of arguments" {
+							t.Errorf("expected panic with message 'odd number of arguments', got: %v", r)
+						}
+					} else {
+						t.Error("expected panic for odd number of arguments, but did not panic")
+					}
+				}()
+			}
+			got := tt.realm_XXX.Call(tt.fn, tt.args...)
+			urequire.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBuilder(t *testing.T) {
+	cases := []struct {
+		name     string
+		build    func() string
+		expected string
+	}{
+		// Basic functionality tests
+		{
+			name: "empty_function",
+			build: func() string {
+				return NewLink("").URL()
+			},
+			expected: "",
+		},
+		{
+			name: "function_without_args",
+			build: func() string {
+				return NewLink("MyFunc").URL()
+			},
+			expected: "/p/moul/txlink$help&func=MyFunc",
+		},
+
+		// Realm tests
+		{
+			name: "gnoland_realm",
+			build: func() string {
+				return Realm("gno.land/r/demo").
+					NewLink("MyFunc").
+					AddArgs("key", "value").
+					URL()
+			},
+			expected: "/r/demo$help&func=MyFunc&key=value",
+		},
+		{
+			name: "external_realm",
+			build: func() string {
+				return Realm("gno.world/r/demo").
+					NewLink("MyFunc").
+					AddArgs("key", "value").
+					URL()
+			},
+			expected: "https://gno.world/r/demo$help&func=MyFunc&key=value",
+		},
+		{
+			name: "empty_realm",
+			build: func() string {
+				return Realm("").
+					NewLink("func").
+					AddArgs("key", "value").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=func&key=value",
+		},
+
+		// URL encoding tests
+		{
+			name: "url_encoding_with_spaces",
+			build: func() string {
+				return NewLink("test").
+					AddArgs("key", "hello world").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=test&key=hello+world",
+		},
+		{
+			name: "url_encoding_with_special_chars",
+			build: func() string {
+				return NewLink("test").
+					AddArgs("key", "a&b=c").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=test&key=a%26b%3Dc",
+		},
+		{
+			name: "url_encoding_with_unicode",
+			build: func() string {
+				return NewLink("func").
+					AddArgs("key", "🌟").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=func&key=%F0%9F%8C%9F",
+		},
+		{
+			name: "url_encoding_with_special_chars_in_key",
+			build: func() string {
+				return NewLink("func").
+					AddArgs("my/key", "value").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=func&my%2Fkey=value",
+		},
+
+		// AddArgs tests
+		{
+			name: "addargs_with_multiple_pairs",
+			build: func() string {
+				return NewLink("MyFunc").
+					AddArgs("key1", "value1", "key2", "value2").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=MyFunc&key1=value1&key2=value2",
+		},
+		{
+			name: "addargs_with_odd_number_of_args",
+			build: func() string {
+				defer func() {
+					if r := recover(); r != nil {
+						if r != "odd number of arguments" {
+							t.Errorf("expected panic with message 'odd number of arguments', got: %v", r)
+						}
+					} else {
+						t.Error("expected panic for odd number of arguments, but did not panic")
+					}
+				}()
+				return NewLink("MyFunc").
+					AddArgs("key1", "value1", "orphan").
+					URL()
+			},
+			expected: "",
+		},
+
+		// Empty values tests
+		{
+			name: "empty_key_should_be_ignored",
+			build: func() string {
+				return NewLink("func").
+					AddArgs("", "value").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=func",
+		},
+		{
+			name: "empty_value_should_be_kept",
+			build: func() string {
+				return NewLink("func").
+					AddArgs("key", "").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=func&key=",
+		},
+
+		// Send tests
+		{
+			name: "send_via_addsend_method",
+			build: func() string {
+				return NewLink("MyFunc").
+					AddArgs("key", "value").
+					SetSend("1000000ugnot").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=MyFunc&.send=1000000ugnot&key=value",
+		},
+		{
+			name: "send_via_addarg_method_panic",
+			build: func() string {
+				defer func() {
+					if r := recover(); r != nil {
+						if r != "invalid key" {
+							t.Errorf("expected panic with message 'invalid key', got: %v", r)
+						}
+					} else {
+						t.Errorf("expected panic for .send key, but did not panic")
+					}
+				}()
+				NewLink("MyFunc").AddArgs(".send", "1000000ugnot")
+				return "no panic occurred"
+			},
+			expected: "",
+		},
+		{
+			name: "addsend_should_override_previous_addsend",
+			build: func() string {
+				return NewLink("MyFunc").
+					SetSend("1000000ugnot").
+					SetSend("2000000ugnot").
+					URL()
+			},
+			expected: "/p/moul/txlink$help&func=MyFunc&.send=2000000ugnot",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.build()
+			urequire.Equal(t, tc.expected, got)
+		})
+	}
+}

--- a/vendored/gno.land/p/nt/avl/v0/README.md
+++ b/vendored/gno.land/p/nt/avl/v0/README.md
@@ -1,0 +1,87 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+
+# AVL Tree Package
+
+The `avl` package provides a gas-efficient AVL tree implementation for storing key-value data in Gno realms.
+
+## Basic Usage
+
+```go
+package myrealm
+
+import "gno.land/p/nt/avl/v0"
+
+// This AVL tree will be persisted after transaction calls
+var tree *avl.Tree
+
+func Set(key string, value int) {
+	// tree.Set takes in a string key, and a value that can be of any type
+	tree.Set(key, value)
+}
+
+func Get(key string) int {
+	// tree.Get returns the value at given key in its raw form,
+	// and a bool to signify the existence of the key-value pair
+	rawValue, exists := tree.Get(key)
+	if !exists {
+		panic("value at given key does not exist")
+	}
+
+	// rawValue needs to be converted into the proper type before returning it
+	return rawValue.(int)
+}
+```
+
+## Storage Architecture: AVL Tree vs Map
+
+In Gno, the choice between `avl.Tree` and `map` is fundamentally about how data is persisted in storage.
+
+**Maps** are stored as a single, monolithic object. When you access *any* value in a map, Gno must load the *entire* map into memory. For a map with 1,000 entries, accessing one value means loading all 1,000 entries.
+
+**AVL trees** store each node as a separate object. When you access a value, Gno only loads the nodes along the search path (typically log2(n) nodes). For a tree with 1,000 entries, accessing one value loads ~10 nodes; but a tree with 1,000,000 entries only needs to load ~20 nodes.
+
+## Storage Comparison Example
+
+Consider a realm with 1,000 key-value pairs. Here's what happens when you access a single value:
+
+**Map storage:**
+
+```
+Object :4 = map{
+  ("0" string):("123" string),
+  ("1" string):("123" string),
+  ...
+  ("999" string):("123" string)
+}
+```
+- Accessing `map["100"]` loads object `:4` (contains **all 1,000 pairs**)
+- Gas cost is proportional to total map size (1,000 entries)
+- **1 object fetch, but massive data load**
+
+**AVL tree storage:**
+
+```
+Object :6 = Node{key="4", height=10, size=1000, left=:7, right=...}
+Object :9 = Node{key="2", height=9, size=334, left=:10, right=...}
+Object :11 = Node{key="14", height=8, size=112, left=:12, right=...}
+Object :13 = Node{key="12", height=6, size=46, left=:14, right=...}
+Object :15 = Node{key="11", height=5, size=24, left=:16, right=...}
+Object :17 = Node{key="102", height=4, size=13, left=:18, right=...}
+Object :19 = Node{key="100", height=3, size=5, left=:30, right=...}
+Object :31 = Node{key="101", height=1, size=2, left=:32, right=...}
+Object :33 = Node{key="100", value="123", height=0, size=1}
+```
+- Accessing `tree.Get("100")` loads ~10 objects (the search path)
+- Gas cost is proportional to log2(n) ≈ 10 nodes
+- **10 object fetches, each containing only a single node**
+
+## Further Reading
+
+- [Why should you use an AVL tree instead of a map?](https://howl.moe/posts/2024-09-19-gno-avl-over-maps/) - Howl detailed analysis
+- [Berty's AVL scalability report](https://github.com/gnolang/hackerspace/issues/67) - Real-world testing with up to 20M entries
+- [Wikipedia - AVL tree](https://en.wikipedia.org/wiki/AVL_tree) - Algorithm details and balancing
+- [Effective Gno](https://docs.gno.land/resources/effective-gno#prefer-avltree-over-map-for-scalable-storage) - High-level usage guidance

--- a/vendored/gno.land/p/nt/avl/v0/doc.gno
+++ b/vendored/gno.land/p/nt/avl/v0/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package avl provides a gas-efficient AVL tree implementation for storing
+// key-value data in Gno realms.
+package avl

--- a/vendored/gno.land/p/nt/avl/v0/filetests/z_0_filetest.gno
+++ b/vendored/gno.land/p/nt/avl/v0/filetests/z_0_filetest.gno
@@ -1,0 +1,23 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/nt/avl/v0"
+)
+
+var node *avl.Node
+
+func init() {
+	node = avl.NewNode("key0", "value0")
+	// node, _ = node.Set("key0", "value0")
+}
+
+func main(cur realm) {
+	var updated bool
+	node, updated = node.Set("key1", "value1")
+	// println(node, updated)
+	println(updated, node.Size())
+}
+
+// Output:
+// false 2

--- a/vendored/gno.land/p/nt/avl/v0/filetests/z_1_filetest.gno
+++ b/vendored/gno.land/p/nt/avl/v0/filetests/z_1_filetest.gno
@@ -1,0 +1,23 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/nt/avl/v0"
+)
+
+var node *avl.Node
+
+func init() {
+	node = avl.NewNode("key0", "value0")
+	node, _ = node.Set("key1", "value1")
+}
+
+func main(cur realm) {
+	var updated bool
+	node, updated = node.Set("key2", "value2")
+	// println(node, updated)
+	println(updated, node.Size())
+}
+
+// Output:
+// false 3

--- a/vendored/gno.land/p/nt/avl/v0/filetests/z_2_filetest.gno
+++ b/vendored/gno.land/p/nt/avl/v0/filetests/z_2_filetest.gno
@@ -1,0 +1,22 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/nt/avl/v0"
+)
+
+var tree avl.Tree
+
+func init() {
+	tree.Set("key0", "value0")
+	tree.Set("key1", "value1")
+}
+
+func main(cur realm) {
+	var updated bool
+	updated = tree.Set("key2", "value2")
+	println(updated, tree.Size())
+}
+
+// Output:
+// false 3

--- a/vendored/gno.land/p/nt/avl/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/avl/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/avl/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/avl/v0/node.gno
+++ b/vendored/gno.land/p/nt/avl/v0/node.gno
@@ -1,0 +1,482 @@
+package avl
+
+//----------------------------------------
+// Node
+
+// Node represents a node in an AVL tree.
+type Node struct {
+	key       string // key is the unique identifier for the node.
+	value     any    // value is the data stored in the node.
+	height    int8   // height is the height of the node in the tree.
+	size      int    // size is the number of leaf nodes (key-value pairs) in the subtree rooted at this node.
+	leftNode  *Node  // leftNode is the left child of the node.
+	rightNode *Node  // rightNode is the right child of the node.
+}
+
+// NewNode creates a new node with the given key and value.
+func NewNode(key string, value any) *Node {
+	return &Node{
+		key:    key,
+		value:  value,
+		height: 0,
+		size:   1,
+	}
+}
+
+// Size returns the size of the subtree rooted at the node.
+func (node *Node) Size() int {
+	if node == nil {
+		return 0
+	}
+	return node.size
+}
+
+// IsLeaf checks if the node is a leaf node (has no children).
+func (node *Node) IsLeaf() bool {
+	return node.height == 0
+}
+
+// Key returns the key of the node.
+func (node *Node) Key() string {
+	return node.key
+}
+
+// Value returns the value of the node.
+func (node *Node) Value() any {
+	return node.value
+}
+
+func (node *Node) _copy() *Node {
+	if node.height == 0 {
+		panic("Why are you copying a value node?")
+	}
+	return &Node{
+		key:       node.key,
+		height:    node.height,
+		size:      node.size,
+		leftNode:  node.leftNode,
+		rightNode: node.rightNode,
+	}
+}
+
+// Has checks if a node with the given key exists in the subtree rooted at the node.
+func (node *Node) Has(key string) (has bool) {
+	if node == nil {
+		return false
+	}
+	if node.key == key {
+		return true
+	}
+	if node.height == 0 {
+		return false
+	} else {
+		if key < node.key {
+			return node.getLeftNode().Has(key)
+		} else {
+			return node.getRightNode().Has(key)
+		}
+	}
+}
+
+// Get searches for a node with the given key in the subtree rooted at the node
+// and returns its index, value, and whether it exists.
+func (node *Node) Get(key string) (index int, value any, exists bool) {
+	if node == nil {
+		return 0, nil, false
+	}
+
+	if node.height == 0 {
+		if node.key == key {
+			return 0, node.value, true
+		} else if node.key < key {
+			return 1, nil, false
+		} else {
+			return 0, nil, false
+		}
+	} else {
+		if key < node.key {
+			return node.getLeftNode().Get(key)
+		} else {
+			rightNode := node.getRightNode()
+			index, value, exists = rightNode.Get(key)
+			index += node.size - rightNode.size
+			return index, value, exists
+		}
+	}
+}
+
+// GetByIndex retrieves the key-value pair of the node at the given index
+// in the subtree rooted at the node.
+func (node *Node) GetByIndex(index int) (key string, value any) {
+	if node.height == 0 {
+		if index == 0 {
+			return node.key, node.value
+		} else {
+			panic("GetByIndex asked for invalid index")
+		}
+	} else {
+		// TODO: could improve this by storing the sizes
+		leftNode := node.getLeftNode()
+		if index < leftNode.size {
+			return leftNode.GetByIndex(index)
+		} else {
+			return node.getRightNode().GetByIndex(index - leftNode.size)
+		}
+	}
+}
+
+// Set inserts a new node with the given key-value pair into the subtree rooted at the node,
+// and returns the new root of the subtree and whether an existing node was updated.
+//
+// XXX consider a better way to do this... perhaps split Node from Node.
+func (node *Node) Set(key string, value any) (newSelf *Node, updated bool) {
+	if node == nil {
+		return NewNode(key, value), false
+	}
+	if node.height == 0 {
+		if key < node.key {
+			return &Node{
+				key:       node.key,
+				height:    1,
+				size:      2,
+				leftNode:  NewNode(key, value),
+				rightNode: node,
+			}, false
+		} else if key == node.key {
+			return NewNode(key, value), true
+		} else {
+			return &Node{
+				key:       key,
+				height:    1,
+				size:      2,
+				leftNode:  node,
+				rightNode: NewNode(key, value),
+			}, false
+		}
+	} else {
+		node = node._copy()
+		if key < node.key {
+			node.leftNode, updated = node.getLeftNode().Set(key, value)
+		} else {
+			node.rightNode, updated = node.getRightNode().Set(key, value)
+		}
+		if updated {
+			return node, updated
+		} else {
+			node.calcHeightAndSize()
+			return node.balance(), updated
+		}
+	}
+}
+
+// Remove deletes the node with the given key from the subtree rooted at the node.
+// returns the new root of the subtree, the new leftmost leaf key (if changed),
+// the removed value and the removal was successful.
+func (node *Node) Remove(key string) (
+	newNode *Node, newKey string, value any, removed bool,
+) {
+	if node == nil {
+		return nil, "", nil, false
+	}
+	if node.height == 0 {
+		if key == node.key {
+			return nil, "", node.value, true
+		} else {
+			return node, "", nil, false
+		}
+	} else {
+		if key < node.key {
+			var newLeftNode *Node
+			newLeftNode, newKey, value, removed = node.getLeftNode().Remove(key)
+			if !removed {
+				return node, "", value, false
+			} else if newLeftNode == nil { // left node held value, was removed
+				return node.rightNode, node.key, value, true
+			}
+			node = node._copy()
+			node.leftNode = newLeftNode
+			node.calcHeightAndSize()
+			node = node.balance()
+			return node, newKey, value, true
+		} else {
+			var newRightNode *Node
+			newRightNode, newKey, value, removed = node.getRightNode().Remove(key)
+			if !removed {
+				return node, "", value, false
+			} else if newRightNode == nil { // right node held value, was removed
+				return node.leftNode, "", value, true
+			}
+			node = node._copy()
+			node.rightNode = newRightNode
+			if newKey != "" {
+				node.key = newKey
+			}
+			node.calcHeightAndSize()
+			node = node.balance()
+			return node, "", value, true
+		}
+	}
+}
+
+func (node *Node) getLeftNode() *Node {
+	return node.leftNode
+}
+
+func (node *Node) getRightNode() *Node {
+	return node.rightNode
+}
+
+// rotateRight performs a right rotation on the node and returns the new root.
+// NOTE: overwrites node
+// TODO: optimize balance & rotate
+func (node *Node) rotateRight() *Node {
+	node = node._copy()
+	l := node.getLeftNode()
+	_l := l._copy()
+
+	_lrCached := _l.rightNode
+	_l.rightNode = node
+	node.leftNode = _lrCached
+
+	node.calcHeightAndSize()
+	_l.calcHeightAndSize()
+
+	return _l
+}
+
+// rotateLeft performs a left rotation on the node and returns the new root.
+// NOTE: overwrites node
+// TODO: optimize balance & rotate
+func (node *Node) rotateLeft() *Node {
+	node = node._copy()
+	r := node.getRightNode()
+	_r := r._copy()
+
+	_rlCached := _r.leftNode
+	_r.leftNode = node
+	node.rightNode = _rlCached
+
+	node.calcHeightAndSize()
+	_r.calcHeightAndSize()
+
+	return _r
+}
+
+// calcHeightAndSize updates the height and size of the node based on its children.
+// NOTE: mutates height and size
+func (node *Node) calcHeightAndSize() {
+	node.height = maxInt8(node.getLeftNode().height, node.getRightNode().height) + 1
+	node.size = node.getLeftNode().size + node.getRightNode().size
+}
+
+// calcBalance calculates the balance factor of the node.
+func (node *Node) calcBalance() int {
+	return int(node.getLeftNode().height) - int(node.getRightNode().height)
+}
+
+// balance balances the subtree rooted at the node and returns the new root.
+// NOTE: assumes that node can be modified
+// TODO: optimize balance & rotate
+func (node *Node) balance() (newSelf *Node) {
+	balance := node.calcBalance()
+	if balance > 1 {
+		if node.getLeftNode().calcBalance() >= 0 {
+			// Left Left Case
+			return node.rotateRight()
+		} else {
+			// Left Right Case
+			left := node.getLeftNode()
+			node.leftNode = left.rotateLeft()
+			return node.rotateRight()
+		}
+	}
+	if balance < -1 {
+		if node.getRightNode().calcBalance() <= 0 {
+			// Right Right Case
+			return node.rotateLeft()
+		} else {
+			// Right Left Case
+			right := node.getRightNode()
+			node.rightNode = right.rotateRight()
+			return node.rotateLeft()
+		}
+	}
+	// Nothing changed
+	return node
+}
+
+// Shortcut for TraverseInRange.
+func (node *Node) Iterate(start, end string, cb func(*Node) bool) bool {
+	return node.TraverseInRange(start, end, true, true, cb)
+}
+
+// Shortcut for TraverseInRange.
+func (node *Node) ReverseIterate(start, end string, cb func(*Node) bool) bool {
+	return node.TraverseInRange(start, end, false, true, cb)
+}
+
+// TraverseInRange traverses all nodes, including inner nodes.
+// Start is inclusive and end is exclusive when ascending,
+// Start and end are inclusive when descending.
+// Empty start and empty end denote no start and no end.
+// If leavesOnly is true, only visit leaf nodes.
+// NOTE: To simulate an exclusive reverse traversal,
+// just append 0x00 to start.
+func (node *Node) TraverseInRange(start, end string, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	if node == nil {
+		return false
+	}
+	afterStart := (start == "" || start < node.key)
+	startOrAfter := (start == "" || start <= node.key)
+	beforeEnd := false
+	if ascending {
+		beforeEnd = (end == "" || node.key < end)
+	} else {
+		beforeEnd = (end == "" || node.key <= end)
+	}
+
+	// Run callback per inner/leaf node.
+	stop := false
+	if (!node.IsLeaf() && !leavesOnly) ||
+		(node.IsLeaf() && startOrAfter && beforeEnd) {
+		stop = cb(node)
+		if stop {
+			return stop
+		}
+	}
+	if node.IsLeaf() {
+		return stop
+	}
+
+	if ascending {
+		// check lower nodes, then higher
+		if afterStart {
+			stop = node.getLeftNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+		if stop {
+			return stop
+		}
+		if beforeEnd {
+			stop = node.getRightNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+	} else {
+		// check the higher nodes first
+		if beforeEnd {
+			stop = node.getRightNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+		if stop {
+			return stop
+		}
+		if afterStart {
+			stop = node.getLeftNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+	}
+
+	return stop
+}
+
+// TraverseByOffset traverses all nodes, including inner nodes.
+// A limit of math.MaxInt means no limit.
+func (node *Node) TraverseByOffset(offset, limit int, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	if node == nil {
+		return false
+	}
+
+	// fast paths. these happen only if TraverseByOffset is called directly on a leaf.
+	if limit <= 0 || offset >= node.size {
+		return false
+	}
+	if node.IsLeaf() {
+		if offset > 0 {
+			return false
+		}
+		return cb(node)
+	}
+
+	// go to the actual recursive function.
+	return node.traverseByOffset(offset, limit, ascending, leavesOnly, cb)
+}
+
+// TraverseByOffset traverses the subtree rooted at the node by offset and limit,
+// in either ascending or descending order, and applies the callback function to each traversed node.
+// If leavesOnly is true, only leaf nodes are visited.
+func (node *Node) traverseByOffset(offset, limit int, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	// caller guarantees: offset < node.size; limit > 0.
+	if !leavesOnly {
+		if cb(node) {
+			return true // Stop traversal if callback returns true
+		}
+	}
+	first, second := node.getLeftNode(), node.getRightNode()
+	if !ascending {
+		first, second = second, first
+	}
+	if first.IsLeaf() {
+		// either run or skip, based on offset
+		if offset > 0 {
+			offset--
+		} else {
+			if cb(first) {
+				return true // Stop traversal if callback returns true
+			}
+			limit--
+			if limit <= 0 {
+				return true // Stop traversal when limit is reached
+			}
+		}
+	} else {
+		// possible cases:
+		// 1 the offset given skips the first node entirely
+		// 2 the offset skips none or part of the first node, but the limit requires some of the second node.
+		// 3 the offset skips none or part of the first node, and the limit stops our search on the first node.
+		if offset >= first.size {
+			offset -= first.size // 1
+		} else {
+			if first.traverseByOffset(offset, limit, ascending, leavesOnly, cb) {
+				return true
+			}
+			// number of leaves which could actually be called from inside
+			delta := first.size - offset
+			offset = 0
+			if delta >= limit {
+				return true // 3
+			}
+			limit -= delta // 2
+		}
+	}
+
+	// because of the caller guarantees and the way we handle the first node,
+	// at this point we know that limit > 0 and there must be some values in
+	// this second node that we include.
+
+	// => if the second node is a leaf, it has to be included.
+	if second.IsLeaf() {
+		return cb(second)
+	}
+	// => if it is not a leaf, it will still be enough to recursively call this
+	// function with the updated offset and limit
+	return second.traverseByOffset(offset, limit, ascending, leavesOnly, cb)
+}
+
+// Only used in testing...
+func (node *Node) lmd() *Node {
+	if node.height == 0 {
+		return node
+	}
+	return node.getLeftNode().lmd()
+}
+
+// Only used in testing...
+func (node *Node) rmd() *Node {
+	if node.height == 0 {
+		return node
+	}
+	return node.getRightNode().rmd()
+}
+
+func maxInt8(a, b int8) int8 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendored/gno.land/p/nt/avl/v0/node_test.gno
+++ b/vendored/gno.land/p/nt/avl/v0/node_test.gno
@@ -1,0 +1,741 @@
+package avl
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func TestTraverseByOffset(t *testing.T) {
+	const testStrings = `Alfa
+Alfred
+Alpha
+Alphabet
+Beta
+Beth
+Book
+Browser`
+	tt := []struct {
+		name string
+		asc  bool
+	}{
+		{"ascending", true},
+		{"descending", false},
+	}
+
+	for _, tt := range tt {
+		t.Run(tt.name, func(t *testing.T) {
+			// use sl to insert the values, and reversed to match the values
+			// we do this to ensure that the order of TraverseByOffset is independent
+			// from the insertion order
+			sl := strings.Split(testStrings, "\n")
+			sort.Strings(sl)
+			reversed := append([]string{}, sl...)
+			reverseSlice(reversed)
+
+			if !tt.asc {
+				sl, reversed = reversed, sl
+			}
+
+			r := NewNode(reversed[0], nil)
+			for _, v := range reversed[1:] {
+				r, _ = r.Set(v, nil)
+			}
+
+			var result []string
+			for i := 0; i < len(sl); i++ {
+				r.TraverseByOffset(i, 1, tt.asc, true, func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+			}
+
+			if !slicesEqual(sl, result) {
+				t.Errorf("want %v got %v", sl, result)
+			}
+
+			for l := 2; l <= len(sl); l++ {
+				// "slices"
+				for i := 0; i <= len(sl); i++ {
+					max := i + l
+					if max > len(sl) {
+						max = len(sl)
+					}
+					exp := sl[i:max]
+					actual := []string{}
+
+					r.TraverseByOffset(i, l, tt.asc, true, func(tr *Node) bool {
+						actual = append(actual, tr.Key())
+						return false
+					})
+					if !slicesEqual(exp, actual) {
+						t.Errorf("want %v got %v", exp, actual)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHas(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		hasKey   string
+		expected bool
+	}{
+		{
+			"has key in non-empty tree",
+			[]string{"C", "A", "B", "E", "D"},
+			"B",
+			true,
+		},
+		{
+			"does not have key in non-empty tree",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			false,
+		},
+		{
+			"has key in single-node tree",
+			[]string{"A"},
+			"A",
+			true,
+		},
+		{
+			"does not have key in single-node tree",
+			[]string{"A"},
+			"B",
+			false,
+		},
+		{
+			"does not have key in empty tree",
+			[]string{},
+			"A",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			result := tree.Has(tt.hasKey)
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []string
+		getKey       string
+		expectIdx    int
+		expectVal    any
+		expectExists bool
+	}{
+		{
+			"get existing key",
+			[]string{"C", "A", "B", "E", "D"},
+			"B",
+			1,
+			nil,
+			true,
+		},
+		{
+			"get non-existent key (smaller)",
+			[]string{"C", "A", "B", "E", "D"},
+			"@",
+			0,
+			nil,
+			false,
+		},
+		{
+			"get non-existent key (larger)",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			5,
+			nil,
+			false,
+		},
+		{
+			"get from empty tree",
+			[]string{},
+			"A",
+			0,
+			nil,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			idx, val, exists := tree.Get(tt.getKey)
+
+			if idx != tt.expectIdx {
+				t.Errorf("Expected index %d, got %d", tt.expectIdx, idx)
+			}
+
+			if val != tt.expectVal {
+				t.Errorf("Expected value %v, got %v", tt.expectVal, val)
+			}
+
+			if exists != tt.expectExists {
+				t.Errorf("Expected exists %t, got %t", tt.expectExists, exists)
+			}
+		})
+	}
+}
+
+func TestGetByIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		idx         int
+		expectKey   string
+		expectVal   any
+		expectPanic bool
+	}{
+		{
+			"get by valid index",
+			[]string{"C", "A", "B", "E", "D"},
+			2,
+			"C",
+			nil,
+			false,
+		},
+		{
+			"get by valid index (smallest)",
+			[]string{"C", "A", "B", "E", "D"},
+			0,
+			"A",
+			nil,
+			false,
+		},
+		{
+			"get by valid index (largest)",
+			[]string{"C", "A", "B", "E", "D"},
+			4,
+			"E",
+			nil,
+			false,
+		},
+		{
+			"get by invalid index (negative)",
+			[]string{"C", "A", "B", "E", "D"},
+			-1,
+			"",
+			nil,
+			true,
+		},
+		{
+			"get by invalid index (out of range)",
+			[]string{"C", "A", "B", "E", "D"},
+			5,
+			"",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected a panic but didn't get one")
+					}
+				}()
+			}
+
+			key, val := tree.GetByIndex(tt.idx)
+
+			if !tt.expectPanic {
+				if key != tt.expectKey {
+					t.Errorf("Expected key %s, got %s", tt.expectKey, key)
+				}
+
+				if val != tt.expectVal {
+					t.Errorf("Expected value %v, got %v", tt.expectVal, val)
+				}
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		removeKey string
+		expected  []string
+	}{
+		{
+			"remove leaf node",
+			[]string{"C", "A", "B", "D"},
+			"B",
+			[]string{"A", "C", "D"},
+		},
+		{
+			"remove node with one child",
+			[]string{"C", "A", "B", "D"},
+			"A",
+			[]string{"B", "C", "D"},
+		},
+		{
+			"remove node with two children",
+			[]string{"C", "A", "B", "E", "D"},
+			"C",
+			[]string{"A", "B", "D", "E"},
+		},
+		{
+			"remove root node",
+			[]string{"C", "A", "B", "E", "D"},
+			"C",
+			[]string{"A", "B", "D", "E"},
+		},
+		{
+			"remove non-existent key",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree, _, _, _ = tree.Remove(tt.removeKey)
+
+			result := make([]string, 0)
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestTraverse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"empty tree",
+			[]string{},
+			[]string{},
+		},
+		{
+			"single node tree",
+			[]string{"A"},
+			[]string{"A"},
+		},
+		{
+			"small tree",
+			[]string{"C", "A", "B", "E", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"large tree",
+			[]string{"H", "D", "L", "B", "F", "J", "N", "A", "C", "E", "G", "I", "K", "M", "O"},
+			[]string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			t.Run("iterate", func(t *testing.T) {
+				var result []string
+				tree.Iterate("", "", func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				if !slicesEqual(tt.expected, result) {
+					t.Errorf("want %v got %v", tt.expected, result)
+				}
+			})
+
+			t.Run("ReverseIterate", func(t *testing.T) {
+				var result []string
+				tree.ReverseIterate("", "", func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				expected := make([]string, len(tt.expected))
+				copy(expected, tt.expected)
+				for i, j := 0, len(expected)-1; i < j; i, j = i+1, j-1 {
+					expected[i], expected[j] = expected[j], expected[i]
+				}
+				if !slicesEqual(expected, result) {
+					t.Errorf("want %v got %v", expected, result)
+				}
+			})
+
+			t.Run("TraverseInRange", func(t *testing.T) {
+				var result []string
+				start, end := "C", "M"
+				tree.TraverseInRange(start, end, true, true, func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				expected := make([]string, 0)
+				for _, key := range tt.expected {
+					if key >= start && key < end {
+						expected = append(expected, key)
+					}
+				}
+				if !slicesEqual(expected, result) {
+					t.Errorf("want %v got %v", expected, result)
+				}
+			})
+
+			t.Run("early termination", func(t *testing.T) {
+				if len(tt.input) == 0 {
+					return // Skip for empty tree
+				}
+
+				var result []string
+				var count int
+				tree.Iterate("", "", func(n *Node) bool {
+					count++
+					result = append(result, n.Key())
+					return true // Stop after first item
+				})
+
+				if count != 1 {
+					t.Errorf("Expected callback to be called exactly once, got %d calls", count)
+				}
+				if len(result) != 1 {
+					t.Errorf("Expected exactly one result, got %d items", len(result))
+				}
+				if len(result) > 0 && result[0] != tt.expected[0] {
+					t.Errorf("Expected first item to be %v, got %v", tt.expected[0], result[0])
+				}
+			})
+		})
+	}
+}
+
+func TestRotateWhenHeightDiffers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"right rotation when left subtree is higher",
+			[]string{"E", "C", "A", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left rotation when right subtree is higher",
+			[]string{"A", "C", "E", "D", "F"},
+			[]string{"A", "C", "D", "E", "F"},
+		},
+		{
+			"left-right rotation",
+			[]string{"E", "A", "C", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"right-left rotation",
+			[]string{"A", "E", "C", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			// perform rotation or balance
+			tree = tree.balance()
+
+			// check tree structure
+			var result []string
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRotateAndBalance(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"right rotation",
+			[]string{"A", "B", "C", "D", "E"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left rotation",
+			[]string{"E", "D", "C", "B", "A"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left-right rotation",
+			[]string{"C", "A", "E", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"right-left rotation",
+			[]string{"C", "E", "A", "D", "B"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree = tree.balance()
+
+			var result []string
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRemoveFromEmptyTree(t *testing.T) {
+	var tree *Node
+	newTree, _, val, removed := tree.Remove("NonExistent")
+	if newTree != nil {
+		t.Errorf("Removing from an empty tree should still be nil tree.")
+	}
+	if val != nil || removed {
+		t.Errorf("Expected no value and removed=false when removing from empty tree.")
+	}
+}
+
+func TestBalanceAfterRemoval(t *testing.T) {
+	tests := []struct {
+		name            string
+		insertKeys      []string
+		removeKey       string
+		expectedBalance int
+	}{
+		{
+			name:            "balance after removing right node",
+			insertKeys:      []string{"B", "A", "D", "C", "E"},
+			removeKey:       "E",
+			expectedBalance: 0,
+		},
+		{
+			name:            "balance after removing left node",
+			insertKeys:      []string{"D", "B", "E", "A", "C"},
+			removeKey:       "A",
+			expectedBalance: 0,
+		},
+		{
+			name:            "ensure no lean after removal",
+			insertKeys:      []string{"C", "B", "E", "A", "D", "F"},
+			removeKey:       "F",
+			expectedBalance: -1,
+		},
+		{
+			name:            "descending order insert, remove middle node",
+			insertKeys:      []string{"E", "D", "C", "B", "A"},
+			removeKey:       "C",
+			expectedBalance: 0,
+		},
+		{
+			name:            "ascending order insert, remove middle node",
+			insertKeys:      []string{"A", "B", "C", "D", "E"},
+			removeKey:       "C",
+			expectedBalance: 0,
+		},
+		{
+			name:            "duplicate key insert, remove the duplicated key",
+			insertKeys:      []string{"C", "B", "C", "A", "D"},
+			removeKey:       "C",
+			expectedBalance: 1,
+		},
+		{
+			name:            "complex rotation case",
+			insertKeys:      []string{"H", "B", "A", "C", "E", "D", "F", "G"},
+			removeKey:       "B",
+			expectedBalance: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.insertKeys {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree, _, _, _ = tree.Remove(tt.removeKey)
+
+			balance := tree.calcBalance()
+			if balance != tt.expectedBalance {
+				t.Errorf("Expected balance factor %d, got %d", tt.expectedBalance, balance)
+			}
+
+			if balance < -1 || balance > 1 {
+				t.Errorf("Tree is unbalanced with factor %d", balance)
+			}
+
+			if errMsg := checkSubtreeBalance(t, tree); errMsg != "" {
+				t.Errorf("AVL property violation after removal: %s", errMsg)
+			}
+		})
+	}
+}
+
+func TestBSTProperty(t *testing.T) {
+	var tree *Node
+	keys := []string{"D", "B", "F", "A", "C", "E", "G"}
+	for _, key := range keys {
+		tree, _ = tree.Set(key, nil)
+	}
+
+	var result []string
+	inorderTraversal(t, tree, &result)
+
+	for i := 1; i < len(result); i++ {
+		if result[i] < result[i-1] {
+			t.Errorf("BST property violated: %s < %s (index %d)",
+				result[i], result[i-1], i)
+		}
+	}
+}
+
+// inorderTraversal performs an inorder traversal of the tree and returns the keys in a list.
+func inorderTraversal(t *testing.T, node *Node, result *[]string) {
+	t.Helper()
+
+	if node == nil {
+		return
+	}
+	// leaf
+	if node.height == 0 {
+		*result = append(*result, node.key)
+		return
+	}
+	inorderTraversal(t, node.leftNode, result)
+	inorderTraversal(t, node.rightNode, result)
+}
+
+// checkSubtreeBalance checks if all nodes under the given node satisfy the AVL tree conditions.
+// The balance factor of all nodes must be ∈ [-1, +1]
+func checkSubtreeBalance(t *testing.T, node *Node) string {
+	t.Helper()
+
+	if node == nil {
+		return ""
+	}
+
+	if node.IsLeaf() {
+		// leaf node must be height=0, size=1
+		if node.height != 0 {
+			return ufmt.Sprintf("Leaf node %s has height %d, expected 0", node.Key(), node.height)
+		}
+		if node.size != 1 {
+			return ufmt.Sprintf("Leaf node %s has size %d, expected 1", node.Key(), node.size)
+		}
+		return ""
+	}
+
+	// check balance factor for current node
+	balanceFactor := node.calcBalance()
+	if balanceFactor < -1 || balanceFactor > 1 {
+		return ufmt.Sprintf("Node %s is unbalanced: balanceFactor=%d", node.Key(), balanceFactor)
+	}
+
+	// check height / size relationship for children
+	left, right := node.getLeftNode(), node.getRightNode()
+	expectedHeight := maxInt8(left.height, right.height) + 1
+	if node.height != expectedHeight {
+		return ufmt.Sprintf("Node %s has incorrect height %d, expected %d", node.Key(), node.height, expectedHeight)
+	}
+	expectedSize := left.Size() + right.Size()
+	if node.size != expectedSize {
+		return ufmt.Sprintf("Node %s has incorrect size %d, expected %d", node.Key(), node.size, expectedSize)
+	}
+
+	// recursively check the left/right subtree
+	if errMsg := checkSubtreeBalance(t, left); errMsg != "" {
+		return errMsg
+	}
+	if errMsg := checkSubtreeBalance(t, right); errMsg != "" {
+		return errMsg
+	}
+
+	return ""
+}
+
+func slicesEqual(w1, w2 []string) bool {
+	if len(w1) != len(w2) {
+		return false
+	}
+	for i := 0; i < len(w1); i++ {
+		if w1[i] != w2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func reverseSlice(ss []string) {
+	for i := 0; i < len(ss)/2; i++ {
+		j := len(ss) - 1 - i
+		ss[i], ss[j] = ss[j], ss[i]
+	}
+}

--- a/vendored/gno.land/p/nt/avl/v0/pager/filetests/z_filetest.gno
+++ b/vendored/gno.land/p/nt/avl/v0/pager/filetests/z_filetest.gno
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/avl/v0/pager"
+	"gno.land/p/nt/seqid/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	var id seqid.ID
+	tree := avl.NewTree()
+	for i := 0; i < 42; i++ {
+		tree.Set(id.Next().String(), i)
+	}
+
+	// Create a new pager.
+	pager := pager.NewPager(tree, 7, false)
+
+	for pn := -1; pn < 8; pn++ {
+		page := pager.GetPage(pn)
+
+		println(ufmt.Sprintf("## Page %d of %d", page.PageNumber, page.TotalPages))
+		for idx, item := range page.Items {
+			println(ufmt.Sprintf("- idx=%d key=%s value=%d", idx, item.Key, item.Value))
+		}
+		println(page.Picker("/"))
+		println()
+	}
+}
+
+// Output:
+// ## Page 0 of 6
+// _0_ | [1](?page=1) | [2](?page=2) | … | [6](?page=6)
+//
+// ## Page 0 of 6
+// _0_ | [1](?page=1) | [2](?page=2) | … | [6](?page=6)
+//
+// ## Page 1 of 6
+// - idx=0 key=0000001 value=0
+// - idx=1 key=0000002 value=1
+// - idx=2 key=0000003 value=2
+// - idx=3 key=0000004 value=3
+// - idx=4 key=0000005 value=4
+// - idx=5 key=0000006 value=5
+// - idx=6 key=0000007 value=6
+// **1** | [2](?page=2) | [3](?page=3) | … | [6](?page=6)
+//
+// ## Page 2 of 6
+// - idx=0 key=0000008 value=7
+// - idx=1 key=0000009 value=8
+// - idx=2 key=000000a value=9
+// - idx=3 key=000000b value=10
+// - idx=4 key=000000c value=11
+// - idx=5 key=000000d value=12
+// - idx=6 key=000000e value=13
+// [1](?page=1) | **2** | [3](?page=3) | [4](?page=4) | … | [6](?page=6)
+//
+// ## Page 3 of 6
+// - idx=0 key=000000f value=14
+// - idx=1 key=000000g value=15
+// - idx=2 key=000000h value=16
+// - idx=3 key=000000j value=17
+// - idx=4 key=000000k value=18
+// - idx=5 key=000000m value=19
+// - idx=6 key=000000n value=20
+// [1](?page=1) | [2](?page=2) | **3** | [4](?page=4) | [5](?page=5) | [6](?page=6)
+//
+// ## Page 4 of 6
+// - idx=0 key=000000p value=21
+// - idx=1 key=000000q value=22
+// - idx=2 key=000000r value=23
+// - idx=3 key=000000s value=24
+// - idx=4 key=000000t value=25
+// - idx=5 key=000000v value=26
+// - idx=6 key=000000w value=27
+// [1](?page=1) | [2](?page=2) | [3](?page=3) | **4** | [5](?page=5) | [6](?page=6)
+//
+// ## Page 5 of 6
+// - idx=0 key=000000x value=28
+// - idx=1 key=000000y value=29
+// - idx=2 key=000000z value=30
+// - idx=3 key=0000010 value=31
+// - idx=4 key=0000011 value=32
+// - idx=5 key=0000012 value=33
+// - idx=6 key=0000013 value=34
+// [1](?page=1) | … | [3](?page=3) | [4](?page=4) | **5** | [6](?page=6)
+//
+// ## Page 6 of 6
+// - idx=0 key=0000014 value=35
+// - idx=1 key=0000015 value=36
+// - idx=2 key=0000016 value=37
+// - idx=3 key=0000017 value=38
+// - idx=4 key=0000018 value=39
+// - idx=5 key=0000019 value=40
+// - idx=6 key=000001a value=41
+// [1](?page=1) | … | [4](?page=4) | [5](?page=5) | **6**
+//
+// ## Page 7 of 6
+// [1](?page=1) | … | [5](?page=5) | [6](?page=6) | _7_
+//

--- a/vendored/gno.land/p/nt/avl/v0/pager/gnomod.toml
+++ b/vendored/gno.land/p/nt/avl/v0/pager/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/avl/v0/pager"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/avl/v0/pager/pager.gno
+++ b/vendored/gno.land/p/nt/avl/v0/pager/pager.gno
@@ -1,0 +1,228 @@
+package pager
+
+import (
+	"math"
+	"net/url"
+	"strconv"
+
+	"gno.land/p/nt/avl/v0/rotree"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// Pager is a struct that holds the AVL tree and pagination parameters.
+type Pager struct {
+	Tree            rotree.IReadOnlyTree
+	PageQueryParam  string
+	SizeQueryParam  string
+	DefaultPageSize int
+	Reversed        bool
+}
+
+// Page represents a single page of results.
+type Page struct {
+	Items      []Item
+	PageNumber int
+	PageSize   int
+	TotalItems int
+	TotalPages int
+	HasPrev    bool
+	HasNext    bool
+	Pager      *Pager // Reference to the parent Pager
+}
+
+// Item represents a key-value pair in the AVL tree.
+type Item struct {
+	Key   string
+	Value any
+}
+
+// NewPager creates a new Pager with default values.
+func NewPager(tree rotree.IReadOnlyTree, defaultPageSize int, reversed bool) *Pager {
+	return &Pager{
+		Tree:            tree,
+		PageQueryParam:  "page",
+		SizeQueryParam:  "size",
+		DefaultPageSize: defaultPageSize,
+		Reversed:        reversed,
+	}
+}
+
+// GetPage retrieves a page of results from the AVL tree.
+func (p *Pager) GetPage(pageNumber int) *Page {
+	return p.GetPageWithSize(pageNumber, p.DefaultPageSize)
+}
+
+func (p *Pager) GetPageWithSize(pageNumber, pageSize int) *Page {
+	totalItems := p.Tree.Size()
+	totalPages := int(math.Ceil(float64(totalItems) / float64(pageSize)))
+
+	page := &Page{
+		TotalItems: totalItems,
+		TotalPages: totalPages,
+		PageSize:   pageSize,
+		Pager:      p,
+	}
+
+	// pages without content
+	if pageSize < 1 {
+		return page
+	}
+
+	// page number provided is not available
+	if pageNumber < 1 {
+		page.HasNext = totalPages > 0
+		return page
+	}
+
+	// page number provided is outside the range of total pages
+	if pageNumber > totalPages {
+		page.PageNumber = pageNumber
+		page.HasPrev = pageNumber > 0
+		return page
+	}
+
+	startIndex := (pageNumber - 1) * pageSize
+	endIndex := startIndex + pageSize
+	if endIndex > totalItems {
+		endIndex = totalItems
+	}
+
+	items := []Item{}
+
+	if p.Reversed {
+		p.Tree.ReverseIterateByOffset(startIndex, endIndex-startIndex, func(key string, value any) bool {
+			items = append(items, Item{Key: key, Value: value})
+			return false
+		})
+	} else {
+		p.Tree.IterateByOffset(startIndex, endIndex-startIndex, func(key string, value any) bool {
+			items = append(items, Item{Key: key, Value: value})
+			return false
+		})
+	}
+
+	page.Items = items
+	page.PageNumber = pageNumber
+	page.HasPrev = pageNumber > 1
+	page.HasNext = pageNumber < totalPages
+	return page
+}
+
+func (p *Pager) MustGetPageByPath(rawURL string) *Page {
+	page, err := p.GetPageByPath(rawURL)
+	if err != nil {
+		panic("invalid path")
+	}
+	return page
+}
+
+// GetPageByPath retrieves a page of results based on the query parameters in the URL path.
+func (p *Pager) GetPageByPath(rawURL string) (*Page, error) {
+	pageNumber, pageSize, err := p.ParseQuery(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return p.GetPageWithSize(pageNumber, pageSize), nil
+}
+
+// Picker generates the Markdown UI for the page Picker
+func (p *Page) Picker(path string) string {
+	pageNumber := p.PageNumber
+	pageNumber = max(pageNumber, 1)
+
+	if p.TotalPages <= 1 {
+		return ""
+	}
+
+	u, _ := url.Parse(path)
+	query := u.Query()
+
+	// Remove existing page query parameter
+	query.Del(p.Pager.PageQueryParam)
+
+	// Encode remaining query parameters
+	baseQuery := query.Encode()
+	if baseQuery != "" {
+		baseQuery = "&" + baseQuery
+	}
+	md := ""
+
+	if p.HasPrev {
+		md += ufmt.Sprintf("[%d](?%s=%d%s) | ", 1, p.Pager.PageQueryParam, 1, baseQuery)
+
+		if p.PageNumber > 4 {
+			md += "… | "
+		}
+
+		if p.PageNumber > 3 {
+			md += ufmt.Sprintf("[%d](?%s=%d%s) | ", p.PageNumber-2, p.Pager.PageQueryParam, p.PageNumber-2, baseQuery)
+		}
+
+		if p.PageNumber > 2 {
+			md += ufmt.Sprintf("[%d](?%s=%d%s) | ", p.PageNumber-1, p.Pager.PageQueryParam, p.PageNumber-1, baseQuery)
+		}
+	}
+
+	if p.PageNumber > 0 && p.PageNumber <= p.TotalPages {
+		md += ufmt.Sprintf("**%d**", p.PageNumber)
+	} else {
+		md += ufmt.Sprintf("_%d_", p.PageNumber)
+	}
+
+	if p.HasNext {
+		if p.PageNumber < p.TotalPages-1 {
+			md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.PageNumber+1, p.Pager.PageQueryParam, p.PageNumber+1, baseQuery)
+		}
+
+		if p.PageNumber < p.TotalPages-2 {
+			md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.PageNumber+2, p.Pager.PageQueryParam, p.PageNumber+2, baseQuery)
+		}
+
+		if p.PageNumber < p.TotalPages-3 {
+			md += " | …"
+		}
+
+		md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.TotalPages, p.Pager.PageQueryParam, p.TotalPages, baseQuery)
+	}
+
+	return md
+}
+
+// ParseQuery parses the URL to extract the page number and page size.
+func (p *Pager) ParseQuery(rawURL string) (int, int, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 1, p.DefaultPageSize, err
+	}
+
+	query := u.Query()
+	pageNumber := 1
+	pageSize := p.DefaultPageSize
+
+	if p.PageQueryParam != "" {
+		if pageStr := query.Get(p.PageQueryParam); pageStr != "" {
+			pageNumber, err = strconv.Atoi(pageStr)
+			if err != nil || pageNumber < 1 {
+				pageNumber = 1
+			}
+		}
+	}
+
+	if p.SizeQueryParam != "" {
+		if sizeStr := query.Get(p.SizeQueryParam); sizeStr != "" {
+			pageSize, err = strconv.Atoi(sizeStr)
+			if err != nil || pageSize < 1 {
+				pageSize = p.DefaultPageSize
+			}
+		}
+	}
+
+	return pageNumber, pageSize, nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendored/gno.land/p/nt/avl/v0/pager/pager_test.gno
+++ b/vendored/gno.land/p/nt/avl/v0/pager/pager_test.gno
@@ -1,0 +1,281 @@
+package pager
+
+import (
+	"testing"
+
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/ufmt/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+func TestPager_GetPage(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	t.Run("normal ordering", func(t *testing.T) {
+		// Create a new pager.
+		pager := NewPager(tree, 10, false)
+
+		// Define test cases.
+		tests := []struct {
+			pageNumber int
+			pageSize   int
+			expected   []Item
+		}{
+			{1, 2, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}}},
+			{2, 2, []Item{{Key: "c", Value: 3}, {Key: "d", Value: 4}}},
+			{3, 2, []Item{{Key: "e", Value: 5}}},
+			{1, 3, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}, {Key: "c", Value: 3}}},
+			{2, 3, []Item{{Key: "d", Value: 4}, {Key: "e", Value: 5}}},
+			{1, 5, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}, {Key: "c", Value: 3}, {Key: "d", Value: 4}, {Key: "e", Value: 5}}},
+			{2, 5, []Item{}},
+		}
+
+		for _, tt := range tests {
+			page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+			uassert.Equal(t, len(tt.expected), len(page.Items))
+
+			for i, item := range page.Items {
+				uassert.Equal(t, tt.expected[i].Key, item.Key)
+				uassert.Equal(t, tt.expected[i].Value, item.Value)
+			}
+		}
+	})
+
+	t.Run("reversed ordering", func(t *testing.T) {
+		// Create a new pager.
+		pager := NewPager(tree, 10, true)
+
+		// Define test cases.
+		tests := []struct {
+			pageNumber int
+			pageSize   int
+			expected   []Item
+		}{
+			{1, 2, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}}},
+			{2, 2, []Item{{Key: "c", Value: 3}, {Key: "b", Value: 2}}},
+			{3, 2, []Item{{Key: "a", Value: 1}}},
+			{1, 3, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}, {Key: "c", Value: 3}}},
+			{2, 3, []Item{{Key: "b", Value: 2}, {Key: "a", Value: 1}}},
+			{1, 5, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}, {Key: "c", Value: 3}, {Key: "b", Value: 2}, {Key: "a", Value: 1}}},
+			{2, 5, []Item{}},
+		}
+
+		for _, tt := range tests {
+			page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+			uassert.Equal(t, len(tt.expected), len(page.Items))
+
+			for i, item := range page.Items {
+				uassert.Equal(t, tt.expected[i].Key, item.Key)
+				uassert.Equal(t, tt.expected[i].Value, item.Value)
+			}
+		}
+	})
+}
+
+func TestPager_GetPageByPath(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	for i := 0; i < 50; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		rawURL       string
+		expectedPage int
+		expectedSize int
+	}{
+		{"/r/foo:bar/baz?size=10&page=1", 1, 10},
+		{"/r/foo:bar/baz?size=10&page=2", 2, 10},
+		{"/r/foo:bar/baz?page=3", 3, pager.DefaultPageSize},
+		{"/r/foo:bar/baz?size=20", 1, 20},
+		{"/r/foo:bar/baz", 1, pager.DefaultPageSize},
+	}
+
+	for _, tt := range tests {
+		page, err := pager.GetPageByPath(tt.rawURL)
+		urequire.NoError(t, err, ufmt.Sprintf("GetPageByPath(%s) returned error: %v", tt.rawURL, err))
+
+		uassert.Equal(t, tt.expectedPage, page.PageNumber)
+		uassert.Equal(t, tt.expectedSize, page.PageSize)
+	}
+}
+
+func TestPage_Picker(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		pageNumber int
+		pageSize   int
+		path       string
+		expected   string
+	}{
+		{1, 2, "/test", "**1** | [2](?page=2) | [3](?page=3)"},
+		{2, 2, "/test", "[1](?page=1) | **2** | [3](?page=3)"},
+		{3, 2, "/test", "[1](?page=1) | [2](?page=2) | **3**"},
+		{1, 2, "/test?foo=bar", "**1** | [2](?page=2&foo=bar) | [3](?page=3&foo=bar)"},
+	}
+
+	for _, tt := range tests {
+		page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+		ui := page.Picker(tt.path)
+		uassert.Equal(t, tt.expected, ui)
+	}
+}
+
+func TestPager_UI_WithManyPages(t *testing.T) {
+	// Create a new AVL tree and populate it with many key-value pairs.
+	tree := avl.NewTree()
+	for i := 0; i < 100; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases for a large number of pages.
+	tests := []struct {
+		pageNumber int
+		pageSize   int
+		path       string
+		expected   string
+	}{
+		{1, 10, "/test", "**1** | [2](?page=2) | [3](?page=3) | … | [10](?page=10)"},
+		{2, 10, "/test", "[1](?page=1) | **2** | [3](?page=3) | [4](?page=4) | … | [10](?page=10)"},
+		{3, 10, "/test", "[1](?page=1) | [2](?page=2) | **3** | [4](?page=4) | [5](?page=5) | … | [10](?page=10)"},
+		{4, 10, "/test", "[1](?page=1) | [2](?page=2) | [3](?page=3) | **4** | [5](?page=5) | [6](?page=6) | … | [10](?page=10)"},
+		{5, 10, "/test", "[1](?page=1) | … | [3](?page=3) | [4](?page=4) | **5** | [6](?page=6) | [7](?page=7) | … | [10](?page=10)"},
+		{6, 10, "/test", "[1](?page=1) | … | [4](?page=4) | [5](?page=5) | **6** | [7](?page=7) | [8](?page=8) | … | [10](?page=10)"},
+		{7, 10, "/test", "[1](?page=1) | … | [5](?page=5) | [6](?page=6) | **7** | [8](?page=8) | [9](?page=9) | [10](?page=10)"},
+		{8, 10, "/test", "[1](?page=1) | … | [6](?page=6) | [7](?page=7) | **8** | [9](?page=9) | [10](?page=10)"},
+		{9, 10, "/test", "[1](?page=1) | … | [7](?page=7) | [8](?page=8) | **9** | [10](?page=10)"},
+		{10, 10, "/test", "[1](?page=1) | … | [8](?page=8) | [9](?page=9) | **10**"},
+	}
+
+	for _, tt := range tests {
+		page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+		ui := page.Picker(tt.path)
+		uassert.Equal(t, tt.expected, ui)
+	}
+}
+
+func TestPager_ParseQuery(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		rawURL        string
+		expectedPage  int
+		expectedSize  int
+		expectedError bool
+	}{
+		{"/r/foo:bar/baz?size=2&page=1", 1, 2, false},
+		{"/r/foo:bar/baz?size=3&page=2", 2, 3, false},
+		{"/r/foo:bar/baz?size=5&page=3", 3, 5, false},
+		{"/r/foo:bar/baz?page=2", 2, pager.DefaultPageSize, false},
+		{"/r/foo:bar/baz?size=3", 1, 3, false},
+		{"/r/foo:bar/baz", 1, pager.DefaultPageSize, false},
+		{"/r/foo:bar/baz?size=0&page=0", 1, pager.DefaultPageSize, false},
+	}
+
+	for _, tt := range tests {
+		page, size, err := pager.ParseQuery(tt.rawURL)
+		if tt.expectedError {
+			uassert.Error(t, err, ufmt.Sprintf("ParseQuery(%s) expected error but got none", tt.rawURL))
+		} else {
+			urequire.NoError(t, err, ufmt.Sprintf("ParseQuery(%s) returned error: %v", tt.rawURL, err))
+			uassert.Equal(t, tt.expectedPage, page, ufmt.Sprintf("ParseQuery(%s) returned page %d, expected %d", tt.rawURL, page, tt.expectedPage))
+			uassert.Equal(t, tt.expectedSize, size, ufmt.Sprintf("ParseQuery(%s) returned size %d, expected %d", tt.rawURL, size, tt.expectedSize))
+		}
+	}
+}
+
+func TestPage_PickerQueryParamPreservation(t *testing.T) {
+	tree := avl.NewTree()
+	for i := 1; i <= 6; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	pager := NewPager(tree, 2, false)
+
+	tests := []struct {
+		name       string
+		pageNumber int
+		path       string
+		expected   string
+	}{
+		{
+			name:       "single query param",
+			pageNumber: 1,
+			path:       "/test?foo=bar",
+			expected:   "**1** | [2](?page=2&foo=bar) | [3](?page=3&foo=bar)",
+		},
+		{
+			name:       "multiple query params",
+			pageNumber: 2,
+			path:       "/test?foo=bar&baz=qux",
+			expected:   "[1](?page=1&baz=qux&foo=bar) | **2** | [3](?page=3&baz=qux&foo=bar)",
+		},
+		{
+			name:       "overwrite existing page param",
+			pageNumber: 1,
+			path:       "/test?param1=value1&page=999&param2=value2",
+			expected:   "**1** | [2](?page=2&param1=value1&param2=value2) | [3](?page=3&param1=value1&param2=value2)",
+		},
+		{
+			name:       "empty query string",
+			pageNumber: 2,
+			path:       "/test",
+			expected:   "[1](?page=1) | **2** | [3](?page=3)",
+		},
+		{
+			name:       "query string with only page param",
+			pageNumber: 2,
+			path:       "/test?page=2",
+			expected:   "[1](?page=1) | **2** | [3](?page=3)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			page := pager.GetPageWithSize(tt.pageNumber, 2)
+			result := page.Picker(tt.path)
+			if result != tt.expected {
+				t.Errorf("\nwant: %s\ngot:  %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/nt/avl/v0/rotree/gnomod.toml
+++ b/vendored/gno.land/p/nt/avl/v0/rotree/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/avl/v0/rotree"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/avl/v0/rotree/rotree.gno
+++ b/vendored/gno.land/p/nt/avl/v0/rotree/rotree.gno
@@ -1,0 +1,177 @@
+// Package rotree provides a read-only wrapper for avl.Tree with safe value transformation.
+//
+// It is useful when you want to expose a read-only view of a tree while ensuring that
+// the sensitive data cannot be modified.
+//
+// Example:
+//
+//	// Define a user structure with sensitive data
+//	type User struct {
+//		Name     string
+//		Balance  int
+//		Internal string // sensitive field
+//	}
+//
+//	// Create and populate the original tree
+//	privateTree := avl.NewTree()
+//	privateTree.Set("alice", &User{
+//		Name:     "Alice",
+//		Balance:  100,
+//		Internal: "sensitive",
+//	})
+//
+//	// Create a safe transformation function that copies the struct
+//	// while excluding sensitive data
+//	makeEntrySafeFn := func(v any) any {
+//		u := v.(*User)
+//		return &User{
+//			Name:     u.Name,
+//			Balance:  u.Balance,
+//			Internal: "", // omit sensitive data
+//		}
+//	}
+//
+//	// Create a read-only view of the tree
+//	PublicTree := rotree.Wrap(tree, makeEntrySafeFn)
+//
+//	// Safely access the data
+//	value, _ := roTree.Get("alice")
+//	user := value.(*User)
+//	// user.Name == "Alice"
+//	// user.Balance == 100
+//	// user.Internal == "" (sensitive data is filtered)
+package rotree
+
+import (
+	"gno.land/p/nt/avl/v0"
+)
+
+// Wrap creates a new ReadOnlyTree from an existing avl.Tree and a safety transformation function.
+// If makeEntrySafeFn is nil, values will be returned as-is without transformation.
+//
+// makeEntrySafeFn is a function that transforms a tree entry into a safe version that can be exposed to external users.
+// This function should be implemented based on the specific safety requirements of your use case:
+//
+//  1. No-op transformation: For primitive types (int, string, etc.) or already safe objects,
+//     simply pass nil as the makeEntrySafeFn to return values as-is.
+//
+//  2. Defensive copying: For mutable types like slices or maps, you should create a deep copy
+//     to prevent modification of the original data.
+//     Example: func(v any) any { return append([]int{}, v.([]int)...) }
+//
+//  3. Read-only wrapper: Return a read-only version of the object that implements
+//     a limited interface.
+//     Example: func(v any) any { return NewReadOnlyObject(v) }
+//
+//  4. DAO transformation: Transform the object into a data access object that
+//     controls how the underlying data can be accessed.
+//     Example: func(v any) any { return NewDAO(v) }
+//
+// The function ensures that the returned object is safe to expose to untrusted code,
+// preventing unauthorized modifications to the original data structure.
+func Wrap(tree *avl.Tree, makeEntrySafeFn func(any) any) *ReadOnlyTree {
+	return &ReadOnlyTree{
+		tree:            tree,
+		makeEntrySafeFn: makeEntrySafeFn,
+	}
+}
+
+// ReadOnlyTree wraps an avl.Tree and provides read-only access.
+type ReadOnlyTree struct {
+	tree            *avl.Tree
+	makeEntrySafeFn func(any) any
+}
+
+// IReadOnlyTree defines the read-only operations available on a tree.
+type IReadOnlyTree interface {
+	Size() int
+	Has(key string) bool
+	Get(key string) (any, bool)
+	GetByIndex(index int) (string, any)
+	Iterate(start, end string, cb avl.IterCbFn) bool
+	ReverseIterate(start, end string, cb avl.IterCbFn) bool
+	IterateByOffset(offset int, count int, cb avl.IterCbFn) bool
+	ReverseIterateByOffset(offset int, count int, cb avl.IterCbFn) bool
+}
+
+// Verify that ReadOnlyTree implements both ITree and IReadOnlyTree
+var (
+	_ avl.ITree     = (*ReadOnlyTree)(nil)
+	_ IReadOnlyTree = (*ReadOnlyTree)(nil)
+)
+
+// getSafeValue applies the makeEntrySafeFn if it exists, otherwise returns the original value
+func (roTree *ReadOnlyTree) getSafeValue(value any) any {
+	if roTree.makeEntrySafeFn == nil {
+		return value
+	}
+	return roTree.makeEntrySafeFn(value)
+}
+
+// Size returns the number of key-value pairs in the tree.
+func (roTree *ReadOnlyTree) Size() int {
+	return roTree.tree.Size()
+}
+
+// Has checks whether a key exists in the tree.
+func (roTree *ReadOnlyTree) Has(key string) bool {
+	return roTree.tree.Has(key)
+}
+
+// Get retrieves the value associated with the given key, converted to a safe format.
+func (roTree *ReadOnlyTree) Get(key string) (any, bool) {
+	value, exists := roTree.tree.Get(key)
+	if !exists {
+		return nil, false
+	}
+	return roTree.getSafeValue(value), true
+}
+
+// GetByIndex retrieves the key-value pair at the specified index in the tree, with the value converted to a safe format.
+func (roTree *ReadOnlyTree) GetByIndex(index int) (string, any) {
+	key, value := roTree.tree.GetByIndex(index)
+	return key, roTree.getSafeValue(value)
+}
+
+// Iterate performs an in-order traversal of the tree within the specified key range.
+func (roTree *ReadOnlyTree) Iterate(start, end string, cb avl.IterCbFn) bool {
+	return roTree.tree.Iterate(start, end, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// ReverseIterate performs a reverse in-order traversal of the tree within the specified key range.
+func (roTree *ReadOnlyTree) ReverseIterate(start, end string, cb avl.IterCbFn) bool {
+	return roTree.tree.ReverseIterate(start, end, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// IterateByOffset performs an in-order traversal of the tree starting from the specified offset.
+func (roTree *ReadOnlyTree) IterateByOffset(offset int, count int, cb avl.IterCbFn) bool {
+	return roTree.tree.IterateByOffset(offset, count, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// ReverseIterateByOffset performs a reverse in-order traversal of the tree starting from the specified offset.
+func (roTree *ReadOnlyTree) ReverseIterateByOffset(offset int, count int, cb avl.IterCbFn) bool {
+	return roTree.tree.ReverseIterateByOffset(offset, count, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// Set is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) Set(key string, value any) bool {
+	panic("Set operation not supported on ReadOnlyTree")
+}
+
+// Remove is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) Remove(key string) (value any, removed bool) {
+	panic("Remove operation not supported on ReadOnlyTree")
+}
+
+// RemoveByIndex is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) RemoveByIndex(index int) (key string, value any) {
+	panic("RemoveByIndex operation not supported on ReadOnlyTree")
+}

--- a/vendored/gno.land/p/nt/avl/v0/rotree/rotree_test.gno
+++ b/vendored/gno.land/p/nt/avl/v0/rotree/rotree_test.gno
@@ -1,0 +1,222 @@
+package rotree
+
+import (
+	"testing"
+
+	"gno.land/p/nt/avl/v0"
+)
+
+func TestExample(t *testing.T) {
+	// User represents our internal data structure
+	type User struct {
+		ID       string
+		Name     string
+		Balance  int
+		Internal string // sensitive internal data
+	}
+
+	// Create and populate the original tree with user pointers
+	tree := avl.NewTree()
+	tree.Set("alice", &User{
+		ID:       "1",
+		Name:     "Alice",
+		Balance:  100,
+		Internal: "sensitive_data_1",
+	})
+	tree.Set("bob", &User{
+		ID:       "2",
+		Name:     "Bob",
+		Balance:  200,
+		Internal: "sensitive_data_2",
+	})
+
+	// Define a makeEntrySafeFn that:
+	// 1. Creates a defensive copy of the User struct
+	// 2. Omits sensitive internal data
+	makeEntrySafeFn := func(v any) any {
+		originalUser := v.(*User)
+		return &User{
+			ID:       originalUser.ID,
+			Name:     originalUser.Name,
+			Balance:  originalUser.Balance,
+			Internal: "", // Omit sensitive data
+		}
+	}
+
+	// Create a read-only view of the tree
+	roTree := Wrap(tree, makeEntrySafeFn)
+
+	// Test retrieving and verifying a user
+	t.Run("Get User", func(t *testing.T) {
+		// Get user from read-only tree
+		value, exists := roTree.Get("alice")
+		if !exists {
+			t.Fatal("User 'alice' not found")
+		}
+
+		user := value.(*User)
+
+		// Verify user data is correct
+		if user.Name != "Alice" || user.Balance != 100 {
+			t.Errorf("Unexpected user data: got name=%s balance=%d", user.Name, user.Balance)
+		}
+
+		// Verify sensitive data is not exposed
+		if user.Internal != "" {
+			t.Error("Sensitive data should not be exposed")
+		}
+
+		// Verify it's a different instance than the original
+		originalValue, _ := tree.Get("alice")
+		originalUser := originalValue.(*User)
+		if user == originalUser {
+			t.Error("Read-only tree should return a copy, not the original pointer")
+		}
+	})
+
+	// Test iterating over users
+	t.Run("Iterate Users", func(t *testing.T) {
+		count := 0
+		roTree.Iterate("", "", func(key string, value any) bool {
+			user := value.(*User)
+			// Verify each user has empty Internal field
+			if user.Internal != "" {
+				t.Error("Sensitive data exposed during iteration")
+			}
+			count++
+			return false
+		})
+
+		if count != 2 {
+			t.Errorf("Expected 2 users, got %d", count)
+		}
+	})
+
+	// Verify that modifications to the returned user don't affect the original
+	t.Run("Modification Safety", func(t *testing.T) {
+		value, _ := roTree.Get("alice")
+		user := value.(*User)
+
+		// Try to modify the returned user
+		user.Balance = 999
+		user.Internal = "hacked"
+
+		// Verify original is unchanged
+		originalValue, _ := tree.Get("alice")
+		originalUser := originalValue.(*User)
+		if originalUser.Balance != 100 || originalUser.Internal != "sensitive_data_1" {
+			t.Error("Original user data was modified")
+		}
+	})
+}
+
+func TestReadOnlyTree(t *testing.T) {
+	// Example of a makeEntrySafeFn that appends "_readonly" to demonstrate transformation
+	makeEntrySafeFn := func(value any) any {
+		return value.(string) + "_readonly"
+	}
+
+	tree := avl.NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	roTree := Wrap(tree, makeEntrySafeFn)
+
+	tests := []struct {
+		name     string
+		key      string
+		expected any
+		exists   bool
+	}{
+		{"ExistingKey1", "key1", "value1_readonly", true},
+		{"ExistingKey2", "key2", "value2_readonly", true},
+		{"NonExistingKey", "key4", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, exists := roTree.Get(tt.key)
+			if exists != tt.exists || value != tt.expected {
+				t.Errorf("For key %s, expected %v (exists: %v), got %v (exists: %v)", tt.key, tt.expected, tt.exists, value, exists)
+			}
+		})
+	}
+}
+
+// Add example tests showing different makeEntrySafeFn implementations
+func TestMakeEntrySafeFnVariants(t *testing.T) {
+	tree := avl.NewTree()
+	tree.Set("slice", []int{1, 2, 3})
+	tree.Set("map", map[string]int{"a": 1})
+
+	tests := []struct {
+		name            string
+		makeEntrySafeFn func(any) any
+		key             string
+		validate        func(t *testing.T, value any)
+	}{
+		{
+			name: "Defensive Copy Slice",
+			makeEntrySafeFn: func(v any) any {
+				original := v.([]int)
+				return append([]int{}, original...)
+			},
+			key: "slice",
+			validate: func(t *testing.T, value any) {
+				slice := value.([]int)
+				// Modify the returned slice
+				slice[0] = 999
+				// Verify original is unchanged
+				originalValue, _ := tree.Get("slice")
+				original := originalValue.([]int)
+				if original[0] != 1 {
+					t.Error("Original slice was modified")
+				}
+			},
+		},
+		// Add more test cases for different makeEntrySafeFn implementations
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roTree := Wrap(tree, tt.makeEntrySafeFn)
+			value, exists := roTree.Get(tt.key)
+			if !exists {
+				t.Fatal("Key not found")
+			}
+			tt.validate(t, value)
+		})
+	}
+}
+
+func TestNilMakeEntrySafeFn(t *testing.T) {
+	// Create a tree with some test data
+	tree := avl.NewTree()
+	originalValue := []int{1, 2, 3}
+	tree.Set("test", originalValue)
+
+	// Create a ReadOnlyTree with nil makeEntrySafeFn
+	roTree := Wrap(tree, nil)
+
+	// Test that we get back the original value
+	value, exists := roTree.Get("test")
+	if !exists {
+		t.Fatal("Key not found")
+	}
+
+	// Verify it's the exact same slice (not a copy)
+	retrievedSlice := value.([]int)
+	if &retrievedSlice[0] != &originalValue[0] {
+		t.Error("Expected to get back the original slice reference")
+	}
+
+	// Test through iteration as well
+	roTree.Iterate("", "", func(key string, value any) bool {
+		retrievedSlice := value.([]int)
+		if &retrievedSlice[0] != &originalValue[0] {
+			t.Error("Expected to get back the original slice reference in iteration")
+		}
+		return false
+	})
+}

--- a/vendored/gno.land/p/nt/avl/v0/tree.gno
+++ b/vendored/gno.land/p/nt/avl/v0/tree.gno
@@ -1,0 +1,124 @@
+package avl
+
+type ITree interface {
+	// read operations
+
+	Size() int
+	Has(key string) bool
+	Get(key string) (value any, exists bool)
+	GetByIndex(index int) (key string, value any)
+	Iterate(start, end string, cb IterCbFn) bool
+	ReverseIterate(start, end string, cb IterCbFn) bool
+	IterateByOffset(offset int, count int, cb IterCbFn) bool
+	ReverseIterateByOffset(offset int, count int, cb IterCbFn) bool
+
+	// write operations
+
+	Set(key string, value any) (updated bool)
+	Remove(key string) (value any, removed bool)
+}
+
+type IterCbFn func(key string, value any) bool
+
+//----------------------------------------
+// Tree
+
+// The zero struct can be used as an empty tree.
+type Tree struct {
+	node *Node
+}
+
+// NewTree creates a new empty AVL tree.
+func NewTree() *Tree {
+	return &Tree{
+		node: nil,
+	}
+}
+
+// Size returns the number of key-value pair in the tree.
+func (tree *Tree) Size() int {
+	return tree.node.Size()
+}
+
+// Has checks whether a key exists in the tree.
+// It returns true if the key exists, otherwise false.
+func (tree *Tree) Has(key string) (has bool) {
+	return tree.node.Has(key)
+}
+
+// Get retrieves the value associated with the given key.
+// It returns the value and a boolean indicating whether the key exists.
+func (tree *Tree) Get(key string) (value any, exists bool) {
+	_, value, exists = tree.node.Get(key)
+	return
+}
+
+// GetByIndex retrieves the key-value pair at the specified index in the tree.
+// It returns the key and value at the given index.
+func (tree *Tree) GetByIndex(index int) (key string, value any) {
+	return tree.node.GetByIndex(index)
+}
+
+// Set inserts a key-value pair into the tree.
+// If the key already exists, the value will be updated.
+// It returns a boolean indicating whether the key was newly inserted or updated.
+func (tree *Tree) Set(key string, value any) (updated bool) {
+	newnode, updated := tree.node.Set(key, value)
+	tree.node = newnode
+	return updated
+}
+
+// Remove removes a key-value pair from the tree.
+// It returns the removed value and a boolean indicating whether the key was found and removed.
+func (tree *Tree) Remove(key string) (value any, removed bool) {
+	newnode, _, value, removed := tree.node.Remove(key)
+	tree.node = newnode
+	return value, removed
+}
+
+// Iterate performs an in-order traversal of the tree within the specified key range.
+// It calls the provided callback function for each key-value pair encountered.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) Iterate(start, end string, cb IterCbFn) bool {
+	return tree.node.TraverseInRange(start, end, true, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// ReverseIterate performs a reverse in-order traversal of the tree within the specified key range.
+// It calls the provided callback function for each key-value pair encountered.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) ReverseIterate(start, end string, cb IterCbFn) bool {
+	return tree.node.TraverseInRange(start, end, false, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// IterateByOffset performs an in-order traversal of the tree starting from the specified offset.
+// It calls the provided callback function for each key-value pair encountered, up to the specified count.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) IterateByOffset(offset int, count int, cb IterCbFn) bool {
+	return tree.node.TraverseByOffset(offset, count, true, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// ReverseIterateByOffset performs a reverse in-order traversal of the tree starting from the specified offset.
+// It calls the provided callback function for each key-value pair encountered, up to the specified count.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) ReverseIterateByOffset(offset int, count int, cb IterCbFn) bool {
+	return tree.node.TraverseByOffset(offset, count, false, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// Verify that Tree implements TreeInterface
+var _ ITree = (*Tree)(nil)

--- a/vendored/gno.land/p/nt/avl/v0/tree_test.gno
+++ b/vendored/gno.land/p/nt/avl/v0/tree_test.gno
@@ -1,0 +1,212 @@
+package avl
+
+import "testing"
+
+func TestNewTree(t *testing.T) {
+	tree := NewTree()
+	if tree.node != nil {
+		t.Error("Expected tree.node to be nil")
+	}
+}
+
+func TestTreeSize(t *testing.T) {
+	tree := NewTree()
+	if tree.Size() != 0 {
+		t.Error("Expected empty tree size to be 0")
+	}
+
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	if tree.Size() != 2 {
+		t.Error("Expected tree size to be 2")
+	}
+}
+
+func TestTreeHas(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	if !tree.Has("key1") {
+		t.Error("Expected tree to have key1")
+	}
+
+	if tree.Has("key2") {
+		t.Error("Expected tree to not have key2")
+	}
+}
+
+func TestTreeGet(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	value, exists := tree.Get("key1")
+	if !exists || value != "value1" {
+		t.Error("Expected Get to return value1 and true")
+	}
+
+	_, exists = tree.Get("key2")
+	if exists {
+		t.Error("Expected Get to return false for non-existent key")
+	}
+}
+
+func TestTreeGetByIndex(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+
+	key, value := tree.GetByIndex(0)
+	if key != "key1" || value != "value1" {
+		t.Error("Expected GetByIndex(0) to return key1 and value1")
+	}
+
+	key, value = tree.GetByIndex(1)
+	if key != "key2" || value != "value2" {
+		t.Error("Expected GetByIndex(1) to return key2 and value2")
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected GetByIndex to panic for out-of-range index")
+		}
+	}()
+	tree.GetByIndex(2)
+}
+
+func TestTreeRemove(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	value, removed := tree.Remove("key1")
+	if !removed || value != "value1" || tree.Size() != 0 {
+		t.Error("Expected Remove to remove key-value pair")
+	}
+
+	_, removed = tree.Remove("key2")
+	if removed {
+		t.Error("Expected Remove to return false for non-existent key")
+	}
+}
+
+func TestTreeIterate(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.Iterate("", "", func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key1", "key2", "key3"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterate(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.ReverseIterate("", "", func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key3", "key2", "key1"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeIterateByOffset(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.IterateByOffset(1, 2, func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key2", "key3"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterateByOffset(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.ReverseIterateByOffset(1, 2, func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key2", "key1"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterateByOffsetVaried(t *testing.T) {
+	tree := NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// All keys in reverse: e d c b a
+	cases := []struct {
+		offset int
+		limit  int
+		want   []string
+	}{
+		{0, 5, []string{"e", "d", "c", "b", "a"}},
+		{0, 1, []string{"e"}},
+		{0, 3, []string{"e", "d", "c"}},
+		{1, 2, []string{"d", "c"}},
+		{2, 2, []string{"c", "b"}},
+		{3, 5, []string{"b", "a"}},
+		{4, 1, []string{"a"}},
+		{4, 10, []string{"a"}},
+		{5, 1, nil},
+		{0, 0, nil},
+		{10, 1, nil},
+	}
+
+	for _, tc := range cases {
+		var got []string
+		tree.ReverseIterateByOffset(tc.offset, tc.limit, func(key string, value any) bool {
+			got = append(got, key)
+			return false
+		})
+		if !slicesEqual(got, tc.want) {
+			t.Errorf("ReverseIterateByOffset(%d, %d): got %v, want %v",
+				tc.offset, tc.limit, got, tc.want)
+		}
+	}
+
+	// Early termination: stop after 2 items from offset 1.
+	var got []string
+	tree.ReverseIterateByOffset(1, 5, func(key string, value any) bool {
+		got = append(got, key)
+		return len(got) >= 2
+	})
+	want := []string{"d", "c"}
+	if !slicesEqual(got, want) {
+		t.Errorf("ReverseIterateByOffset early stop: got %v, want %v", got, want)
+	}
+}

--- a/vendored/gno.land/p/nt/cford32/v0/LICENSE
+++ b/vendored/gno.land/p/nt/cford32/v0/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendored/gno.land/p/nt/cford32/v0/README.md
+++ b/vendored/gno.land/p/nt/cford32/v0/README.md
@@ -1,0 +1,82 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+
+# cford32
+
+```
+package cford32 // import "gno.land/p/nt/cford32/v0"
+
+Package cford32 implements a base32-like encoding/decoding package, with the
+encoding scheme specified by Douglas Crockford.
+
+From the website, the requirements of said encoding scheme are to:
+
+  - Be human readable and machine readable.
+  - Be compact. Humans have difficulty in manipulating long strings of arbitrary
+    symbols.
+  - Be error resistant. Entering the symbols must not require keyboarding
+    gymnastics.
+  - Be pronounceable. Humans should be able to accurately transmit the symbols
+    to other humans using a telephone.
+
+This is slightly different from a simple difference in encoding table from
+the Go's stdlib `encoding/base32`, as when decoding the characters i I l L are
+parsed as 1, and o O is parsed as 0.
+
+This package additionally provides ways to encode uint64's efficiently, as well
+as efficient encoding to a lowercase variation of the encoding. The encodings
+never use paddings.
+
+# Uint64 Encoding
+
+Aside from lower/uppercase encoding, there is a compact encoding, allowing to
+encode all values in [0,2^34), and the full encoding, allowing all values in
+[0,2^64). The compact encoding uses 7 characters, and the full encoding uses 13
+characters. Both are parsed unambiguously by the Uint64 decoder.
+
+The compact encodings have the first character between ['0','f'], while the
+full encoding's first character ranges between ['g','z']. Practically, in your
+usage of the package, you should consider which one to use and stick with it,
+while considering that the compact encoding, once it reaches 2^34, automatically
+switches to the full encoding. The properties of the generated strings are still
+maintained: for instance, any two encoded uint64s x,y consistently generated
+with the compact encoding, if the numeric value is x < y, will also be x < y in
+lexical ordering. However, values [0,2^34) have a "double encoding", which if
+mixed together lose the lexical ordering property.
+
+The Uint64 encoding is most useful for generating string versions of Uint64 IDs.
+Practically, it allows you to retain sleek and compact IDs for your application
+for the first 2^34 (>17 billion) entities, while seamlessly rolling over to the
+full encoding should you exceed that. You are encouraged to use it unless you
+have a requirement or preferences for IDs consistently being always the same
+size.
+
+To use the cford32 encoding for IDs, you may want to consider using package
+gno.land/p/nt/seqid/v0.
+
+[specified by Douglas Crockford]: https://www.crockford.com/base32.html
+
+func AppendCompact(id uint64, b []byte) []byte
+func AppendDecode(dst, src []byte) ([]byte, error)
+func AppendEncode(dst, src []byte) []byte
+func AppendEncodeLower(dst, src []byte) []byte
+func Decode(dst, src []byte) (n int, err error)
+func DecodeString(s string) ([]byte, error)
+func DecodedLen(n int) int
+func Encode(dst, src []byte)
+func EncodeLower(dst, src []byte)
+func EncodeToString(src []byte) string
+func EncodeToStringLower(src []byte) string
+func EncodedLen(n int) int
+func NewDecoder(r io.Reader) io.Reader
+func NewEncoder(w io.Writer) io.WriteCloser
+func NewEncoderLower(w io.Writer) io.WriteCloser
+func PutCompact(id uint64) []byte
+func PutUint64(id uint64) [13]byte
+func PutUint64Lower(id uint64) [13]byte
+func Uint64(b []byte) (uint64, error)
+type CorruptInputError int64
+```

--- a/vendored/gno.land/p/nt/cford32/v0/cford32.gno
+++ b/vendored/gno.land/p/nt/cford32/v0/cford32.gno
@@ -1,0 +1,704 @@
+// Modified from the Go Source code for encoding/base32.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cford32 implements a base32-like encoding/decoding package, with the
+// encoding scheme [specified by Douglas Crockford].
+//
+// From the website, the requirements of said encoding scheme are to:
+//
+//   - Be human readable and machine readable.
+//   - Be compact. Humans have difficulty in manipulating long strings of arbitrary symbols.
+//   - Be error resistant. Entering the symbols must not require keyboarding gymnastics.
+//   - Be pronounceable. Humans should be able to accurately transmit the symbols to other humans using a telephone.
+//
+// This is slightly different from a simple difference in encoding table from
+// the Go's stdlib `encoding/base32`, as when decoding the characters i I l L are
+// parsed as 1, and o O is parsed as 0.
+//
+// This package additionally provides ways to encode uint64's efficiently,
+// as well as efficient encoding to a lowercase variation of the encoding.
+// The encodings never use paddings.
+//
+// # Uint64 Encoding
+//
+// Aside from lower/uppercase encoding, there is a compact encoding, allowing
+// to encode all values in [0,2^34), and the full encoding, allowing all
+// values in [0,2^64). The compact encoding uses 7 characters, and the full
+// encoding uses 13 characters. Both are parsed unambiguously by the Uint64
+// decoder.
+//
+// The compact encodings have the first character between ['0','f'], while the
+// full encoding's first character ranges between ['g','z']. Practically, in
+// your usage of the package, you should consider which one to use and stick
+// with it, while considering that the compact encoding, once it reaches 2^34,
+// automatically switches to the full encoding. The properties of the generated
+// strings are still maintained: for instance, any two encoded uint64s x,y
+// consistently generated with the compact encoding, if the numeric value is
+// x < y, will also be x < y in lexical ordering. However, values [0,2^34) have a
+// "double encoding", which if mixed together lose the lexical ordering property.
+//
+// The Uint64 encoding is most useful for generating string versions of Uint64
+// IDs. Practically, it allows you to retain sleek and compact IDs for your
+// application for the first 2^34 (>17 billion) entities, while seamlessly
+// rolling over to the full encoding should you exceed that. You are encouraged
+// to use it unless you have a requirement or preferences for IDs consistently
+// being always the same size.
+//
+// To use the cford32 encoding for IDs, you may want to consider using package
+// [gno.land/p/nt/seqid/v0].
+//
+// [specified by Douglas Crockford]: https://www.crockford.com/base32.html
+package cford32
+
+import (
+	"io"
+	"strconv"
+)
+
+const (
+	encTable      = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+	encTableLower = "0123456789abcdefghjkmnpqrstvwxyz"
+
+	// each line is 16 bytes
+	decTable = "" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" + // 00-0f
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" + // 10-1f
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" + // 20-2f
+		"\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\xff\xff\xff\xff\xff\xff" + // 30-3f
+		"\xff\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x01\x12\x13\x01\x14\x15\x00" + // 40-4f
+		"\x16\x17\x18\x19\x1a\xff\x1b\x1c\x1d\x1e\x1f\xff\xff\xff\xff\xff" + // 50-5f
+		"\xff\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x01\x12\x13\x01\x14\x15\x00" + // 60-6f
+		"\x16\x17\x18\x19\x1a\xff\x1b\x1c\x1d\x1e\x1f\xff\xff\xff\xff\xff" + // 70-7f
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" + // 80-ff (not ASCII)
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff" +
+		"\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff"
+)
+
+// CorruptInputError is returned by parsing functions when an invalid character
+// in the input is found. The integer value represents the byte index where
+// the error occurred.
+//
+// This is typically because the given character does not exist in the encoding.
+type CorruptInputError int64
+
+func (e CorruptInputError) Error() string {
+	return "illegal cford32 data at input byte " + strconv.FormatInt(int64(e), 10)
+}
+
+// Uint64 parses a cford32-encoded byte slice into a uint64.
+//
+//   - The parser requires all provided character to be valid cford32 characters.
+//   - The parser disregards case.
+//   - If the first character is '0' <= c <= 'f', then the passed value is assumed
+//     encoded in the compact encoding, and must be 7 characters long.
+//   - If the first character is 'g' <= c <= 'z',  then the passed value is
+//     assumed encoded in the full encoding, and must be 13 characters long.
+//
+// If any of these requirements fail, a CorruptInputError will be returned.
+func Uint64(b []byte) (uint64, error) {
+	if len(b) == 0 {
+		return 0, CorruptInputError(0)
+	}
+	b0 := decTable[b[0]]
+	switch {
+	default:
+		return 0, CorruptInputError(0)
+	case len(b) == 7 && b0 < 16:
+		decVals := [7]byte{
+			decTable[b[0]],
+			decTable[b[1]],
+			decTable[b[2]],
+			decTable[b[3]],
+			decTable[b[4]],
+			decTable[b[5]],
+			decTable[b[6]],
+		}
+		for idx, v := range decVals {
+			if v >= 32 {
+				return 0, CorruptInputError(idx)
+			}
+		}
+
+		return 0 +
+			uint64(decVals[0])<<30 |
+			uint64(decVals[1])<<25 |
+			uint64(decVals[2])<<20 |
+			uint64(decVals[3])<<15 |
+			uint64(decVals[4])<<10 |
+			uint64(decVals[5])<<5 |
+			uint64(decVals[6]), nil
+	case len(b) == 13 && b0 >= 16 && b0 < 32:
+		decVals := [13]byte{
+			decTable[b[0]] & 0x0F, // disregard high bit
+			decTable[b[1]],
+			decTable[b[2]],
+			decTable[b[3]],
+			decTable[b[4]],
+			decTable[b[5]],
+			decTable[b[6]],
+			decTable[b[7]],
+			decTable[b[8]],
+			decTable[b[9]],
+			decTable[b[10]],
+			decTable[b[11]],
+			decTable[b[12]],
+		}
+		for idx, v := range decVals {
+			if v >= 32 {
+				return 0, CorruptInputError(idx)
+			}
+		}
+
+		return 0 +
+			uint64(decVals[0])<<60 |
+			uint64(decVals[1])<<55 |
+			uint64(decVals[2])<<50 |
+			uint64(decVals[3])<<45 |
+			uint64(decVals[4])<<40 |
+			uint64(decVals[5])<<35 |
+			uint64(decVals[6])<<30 |
+			uint64(decVals[7])<<25 |
+			uint64(decVals[8])<<20 |
+			uint64(decVals[9])<<15 |
+			uint64(decVals[10])<<10 |
+			uint64(decVals[11])<<5 |
+			uint64(decVals[12]), nil
+	}
+}
+
+const mask = 31
+
+// PutUint64 returns a cford32-encoded byte slice.
+func PutUint64(id uint64) [13]byte {
+	return [13]byte{
+		encTable[id>>60&mask|0x10], // specify full encoding
+		encTable[id>>55&mask],
+		encTable[id>>50&mask],
+		encTable[id>>45&mask],
+		encTable[id>>40&mask],
+		encTable[id>>35&mask],
+		encTable[id>>30&mask],
+		encTable[id>>25&mask],
+		encTable[id>>20&mask],
+		encTable[id>>15&mask],
+		encTable[id>>10&mask],
+		encTable[id>>5&mask],
+		encTable[id&mask],
+	}
+}
+
+// PutUint64Lower returns a cford32-encoded byte array, swapping uppercase
+// letters with lowercase.
+//
+// For more information on how the value is encoded, see [Uint64].
+func PutUint64Lower(id uint64) [13]byte {
+	return [13]byte{
+		encTableLower[id>>60&mask|0x10],
+		encTableLower[id>>55&mask],
+		encTableLower[id>>50&mask],
+		encTableLower[id>>45&mask],
+		encTableLower[id>>40&mask],
+		encTableLower[id>>35&mask],
+		encTableLower[id>>30&mask],
+		encTableLower[id>>25&mask],
+		encTableLower[id>>20&mask],
+		encTableLower[id>>15&mask],
+		encTableLower[id>>10&mask],
+		encTableLower[id>>5&mask],
+		encTableLower[id&mask],
+	}
+}
+
+// PutCompact returns a cford32-encoded byte slice, using the compact
+// representation of cford32 described in the package documentation where
+// possible (all values of id < 1<<34). The lowercase encoding is used.
+//
+// The resulting byte slice will be 7 bytes long for all compact values,
+// and 13 bytes long for
+func PutCompact(id uint64) []byte {
+	return AppendCompact(id, nil)
+}
+
+// AppendCompact works like [PutCompact] but appends to the given byte slice
+// instead of allocating one anew.
+func AppendCompact(id uint64, b []byte) []byte {
+	const maxCompact = 1 << 34
+	if id < maxCompact {
+		return append(b,
+			encTableLower[id>>30&mask],
+			encTableLower[id>>25&mask],
+			encTableLower[id>>20&mask],
+			encTableLower[id>>15&mask],
+			encTableLower[id>>10&mask],
+			encTableLower[id>>5&mask],
+			encTableLower[id&mask],
+		)
+	}
+	return append(b,
+		encTableLower[id>>60&mask|0x10],
+		encTableLower[id>>55&mask],
+		encTableLower[id>>50&mask],
+		encTableLower[id>>45&mask],
+		encTableLower[id>>40&mask],
+		encTableLower[id>>35&mask],
+		encTableLower[id>>30&mask],
+		encTableLower[id>>25&mask],
+		encTableLower[id>>20&mask],
+		encTableLower[id>>15&mask],
+		encTableLower[id>>10&mask],
+		encTableLower[id>>5&mask],
+		encTableLower[id&mask],
+	)
+}
+
+func DecodedLen(n int) int {
+	return n/8*5 + n%8*5/8
+}
+
+func EncodedLen(n int) int {
+	return n/5*8 + (n%5*8+4)/5
+}
+
+// Encode encodes src using the encoding enc,
+// writing [EncodedLen](len(src)) bytes to dst.
+//
+// The encoding does not contain any padding, unlike Go's base32.
+func Encode(dst, src []byte) {
+	// Copied from encoding/base32/base32.go (go1.22)
+	if len(src) == 0 {
+		return
+	}
+
+	di, si := 0, 0
+	n := (len(src) / 5) * 5
+	for si < n {
+		// Combining two 32 bit loads allows the same code to be used
+		// for 32 and 64 bit platforms.
+		hi := uint32(src[si+0])<<24 | uint32(src[si+1])<<16 | uint32(src[si+2])<<8 | uint32(src[si+3])
+		lo := hi<<8 | uint32(src[si+4])
+
+		dst[di+0] = encTable[(hi>>27)&0x1F]
+		dst[di+1] = encTable[(hi>>22)&0x1F]
+		dst[di+2] = encTable[(hi>>17)&0x1F]
+		dst[di+3] = encTable[(hi>>12)&0x1F]
+		dst[di+4] = encTable[(hi>>7)&0x1F]
+		dst[di+5] = encTable[(hi>>2)&0x1F]
+		dst[di+6] = encTable[(lo>>5)&0x1F]
+		dst[di+7] = encTable[(lo)&0x1F]
+
+		si += 5
+		di += 8
+	}
+
+	// Add the remaining small block
+	remain := len(src) - si
+	if remain == 0 {
+		return
+	}
+
+	// Encode the remaining bytes in reverse order.
+	val := uint32(0)
+	switch remain {
+	case 4:
+		val |= uint32(src[si+3])
+		dst[di+6] = encTable[val<<3&0x1F]
+		dst[di+5] = encTable[val>>2&0x1F]
+		fallthrough
+	case 3:
+		val |= uint32(src[si+2]) << 8
+		dst[di+4] = encTable[val>>7&0x1F]
+		fallthrough
+	case 2:
+		val |= uint32(src[si+1]) << 16
+		dst[di+3] = encTable[val>>12&0x1F]
+		dst[di+2] = encTable[val>>17&0x1F]
+		fallthrough
+	case 1:
+		val |= uint32(src[si+0]) << 24
+		dst[di+1] = encTable[val>>22&0x1F]
+		dst[di+0] = encTable[val>>27&0x1F]
+	}
+}
+
+// EncodeLower is like [Encode], but uses the lowercase
+func EncodeLower(dst, src []byte) {
+	// Copied from encoding/base32/base32.go (go1.22)
+	if len(src) == 0 {
+		return
+	}
+
+	di, si := 0, 0
+	n := (len(src) / 5) * 5
+	for si < n {
+		// Combining two 32 bit loads allows the same code to be used
+		// for 32 and 64 bit platforms.
+		hi := uint32(src[si+0])<<24 | uint32(src[si+1])<<16 | uint32(src[si+2])<<8 | uint32(src[si+3])
+		lo := hi<<8 | uint32(src[si+4])
+
+		dst[di+0] = encTableLower[(hi>>27)&0x1F]
+		dst[di+1] = encTableLower[(hi>>22)&0x1F]
+		dst[di+2] = encTableLower[(hi>>17)&0x1F]
+		dst[di+3] = encTableLower[(hi>>12)&0x1F]
+		dst[di+4] = encTableLower[(hi>>7)&0x1F]
+		dst[di+5] = encTableLower[(hi>>2)&0x1F]
+		dst[di+6] = encTableLower[(lo>>5)&0x1F]
+		dst[di+7] = encTableLower[(lo)&0x1F]
+
+		si += 5
+		di += 8
+	}
+
+	// Add the remaining small block
+	remain := len(src) - si
+	if remain == 0 {
+		return
+	}
+
+	// Encode the remaining bytes in reverse order.
+	val := uint32(0)
+	switch remain {
+	case 4:
+		val |= uint32(src[si+3])
+		dst[di+6] = encTableLower[val<<3&0x1F]
+		dst[di+5] = encTableLower[val>>2&0x1F]
+		fallthrough
+	case 3:
+		val |= uint32(src[si+2]) << 8
+		dst[di+4] = encTableLower[val>>7&0x1F]
+		fallthrough
+	case 2:
+		val |= uint32(src[si+1]) << 16
+		dst[di+3] = encTableLower[val>>12&0x1F]
+		dst[di+2] = encTableLower[val>>17&0x1F]
+		fallthrough
+	case 1:
+		val |= uint32(src[si+0]) << 24
+		dst[di+1] = encTableLower[val>>22&0x1F]
+		dst[di+0] = encTableLower[val>>27&0x1F]
+	}
+}
+
+// AppendEncode appends the cford32 encoded src to dst
+// and returns the extended buffer.
+func AppendEncode(dst, src []byte) []byte {
+	n := EncodedLen(len(src))
+	dst = grow(dst, n)
+	Encode(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n]
+}
+
+// AppendEncodeLower appends the lowercase cford32 encoded src to dst
+// and returns the extended buffer.
+func AppendEncodeLower(dst, src []byte) []byte {
+	n := EncodedLen(len(src))
+	dst = grow(dst, n)
+	EncodeLower(dst[len(dst):][:n], src)
+	return dst[:len(dst)+n]
+}
+
+func grow(s []byte, n int) []byte {
+	// slices.Grow
+	if n -= cap(s) - len(s); n > 0 {
+		news := make([]byte, cap(s)+n)
+		copy(news[:cap(s)], s[:cap(s)])
+		return news[:len(s)]
+	}
+	return s
+}
+
+// EncodeToString returns the cford32 encoding of src.
+func EncodeToString(src []byte) string {
+	buf := make([]byte, EncodedLen(len(src)))
+	Encode(buf, src)
+	return string(buf)
+}
+
+// EncodeToStringLower returns the cford32 lowercase encoding of src.
+func EncodeToStringLower(src []byte) string {
+	buf := make([]byte, EncodedLen(len(src)))
+	EncodeLower(buf, src)
+	return string(buf)
+}
+
+func decode(dst, src []byte) (n int, err error) {
+	dsti := 0
+	olen := len(src)
+
+	for len(src) > 0 {
+		// Decode quantum using the base32 alphabet
+		var dbuf [8]byte
+		dlen := 8
+
+		for j := 0; j < 8; {
+			if len(src) == 0 {
+				// We have reached the end and are not expecting any padding
+				dlen = j
+				break
+			}
+			in := src[0]
+			src = src[1:]
+			dbuf[j] = decTable[in]
+			if dbuf[j] == 0xFF {
+				return n, CorruptInputError(olen - len(src) - 1)
+			}
+			j++
+		}
+
+		// Pack 8x 5-bit source blocks into 5 byte destination
+		// quantum
+		switch dlen {
+		case 8:
+			dst[dsti+4] = dbuf[6]<<5 | dbuf[7]
+			n++
+			fallthrough
+		case 7:
+			dst[dsti+3] = dbuf[4]<<7 | dbuf[5]<<2 | dbuf[6]>>3
+			n++
+			fallthrough
+		case 5:
+			dst[dsti+2] = dbuf[3]<<4 | dbuf[4]>>1
+			n++
+			fallthrough
+		case 4:
+			dst[dsti+1] = dbuf[1]<<6 | dbuf[2]<<1 | dbuf[3]>>4
+			n++
+			fallthrough
+		case 2:
+			dst[dsti+0] = dbuf[0]<<3 | dbuf[1]>>2
+			n++
+		}
+		dsti += 5
+	}
+	return n, nil
+}
+
+type encoder struct {
+	err  error
+	w    io.Writer
+	enc  func(dst, src []byte)
+	buf  [5]byte    // buffered data waiting to be encoded
+	nbuf int        // number of bytes in buf
+	out  [1024]byte // output buffer
+}
+
+func NewEncoder(w io.Writer) io.WriteCloser {
+	return &encoder{w: w, enc: Encode}
+}
+
+func NewEncoderLower(w io.Writer) io.WriteCloser {
+	return &encoder{w: w, enc: EncodeLower}
+}
+
+func (e *encoder) Write(p []byte) (n int, err error) {
+	if e.err != nil {
+		return 0, e.err
+	}
+
+	// Leading fringe.
+	if e.nbuf > 0 {
+		var i int
+		for i = 0; i < len(p) && e.nbuf < 5; i++ {
+			e.buf[e.nbuf] = p[i]
+			e.nbuf++
+		}
+		n += i
+		p = p[i:]
+		if e.nbuf < 5 {
+			return
+		}
+		e.enc(e.out[0:], e.buf[0:])
+		if _, e.err = e.w.Write(e.out[0:8]); e.err != nil {
+			return n, e.err
+		}
+		e.nbuf = 0
+	}
+
+	// Large interior chunks.
+	for len(p) >= 5 {
+		nn := len(e.out) / 8 * 5
+		if nn > len(p) {
+			nn = len(p)
+			nn -= nn % 5
+		}
+		e.enc(e.out[0:], p[0:nn])
+		if _, e.err = e.w.Write(e.out[0 : nn/5*8]); e.err != nil {
+			return n, e.err
+		}
+		n += nn
+		p = p[nn:]
+	}
+
+	// Trailing fringe.
+	copy(e.buf[:], p)
+	e.nbuf = len(p)
+	n += len(p)
+	return
+}
+
+// Close flushes any pending output from the encoder.
+// It is an error to call Write after calling Close.
+func (e *encoder) Close() error {
+	// If there's anything left in the buffer, flush it out
+	if e.err == nil && e.nbuf > 0 {
+		e.enc(e.out[0:], e.buf[0:e.nbuf])
+		encodedLen := EncodedLen(e.nbuf)
+		e.nbuf = 0
+		_, e.err = e.w.Write(e.out[0:encodedLen])
+	}
+	return e.err
+}
+
+// Decode decodes src using cford32. It writes at most
+// [DecodedLen](len(src)) bytes to dst and returns the number of bytes
+// written. If src contains invalid cford32 data, it will return the
+// number of bytes successfully written and [CorruptInputError].
+// Newline characters (\r and \n) are ignored.
+func Decode(dst, src []byte) (n int, err error) {
+	buf := make([]byte, len(src))
+	l := stripNewlines(buf, src)
+	return decode(dst, buf[:l])
+}
+
+// AppendDecode appends the cford32 decoded src to dst
+// and returns the extended buffer.
+// If the input is malformed, it returns the partially decoded src and an error.
+func AppendDecode(dst, src []byte) ([]byte, error) {
+	n := DecodedLen(len(src))
+
+	dst = grow(dst, n)
+	dstsl := dst[len(dst) : len(dst)+n]
+	n, err := Decode(dstsl, src)
+	return dst[:len(dst)+n], err
+}
+
+// DecodeString returns the bytes represented by the cford32 string s.
+func DecodeString(s string) ([]byte, error) {
+	buf := []byte(s)
+	l := stripNewlines(buf, buf)
+	n, err := decode(buf, buf[:l])
+	return buf[:n], err
+}
+
+// stripNewlines removes newline characters and returns the number
+// of non-newline characters copied to dst.
+func stripNewlines(dst, src []byte) int {
+	offset := 0
+	for _, b := range src {
+		if b == '\r' || b == '\n' {
+			continue
+		}
+		dst[offset] = b
+		offset++
+	}
+	return offset
+}
+
+type decoder struct {
+	err    error
+	r      io.Reader
+	buf    [1024]byte // leftover input
+	nbuf   int
+	out    []byte // leftover decoded output
+	outbuf [1024 / 8 * 5]byte
+}
+
+// NewDecoder constructs a new base32 stream decoder.
+func NewDecoder(r io.Reader) io.Reader {
+	return &decoder{r: &newlineFilteringReader{r}}
+}
+
+func readEncodedData(r io.Reader, buf []byte) (n int, err error) {
+	for n < 1 && err == nil {
+		var nn int
+		nn, err = r.Read(buf[n:])
+		n += nn
+	}
+	return
+}
+
+func (d *decoder) Read(p []byte) (n int, err error) {
+	// Use leftover decoded output from last read.
+	if len(d.out) > 0 {
+		n = copy(p, d.out)
+		d.out = d.out[n:]
+		if len(d.out) == 0 {
+			return n, d.err
+		}
+		return n, nil
+	}
+
+	if d.err != nil {
+		return 0, d.err
+	}
+
+	// Read nn bytes from input, bounded [8,len(d.buf)]
+	nn := (len(p)/5 + 1) * 8
+	if nn > len(d.buf) {
+		nn = len(d.buf)
+	}
+
+	nn, d.err = readEncodedData(d.r, d.buf[d.nbuf:nn])
+	d.nbuf += nn
+	if d.nbuf < 1 {
+		return 0, d.err
+	}
+
+	// Decode chunk into p, or d.out and then p if p is too small.
+	nr := d.nbuf
+	if d.err != io.EOF && nr%8 != 0 {
+		nr -= nr % 8
+	}
+	nw := DecodedLen(d.nbuf)
+
+	if nw > len(p) {
+		nw, err = decode(d.outbuf[0:], d.buf[0:nr])
+		d.out = d.outbuf[0:nw]
+		n = copy(p, d.out)
+		d.out = d.out[n:]
+	} else {
+		n, err = decode(p, d.buf[0:nr])
+	}
+	d.nbuf -= nr
+	for i := 0; i < d.nbuf; i++ {
+		d.buf[i] = d.buf[i+nr]
+	}
+
+	if err != nil && (d.err == nil || d.err == io.EOF) {
+		d.err = err
+	}
+
+	if len(d.out) > 0 {
+		// We cannot return all the decoded bytes to the caller in this
+		// invocation of Read, so we return a nil error to ensure that Read
+		// will be called again.  The error stored in d.err, if any, will be
+		// returned with the last set of decoded bytes.
+		return n, nil
+	}
+
+	return n, d.err
+}
+
+type newlineFilteringReader struct {
+	wrapped io.Reader
+}
+
+func (r *newlineFilteringReader) Read(p []byte) (int, error) {
+	n, err := r.wrapped.Read(p)
+	for n > 0 {
+		s := p[0:n]
+		offset := stripNewlines(s, s)
+		if err != nil || offset > 0 {
+			return offset, err
+		}
+		// Previous buffer entirely whitespace, read again
+		n, err = r.wrapped.Read(p)
+	}
+	return n, err
+}

--- a/vendored/gno.land/p/nt/cford32/v0/cford32_test.gno
+++ b/vendored/gno.land/p/nt/cford32/v0/cford32_test.gno
@@ -1,0 +1,677 @@
+package cford32
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+)
+
+func TestCompactRoundtrip(t *testing.T) {
+	buf := make([]byte, 13)
+	prev := make([]byte, 13)
+	for i := uint64(0); i < (1 << 10); i++ {
+		res := AppendCompact(i, buf[:0])
+		back, err := Uint64(res)
+		testEqual(t, "Uint64(%q) = (%d, %v), want %v", string(res), back, err, nil)
+		testEqual(t, "Uint64(%q) = %d, want %v", string(res), back, i)
+
+		testEqual(t, "bytes.Compare(prev, res) = %d, want %d", bytes.Compare(prev, res), -1)
+		prev, buf = res, prev
+	}
+	for i := uint64(1<<34 - 1024); i < (1<<34 + 1024); i++ {
+		res := AppendCompact(i, buf[:0])
+		back, err := Uint64(res)
+		// println(string(res))
+		testEqual(t, "Uint64(%q) = (%d, %v), want %v", string(res), back, err, nil)
+		testEqual(t, "Uint64(%q) = %d, want %v", string(res), back, i)
+
+		testEqual(t, "bytes.Compare(prev, res) = %d, want %d", bytes.Compare(prev, res), -1)
+		prev, buf = res, prev
+	}
+	for i := uint64(1<<64 - 5000); i != 0; i++ {
+		res := AppendCompact(i, buf[:0])
+		back, err := Uint64(res)
+		testEqual(t, "Uint64(%q) = (%d, %v), want %v", string(res), back, err, nil)
+		testEqual(t, "Uint64(%q) = %d, want %v", string(res), back, i)
+
+		testEqual(t, "bytes.Compare(prev, res) = %d, want %d", bytes.Compare(prev, res), -1)
+		prev, buf = res, prev
+	}
+}
+
+func BenchmarkCompact(b *testing.B) {
+	buf := make([]byte, 13)
+	for i := 0; i < b.N; i++ {
+		_ = AppendCompact(uint64(i), buf[:0])
+	}
+}
+
+func TestUint64(t *testing.T) {
+	tt := []struct {
+		val    string
+		output uint64
+		err    string
+	}{
+		{"0000001", 1, ""},
+		{"OoOoOoL", 1, ""},
+		{"OoUoOoL", 0, CorruptInputError(2).Error()},
+		{"!123123", 0, CorruptInputError(0).Error()},
+		{"Loooooo", 1073741824, ""},
+		{"goooooo", 0, CorruptInputError(0).Error()},
+		{"goooooooooooo", 0, ""},
+		{"goooooooooolo", 32, ""},
+		{"fzzzzzz", (1 << 34) - 1, ""},
+		{"g00000fzzzzzz", (1 << 34) - 1, ""},
+		{"g000000", 0, CorruptInputError(0).Error()},
+		{"g00000g000000", (1 << 34), ""},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.val, func(t *testing.T) {
+			res, err := Uint64([]byte(tc.val))
+			if tc.err != "" {
+				_ = uassert.Error(t, err) &&
+					uassert.Equal(t, tc.err, err.Error())
+			} else {
+				_ = uassert.NoError(t, err) &&
+					uassert.Equal(t, tc.output, res)
+			}
+		})
+	}
+}
+
+func TestRandomCompactRoundtrip(t *testing.T) {
+	for i := 0; i < 1<<12; i++ {
+		value := rand.Uint64()
+		encoded := PutCompact(value)
+		decoded, err := Uint64(encoded)
+		uassert.NoError(t, err)
+		uassert.Equal(t, value, decoded)
+	}
+}
+
+type testpair struct {
+	decoded, encoded string
+}
+
+var pairs = []testpair{
+	{"", ""},
+	{"f", "CR"},
+	{"fo", "CSQG"},
+	{"foo", "CSQPY"},
+	{"foob", "CSQPYRG"},
+	{"fooba", "CSQPYRK1"},
+	{"foobar", "CSQPYRK1E8"},
+
+	{"sure.", "EDTQ4S9E"},
+	{"sure", "EDTQ4S8"},
+	{"sur", "EDTQ4"},
+	{"su", "EDTG"},
+	{"leasure.", "DHJP2WVNE9JJW"},
+	{"easure.", "CNGQ6XBJCMQ0"},
+	{"asure.", "C5SQAWK55R"},
+}
+
+var bigtest = testpair{
+	"Twas brillig, and the slithy toves",
+	"AHVP2WS0C9S6JV3CD5KJR831DSJ20X38CMG76V39EHM7J83MDXV6AWR",
+}
+
+func testEqual(t *testing.T, msg string, args ...any) bool {
+	t.Helper()
+	if args[len(args)-2] != args[len(args)-1] {
+		t.Errorf(msg, args...)
+		return false
+	}
+	return true
+}
+
+func TestEncode(t *testing.T) {
+	for _, p := range pairs {
+		got := EncodeToString([]byte(p.decoded))
+		testEqual(t, "Encode(%q) = %q, want %q", p.decoded, got, p.encoded)
+		dst := AppendEncode([]byte("lead"), []byte(p.decoded))
+		testEqual(t, `AppendEncode("lead", %q) = %q, want %q`, p.decoded, string(dst), "lead"+p.encoded)
+	}
+}
+
+func TestEncoder(t *testing.T) {
+	for _, p := range pairs {
+		bb := &strings.Builder{}
+		encoder := NewEncoder(bb)
+		encoder.Write([]byte(p.decoded))
+		encoder.Close()
+		testEqual(t, "Encode(%q) = %q, want %q", p.decoded, bb.String(), p.encoded)
+	}
+}
+
+func TestEncoderBuffering(t *testing.T) {
+	input := []byte(bigtest.decoded)
+	for bs := 1; bs <= 12; bs++ {
+		bb := &strings.Builder{}
+		encoder := NewEncoder(bb)
+		for pos := 0; pos < len(input); pos += bs {
+			end := pos + bs
+			if end > len(input) {
+				end = len(input)
+			}
+			n, err := encoder.Write(input[pos:end])
+			testEqual(t, "Write(%q) gave error %v, want %v", input[pos:end], err, error(nil))
+			testEqual(t, "Write(%q) gave length %v, want %v", input[pos:end], n, end-pos)
+		}
+		err := encoder.Close()
+		testEqual(t, "Close gave error %v, want %v", err, error(nil))
+		testEqual(t, "Encoding/%d of %q = %q, want %q", bs, bigtest.decoded, bb.String(), bigtest.encoded)
+	}
+}
+
+func TestDecode(t *testing.T) {
+	for _, p := range pairs {
+		dbuf := make([]byte, DecodedLen(len(p.encoded)))
+		count, err := decode(dbuf, []byte(p.encoded))
+		testEqual(t, "Decode(%q) = error %v, want %v", p.encoded, err, error(nil))
+		testEqual(t, "Decode(%q) = length %v, want %v", p.encoded, count, len(p.decoded))
+		testEqual(t, "Decode(%q) = %q, want %q", p.encoded, string(dbuf[0:count]), p.decoded)
+
+		dbuf, err = DecodeString(p.encoded)
+		testEqual(t, "DecodeString(%q) = error %v, want %v", p.encoded, err, error(nil))
+		testEqual(t, "DecodeString(%q) = %q, want %q", p.encoded, string(dbuf), p.decoded)
+
+		// XXX: https://github.com/gnolang/gno/issues/1570
+		dst, err := AppendDecode(append([]byte(nil), []byte("lead")...), []byte(p.encoded))
+		testEqual(t, "AppendDecode(%q) = error %v, want %v", p.encoded, err, error(nil))
+		testEqual(t, `AppendDecode("lead", %q) = %q, want %q`, p.encoded, string(dst), "lead"+p.decoded)
+
+		dst2, err := AppendDecode(dst[:0:len(p.decoded)], []byte(p.encoded))
+		testEqual(t, "AppendDecode(%q) = error %v, want %v", p.encoded, err, error(nil))
+		testEqual(t, `AppendDecode("", %q) = %q, want %q`, p.encoded, string(dst2), p.decoded)
+		// XXX: https://github.com/gnolang/gno/issues/1569
+		// old used &dst2[0] != &dst[0] as a check.
+		if len(dst) > 0 && len(dst2) > 0 && cap(dst2) != len(p.decoded) {
+			t.Errorf("unexpected capacity growth: got %d, want %d", cap(dst2), len(p.decoded))
+		}
+	}
+}
+
+// A minimal variation on strings.Reader.
+// Here, we return a io.EOF immediately on Read if the read has reached the end
+// of the reader. It's used to simplify TestDecoder.
+type stringReader struct {
+	s string
+	i int64
+}
+
+func (r *stringReader) Read(b []byte) (n int, err error) {
+	if r.i >= int64(len(r.s)) {
+		return 0, io.EOF
+	}
+	n = copy(b, r.s[r.i:])
+	r.i += int64(n)
+	if r.i >= int64(len(r.s)) {
+		return n, io.EOF
+	}
+	return
+}
+
+func TestDecoder(t *testing.T) {
+	for _, p := range pairs {
+		decoder := NewDecoder(&stringReader{p.encoded, 0})
+		dbuf := make([]byte, DecodedLen(len(p.encoded)))
+		count, err := decoder.Read(dbuf)
+		if err != nil && err != io.EOF {
+			t.Fatal("Read failed", err)
+		}
+		testEqual(t, "Read from %q = length %v, want %v", p.encoded, count, len(p.decoded))
+		testEqual(t, "Decoding of %q = %q, want %q", p.encoded, string(dbuf[0:count]), p.decoded)
+		if err != io.EOF {
+			_, err = decoder.Read(dbuf)
+		}
+		testEqual(t, "Read from %q = %v, want %v", p.encoded, err, io.EOF)
+	}
+}
+
+type badReader struct {
+	data   []byte
+	errs   []error
+	called int
+	limit  int
+}
+
+// Populates p with data, returns a count of the bytes written and an
+// error.  The error returned is taken from badReader.errs, with each
+// invocation of Read returning the next error in this slice, or io.EOF,
+// if all errors from the slice have already been returned.  The
+// number of bytes returned is determined by the size of the input buffer
+// the test passes to decoder.Read and will be a multiple of 8, unless
+// badReader.limit is non zero.
+func (b *badReader) Read(p []byte) (int, error) {
+	lim := len(p)
+	if b.limit != 0 && b.limit < lim {
+		lim = b.limit
+	}
+	if len(b.data) < lim {
+		lim = len(b.data)
+	}
+	for i := range p[:lim] {
+		p[i] = b.data[i]
+	}
+	b.data = b.data[lim:]
+	err := io.EOF
+	if b.called < len(b.errs) {
+		err = b.errs[b.called]
+	}
+	b.called++
+	return lim, err
+}
+
+// TestIssue20044 tests that decoder.Read behaves correctly when the caller
+// supplied reader returns an error.
+func TestIssue20044(t *testing.T) {
+	badErr := errors.New("bad reader error")
+	testCases := []struct {
+		r       badReader
+		res     string
+		err     error
+		dbuflen int
+	}{
+		// Check valid input data accompanied by an error is processed and the error is propagated.
+		{
+			r:   badReader{data: []byte("d1jprv3fexqq4v34"), errs: []error{badErr}},
+			res: "helloworld", err: badErr,
+		},
+		// Check a read error accompanied by input data consisting of newlines only is propagated.
+		{
+			r:   badReader{data: []byte("\n\n\n\n\n\n\n\n"), errs: []error{badErr, nil}},
+			res: "", err: badErr,
+		},
+		// Reader will be called twice.  The first time it will return 8 newline characters.  The
+		// second time valid base32 encoded data and an error.  The data should be decoded
+		// correctly and the error should be propagated.
+		{
+			r:   badReader{data: []byte("\n\n\n\n\n\n\n\nd1jprv3fexqq4v34"), errs: []error{nil, badErr}},
+			res: "helloworld", err: badErr, dbuflen: 8,
+		},
+		// Reader returns invalid input data (too short) and an error.  Verify the reader
+		// error is returned.
+		{
+			r:   badReader{data: []byte("c"), errs: []error{badErr}},
+			res: "", err: badErr,
+		},
+		// Reader returns invalid input data (too short) but no error.  Verify io.ErrUnexpectedEOF
+		// is returned.
+		// NOTE(thehowl): I don't think this should applyto us?
+		/* {
+			r:   badReader{data: []byte("c"), errs: []error{nil}},
+			res: "", err: io.ErrUnexpectedEOF,
+		},*/
+		// Reader returns invalid input data and an error.  Verify the reader and not the
+		// decoder error is returned.
+		{
+			r:   badReader{data: []byte("cu"), errs: []error{badErr}},
+			res: "", err: badErr,
+		},
+		// Reader returns valid data and io.EOF.  Check data is decoded and io.EOF is propagated.
+		{
+			r:   badReader{data: []byte("csqpyrk1"), errs: []error{io.EOF}},
+			res: "fooba", err: io.EOF,
+		},
+		// Check errors are properly reported when decoder.Read is called multiple times.
+		// decoder.Read will be called 8 times, badReader.Read will be called twice, returning
+		// valid data both times but an error on the second call.
+		{
+			r:   badReader{data: []byte("dhjp2wvne9jjwc9g"), errs: []error{nil, badErr}},
+			res: "leasure.10", err: badErr, dbuflen: 1,
+		},
+		// Check io.EOF is properly reported when decoder.Read is called multiple times.
+		// decoder.Read will be called 8 times, badReader.Read will be called twice, returning
+		// valid data both times but io.EOF on the second call.
+		{
+			r:   badReader{data: []byte("dhjp2wvne9jjw"), errs: []error{nil, io.EOF}},
+			res: "leasure.", err: io.EOF, dbuflen: 1,
+		},
+		// The following two test cases check that errors are propagated correctly when more than
+		// 8 bytes are read at a time.
+		{
+			r:   badReader{data: []byte("dhjp2wvne9jjw"), errs: []error{io.EOF}},
+			res: "leasure.", err: io.EOF, dbuflen: 11,
+		},
+		{
+			r:   badReader{data: []byte("dhjp2wvne9jjwc9g"), errs: []error{badErr}},
+			res: "leasure.10", err: badErr, dbuflen: 11,
+		},
+		// Check that errors are correctly propagated when the reader returns valid bytes in
+		// groups that are not divisible by 8.  The first read will return 11 bytes and no
+		// error.  The second will return 7 and an error.  The data should be decoded correctly
+		// and the error should be propagated.
+		// NOTE(thehowl): again, this is on the assumption that this is padded, and it's not.
+		/* {
+			r:   badReader{data: []byte("dhjp2wvne9jjw"), errs: []error{nil, badErr}, limit: 11},
+			res: "leasure.", err: badErr,
+		}, */
+	}
+
+	for idx, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", idx, string(tc.res)), func(t *testing.T) {
+			input := tc.r.data
+			decoder := NewDecoder(&tc.r)
+			var dbuflen int
+			if tc.dbuflen > 0 {
+				dbuflen = tc.dbuflen
+			} else {
+				dbuflen = DecodedLen(len(input))
+			}
+			dbuf := make([]byte, dbuflen)
+			var err error
+			var res []byte
+			for err == nil {
+				var n int
+				n, err = decoder.Read(dbuf)
+				if n > 0 {
+					res = append(res, dbuf[:n]...)
+				}
+			}
+
+			testEqual(t, "Decoding of %q = %q, want %q", string(input), string(res), tc.res)
+			testEqual(t, "Decoding of %q err = %v, expected %v", string(input), err, tc.err)
+		})
+	}
+}
+
+// TestDecoderError verifies decode errors are propagated when there are no read
+// errors.
+func TestDecoderError(t *testing.T) {
+	for _, readErr := range []error{io.EOF, nil} {
+		input := "ucsqpyrk1u"
+		dbuf := make([]byte, DecodedLen(len(input)))
+		br := badReader{data: []byte(input), errs: []error{readErr}}
+		decoder := NewDecoder(&br)
+		n, err := decoder.Read(dbuf)
+		testEqual(t, "Read after EOF, n = %d, expected %d", n, 0)
+		if _, ok := err.(CorruptInputError); !ok {
+			t.Errorf("Corrupt input error expected.  Found %T", err)
+		}
+	}
+}
+
+// TestReaderEOF ensures decoder.Read behaves correctly when input data is
+// exhausted.
+func TestReaderEOF(t *testing.T) {
+	for _, readErr := range []error{io.EOF, nil} {
+		input := "MZXW6YTB"
+		br := badReader{data: []byte(input), errs: []error{nil, readErr}}
+		decoder := NewDecoder(&br)
+		dbuf := make([]byte, DecodedLen(len(input)))
+		n, err := decoder.Read(dbuf)
+		testEqual(t, "Decoding of %q err = %v, expected %v", input, err, error(nil))
+		n, err = decoder.Read(dbuf)
+		testEqual(t, "Read after EOF, n = %d, expected %d", n, 0)
+		testEqual(t, "Read after EOF, err = %v, expected %v", err, io.EOF)
+		n, err = decoder.Read(dbuf)
+		testEqual(t, "Read after EOF, n = %d, expected %d", n, 0)
+		testEqual(t, "Read after EOF, err = %v, expected %v", err, io.EOF)
+	}
+}
+
+func TestDecoderBuffering(t *testing.T) {
+	for bs := 1; bs <= 12; bs++ {
+		decoder := NewDecoder(strings.NewReader(bigtest.encoded))
+		buf := make([]byte, len(bigtest.decoded)+12)
+		var total int
+		var n int
+		var err error
+		for total = 0; total < len(bigtest.decoded) && err == nil; {
+			n, err = decoder.Read(buf[total : total+bs])
+			total += n
+		}
+		if err != nil && err != io.EOF {
+			t.Errorf("Read from %q at pos %d = %d, unexpected error %v", bigtest.encoded, total, n, err)
+		}
+		testEqual(t, "Decoding/%d of %q = %q, want %q", bs, bigtest.encoded, string(buf[0:total]), bigtest.decoded)
+	}
+}
+
+func TestDecodeCorrupt(t *testing.T) {
+	testCases := []struct {
+		input  string
+		offset int // -1 means no corruption.
+	}{
+		{"", -1},
+		{"iIoOlL", -1},
+		{"!!!!", 0},
+		{"uxp10", 0},
+		{"x===", 1},
+		{"AA=A====", 2},
+		{"AAA=AAAA", 3},
+		// Much fewer cases compared to Go as there are much fewer cases where input
+		// can be "corrupted".
+	}
+	for _, tc := range testCases {
+		dbuf := make([]byte, DecodedLen(len(tc.input)))
+		_, err := Decode(dbuf, []byte(tc.input))
+		if tc.offset == -1 {
+			if err != nil {
+				t.Error("Decoder wrongly detected corruption in", tc.input)
+			}
+			continue
+		}
+		switch err := err.(type) {
+		case CorruptInputError:
+			testEqual(t, "Corruption in %q at offset %v, want %v", tc.input, int(err), tc.offset)
+		default:
+			t.Error("Decoder failed to detect corruption in", tc)
+		}
+	}
+}
+
+func TestBig(t *testing.T) {
+	n := 3*1000 + 1
+	raw := make([]byte, n)
+	const alpha = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	for i := 0; i < n; i++ {
+		raw[i] = alpha[i%len(alpha)]
+	}
+	encoded := new(bytes.Buffer)
+	w := NewEncoder(encoded)
+	nn, err := w.Write(raw)
+	if nn != n || err != nil {
+		t.Fatalf("Encoder.Write(raw) = %d, %v want %d, nil", nn, err, n)
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatalf("Encoder.Close() = %v want nil", err)
+	}
+	decoded, err := io.ReadAll(NewDecoder(encoded))
+	if err != nil {
+		t.Fatalf("io.ReadAll(NewDecoder(...)): %v", err)
+	}
+
+	if !bytes.Equal(raw, decoded) {
+		var i int
+		for i = 0; i < len(decoded) && i < len(raw); i++ {
+			if decoded[i] != raw[i] {
+				break
+			}
+		}
+		t.Errorf("Decode(Encode(%d-byte string)) failed at offset %d", n, i)
+	}
+}
+
+func testStringEncoding(t *testing.T, expected string, examples []string) {
+	for _, e := range examples {
+		buf, err := DecodeString(e)
+		if err != nil {
+			t.Errorf("Decode(%q) failed: %v", e, err)
+			continue
+		}
+		if s := string(buf); s != expected {
+			t.Errorf("Decode(%q) = %q, want %q", e, s, expected)
+		}
+	}
+}
+
+func TestNewLineCharacters(t *testing.T) {
+	// Each of these should decode to the string "sure", without errors.
+	examples := []string{
+		"EDTQ4S8",
+		"EDTQ4S8\r",
+		"EDTQ4S8\n",
+		"EDTQ4S8\r\n",
+		"EDTQ4S\r\n8",
+		"EDT\rQ4S\n8",
+		"edt\nq4s\r8",
+		"edt\nq4s8",
+		"EDTQ4S\n8",
+	}
+	testStringEncoding(t, "sure", examples)
+}
+
+func BenchmarkEncode(b *testing.B) {
+	data := make([]byte, 8192)
+	buf := make([]byte, EncodedLen(len(data)))
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		Encode(buf, data)
+	}
+}
+
+func BenchmarkEncodeToString(b *testing.B) {
+	data := make([]byte, 8192)
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		EncodeToString(data)
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	data := make([]byte, EncodedLen(8192))
+	Encode(data, make([]byte, 8192))
+	buf := make([]byte, 8192)
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		Decode(buf, data)
+	}
+}
+
+func BenchmarkDecodeString(b *testing.B) {
+	data := EncodeToString(make([]byte, 8192))
+	b.SetBytes(int64(len(data)))
+	for i := 0; i < b.N; i++ {
+		DecodeString(data)
+	}
+}
+
+/* TODO: rewrite without using goroutines
+func TestBufferedDecodingSameError(t *testing.T) {
+	testcases := []struct {
+		prefix            string
+		chunkCombinations [][]string
+		expected          error
+	}{
+		// Normal case, this is valid input
+		{"helloworld", [][]string{
+			{"D1JP", "RV3F", "EXQQ", "4V34"},
+			{"D1JPRV3FEXQQ4V34"},
+			{"D1J", "PRV", "3FE", "XQQ", "4V3", "4"},
+			{"D1JPRV3FEXQQ4V", "34"},
+		}, nil},
+
+		// Normal case, this is valid input
+		{"fooba", [][]string{
+			{"CSQPYRK1"},
+			{"CSQPYRK", "1"},
+			{"CSQPYR", "K1"},
+			{"CSQPY", "RK1"},
+			{"CSQPY", "RK", "1"},
+			{"CSQPY", "RK1"},
+			{"CSQP", "YR", "K1"},
+		}, nil},
+
+		// NOTE: many test cases have been removed as we don't return ErrUnexpectedEOF.
+	}
+
+	for _, testcase := range testcases {
+		for _, chunks := range testcase.chunkCombinations {
+			pr, pw := io.Pipe()
+
+			// Write the encoded chunks into the pipe
+			go func() {
+				for _, chunk := range chunks {
+					pw.Write([]byte(chunk))
+				}
+				pw.Close()
+			}()
+
+			decoder := NewDecoder(pr)
+			back, err := io.ReadAll(decoder)
+
+			if err != testcase.expected {
+				t.Errorf("Expected %v, got %v; case %s %+v", testcase.expected, err, testcase.prefix, chunks)
+			}
+			if testcase.expected == nil {
+				testEqual(t, "Decode from NewDecoder(chunkReader(%v)) = %q, want %q", chunks, string(back), testcase.prefix)
+			}
+		}
+	}
+}
+*/
+
+func TestEncodedLen(t *testing.T) {
+	type test struct {
+		n    int
+		want int64
+	}
+	tests := []test{
+		{0, 0},
+		{1, 2},
+		{2, 4},
+		{3, 5},
+		{4, 7},
+		{5, 8},
+		{6, 10},
+		{7, 12},
+		{10, 16},
+		{11, 18},
+	}
+	// check overflow
+	tests = append(tests, test{(math.MaxInt-4)/8 + 1, 1844674407370955162})
+	tests = append(tests, test{math.MaxInt/8*5 + 4, math.MaxInt})
+	for _, tt := range tests {
+		if got := EncodedLen(tt.n); int64(got) != tt.want {
+			t.Errorf("EncodedLen(%d): got %d, want %d", tt.n, got, tt.want)
+		}
+	}
+}
+
+func TestDecodedLen(t *testing.T) {
+	type test struct {
+		n    int
+		want int64
+	}
+	tests := []test{
+		{0, 0},
+		{2, 1},
+		{4, 2},
+		{5, 3},
+		{7, 4},
+		{8, 5},
+		{10, 6},
+		{12, 7},
+		{16, 10},
+		{18, 11},
+	}
+	// check overflow
+	tests = append(tests, test{math.MaxInt/5 + 1, 1152921504606846976})
+	tests = append(tests, test{math.MaxInt, 5764607523034234879})
+	for _, tt := range tests {
+		if got := DecodedLen(tt.n); int64(got) != tt.want {
+			t.Errorf("DecodedLen(%d): got %d, want %d", tt.n, got, tt.want)
+		}
+	}
+}

--- a/vendored/gno.land/p/nt/cford32/v0/doc.gno
+++ b/vendored/gno.land/p/nt/cford32/v0/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package cford32 implements a modified base32 encoding based on Douglas
+// Crockford's base32 encoding.
+package cford32

--- a/vendored/gno.land/p/nt/cford32/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/cford32/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/cford32/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/markdown/sanitize/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/markdown/sanitize/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/markdown/sanitize/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/markdown/sanitize/v0/sanitize.gno
+++ b/vendored/gno.land/p/nt/markdown/sanitize/v0/sanitize.gno
@@ -1,0 +1,1753 @@
+// Package sanitize provides input-cleaning primitives and safe-emit
+// builders for each markdown lexical slot. Realm authors wrap user-
+// supplied strings with these helpers before flowing them into rendered
+// markdown output. Each helper targets one specific slot (link text,
+// heading text, URL href, table cell, HTML attribute, fenced code block,
+// blockquote, footnote definition, link-reference definition, etc.) and
+// neutralizes the bytes that would otherwise let user content break out
+// of that slot or inject new top-level structure.
+//
+// Pick the right helper from the table under "Picking the right helper"
+// below, then wrap each user-supplied argument exactly once at the call
+// site (see "The audit rule").
+//
+// # Wrap once
+//
+// Most escapers and safe-emit builders in this package are NOT
+// idempotent — applying them twice re-escapes bytes the first pass
+// added (`\*` becomes `\\\*`, `&amp;` becomes `&amp;amp;`, a fenced
+// block gets re-fenced). Wrap each user-derived string with at most
+// one sanitize.* call. Block and BlockRich are exceptions —
+// idempotent by design — but the at-most-once rule is still the
+// safest default. See the "Idempotence classes" enumeration below
+// for the full breakdown.
+//
+// Some markdown-builder packages (e.g. p/moul/md) sanitize the args of
+// specific helpers internally — see each builder's package doc for the
+// per-helper contract. If the builder sanitizes for you, pass the raw
+// user input; if it doesn't, wrap the input with the right sanitize.*
+// helper at the call site.
+//
+// # Picking the right helper
+//
+// Match the helper to the slot the user content lands in:
+//
+//	slot                                       helper
+//	-------------------------------------------------------------
+//	[text](url)                                InlineText (text)
+//	# Heading text                             InlineText
+//	**bold** _italic_                          InlineText
+//	![alt](src)                                InlineText (alt)
+//	> [!NOTE] one-line title                   InlineText
+//	multi-paragraph post body                  Block
+//	multi-paragraph post body w/ rich block    BlockRich
+//	  structure (headings, lists, tables, etc.)
+//	multi-line blockquote (`> ` prefixed)      Blockquote
+//	multi-line blockquote w/ rich block body   BlockquoteRich
+//	[text](url "title")                        LinkTitle (title)
+//	| cell |                                   TableCell
+//	<gno-card caption="X">                     HTMLEscape
+//	<h5>X</h5>                                 HTMLEscape
+//	any URL going into ](X)                    URL
+//	any image src going into (X)               ImageURL
+//	`inline code` inside running prose         InlineCode
+//	multi-line fenced code block               CodeBlock
+//	multi-line fenced code with language tag   LanguageCodeBlock
+//	[^name]: footnote body                     FootnoteDefinition
+//	[label]: url "title" reference def         LinkReferenceDefinition
+//	r/sys/users handle                         UserName       (validator)
+//	g1.../gpub1... etc.                        BechString     (validator)
+//	footnote / LRD label / {#id} anchor name   FootnoteLabel  (validator)
+//	fenced-code language tag                   LanguageName   (validator)
+//	prefix arg to md.Nested                    NestedPrefix   (validator)
+//
+// # Invariants
+//
+// All helpers in this package are panic-free for any string input and
+// run in O(len(input)) time with bounded allocation.
+//
+// Idempotence classes:
+//
+//	Idempotent (calling twice == calling once):
+//	  StripBidiAndZeroWidth, NormalizeBreaks
+//	  UserName, BechString, FootnoteLabel, LanguageName, NestedPrefix
+//	  URL, ImageURL              (accept→identity; reject→"")
+//	  Block                      (bracket walker treats \[/\] as ordinary;
+//	                              line-leader escapes don't re-fire on
+//	                              already-escaped `\#` etc.)
+//	  BlockRich                  (TrimLeft/TrimRight + "\n\n" wrap is stable)
+//
+//	NOT idempotent — never wrap an already-sanitized string:
+//	  InlineText, LinkTitle, TableCell   (re-escape backslashes)
+//	  HTMLEscape                         (re-escapes `&` → `&amp;`)
+//	  Blockquote, BlockquoteRich         (re-prefixes `> `, nesting the quote each pass)
+//	  InlineCode, CodeBlock,
+//	  LanguageCodeBlock                  (wrap with a fence — calling twice double-wraps)
+//	  FootnoteDefinition,
+//	  LinkReferenceDefinition            (compose Block/InlineText/URL internally —
+//	                                      passing already-sanitized strings double-escapes)
+//
+//	CodeFence is pure: same inputs always give the same output.
+//
+// Validators (UserName / BechString / FootnoteLabel / LanguageName /
+// NestedPrefix) return either the cleaned input verbatim or "". They
+// never partially-sanitize: if the input doesn't match the slot's
+// charset/shape, the answer is rejection.
+//
+// # Composition rules
+//
+// Direct sanitize use (when emitting markdown without a builder package):
+//
+//	out := "# " + sanitize.InlineText(userTitle) + "\n\n" +
+//	       sanitize.Block(userBody)
+//	out += sanitize.Blockquote(userQuote)
+//	out += sanitize.LanguageCodeBlock(realmLang, userCode)
+//
+// Use with a builder package (e.g. p/moul/md): pass raw user input to
+// the builder helpers that sanitize internally — do NOT pre-wrap with
+// sanitize.*, or the input gets double-escaped (escapers are not
+// idempotent). See the builder's package doc for the per-helper
+// contract. For example, with p/moul/md:
+//
+//	md.Blockquote(userProse)                 // good — md.Blockquote sanitizes
+//	md.LanguageCodeBlock(realmLang, userCode) // good — sanitizes both args
+//	md.Link(userText, userURL)               // good — sanitizes both slots
+//
+//	md.Blockquote(sanitize.Block(userProse))         // BAD: double-wrap
+//	md.Link(sanitize.InlineText(t), sanitize.URL(u)) // BAD: double-wrap
+//
+// Wrong (across all callers):
+//
+//	sanitize.InlineText(sanitize.InlineText(s))   double-wrap (re-escape)
+//	sanitize.TableCell(sanitize.InlineText(s))    TableCell already calls InlineText
+//	sanitize.URL(sanitize.InlineText(href))       inline-escape backslash-escapes `.` `-` `_`
+//	                                              inside the URL, corrupting the host/path
+//	sanitize.Blockquote(sanitize.Blockquote(s))   double-wrap — outer would escape the
+//	                                              inner `> ` prefixes
+//	sanitize.Block(sanitize.BlockRich(s))         double-sanitize — strict Block re-escapes
+//	                                              the markers BlockRich preserved (headings,
+//	                                              lists, tables); BlockRich's rich structure
+//	                                              renders as literal text after Block escapes
+//	                                              its line-leaders
+//	sanitize.BlockRich(sanitize.Block(s))         pointless double-sanitize — Block already
+//	                                              escaped every line-leader to `\#`/`\>`/etc.;
+//	                                              BlockRich preserves the backslash escapes
+//	                                              as visible artifacts in user prose
+//	sanitize.Blockquote(sanitize.BlockRich(s))    double-sanitize — Blockquote's Block step
+//	                                              re-escapes the markers BlockRich preserved
+//	sanitize.BlockRich(sanitize.Blockquote(s))    nonsense — Blockquote already line-prefixed
+//	                                              with `> `; BlockRich expects raw user content
+//	sanitize.BlockquoteRich(sanitize.BlockRich(s)) double-wrap — Rich + Rich nests twice
+//	sanitize.BlockRich(sanitize.TableCell(s))     wrong slot — use TableCell for cell content,
+//	                                              BlockRich for multi-paragraph block content
+//	sanitize.TableCell(multiParagraphProse)       newlines fold to space silently; use a
+//	                                              non-table layout for multi-paragraph text
+//
+// # Threat model
+//
+// Sanitizers in this package defend against:
+//
+//   - bidi/zero-width injection: invisible characters that make
+//     displayed text disagree with stored bytes (e.g. an address `g1abc...`
+//     that renders as `g1xyz...`, or a username that visually collides
+//     with another). Stripped by StripBidiAndZeroWidth, which runs as
+//     the first step of every text-shaped helper.
+//   - line-ending homoglyphs: CR-only and Unicode separators
+//     (U+0085 NEL, U+2028, U+2029) that some renderers treat as line
+//     breaks. Folded uniformly.
+//   - markdown-structure injection: user content opening a heading,
+//     blockquote, list, code fence, link-reference def, setext underline,
+//     gnoweb extension delimiter, or GFM table row at document level.
+//     Strict Block escapes the line-leading `|` of any GFM table row so
+//     user content cannot inject `<table>`-shaped structure; permissive
+//     BlockRich preserves table rows so authors can compose `<table>`
+//     elements (gnoweb loads extension.Table per render_config.go).
+//   - HTML block type 1-5 absorption: CommonMark §4.6 HTML block types 1
+//     (`<script>`, `<pre>`, `<style>`, `<textarea>`), 2 (`<!--`), 3
+//     (`<?`), 4 (`<!UPPER`), and 5 (`<![CDATA[`) do NOT close on a blank
+//     line — they only close on a type-specific token (`</tag>`, `-->`,
+//     `?>`, `>`, `]]>`) or EOF. Without a defense, user content opening
+//     any of these would swallow realm chrome appended afterward. Both
+//     Block and BlockRich line-escape the openers (prepend `\`) so the
+//     block never opens; this defense is unconditional in both modes.
+//     Types 6 and 7 close on a blank line, so BlockRich's `\n\n`
+//     paragraph envelope already bounds them and no escape is needed.
+//   - realm-discipline boundary (caller's responsibility, not enforced):
+//     callers should emit realm chrome at flush-left column 0 around
+//     `BlockRich(user)`. Indented chrome (4+ leading spaces, list-item
+//     continuations, footnote-definition body, or an unclosed Type 1
+//     HTML tag in realm chrome before the call) can extend across blank
+//     lines into user content or vice versa. The sanitizer cannot
+//     defend against malformed realm chrome — only against user input.
+//   - footnote / link-reference namespace pollution: user content
+//     containing `[^name]` or `[text][label]` syntax that would otherwise
+//     resolve against realm-defined footnote definitions or link
+//     reference definitions elsewhere on the page. Block escapes the
+//     opening `[` in both shapes.
+//   - reference-link / footnote-ref / shortcut-ref collisions:
+//     `[text][label]`, `[^name]`, and bare `[label]` shortcut forms
+//     are ALL neutralized by Block's bracket walk, which preserves
+//     only inline `[text](url)` and `![alt](src)` syntax — everything
+//     else has both `[` and `]` backslash-escaped, so the parser sees
+//     literal text and can't resolve against realm-defined LRDs or
+//     footnote definitions.
+//   - multi-line LRD evasion: Block's walker recognises `[lab\nel]: url`
+//     across newlines (single `\n` OK, blank line aborts) and strips
+//     the whole region. `\]` inside the label is honored as an escaped
+//     literal, so `[label\]: url` is NOT treated as an LRD (renders as
+//     literal text).
+//   - URL scheme abuse: javascript:, data:text/html, vbscript:, blob:,
+//     protocol-relative //, mailto: with prefill phishing parameters.
+//     Allowlist-only (URL / ImageURL).
+//   - HTML attribute / element breakout: `"`, `<`, `>`, `&`, `'` inside
+//     HTML lexical slots. Handled by HTMLEscape.
+//   - CommonMark §2.3 NUL: replaced with U+FFFD by Block, InlineText,
+//     LinkTitle, TableCell, HTMLEscape, InlineCode, CodeBlock, and
+//     LanguageCodeBlock.
+//   - code-fence leakage: a user-opened ``` ``` ``` fence that runs to EOF
+//     with no closing fence, which would otherwise swallow every realm-
+//     emitted line that follows. Block auto-closes any open fence at EOF.
+//   - table-alignment drift: tabs inside table cells expanding to variable
+//     widths (1-4 spaces depending on column position) and shifting cell
+//     boundaries unpredictably. TableCell replaces tabs with single spaces.
+//
+// What this package does NOT do:
+//
+//   - It does not store state. Every helper is a pure function.
+//   - It does not validate semantic correctness. sanitize.URL accepts
+//     a syntactically valid https:// URL even if the host is malicious;
+//     URL reputation is a separate layer.
+//   - It does not enforce CSS containment. ImageURL admits data:image/*
+//     URIs on the assumption that the deploying gnoweb instance caps
+//     rendered image dimensions via CSS. Without that cap, a malicious
+//     image can blow out the page layout or exhaust memory.
+//   - It does not perform structural sandboxing of foreign markdown.
+//     If a realm concatenates an opaque markdown blob returned from a
+//     polymorphic interface (`someThing.Render()`), it needs a structural
+//     sandbox primitive (e.g. a `<gno-card>` extension), not just leaf
+//     sanitization.
+//
+// # When to use Block vs BlockRich
+//
+// Both are safe sanitizers; both run identical realm-binding defenses.
+// They differ in what user-authored block structure survives:
+//
+//   - Block — paragraph-shaped only. Escapes `#`, `>`, list markers,
+//     `---`/`***`/`___` thematic breaks, and `===`/`---` setext
+//     underlines. Use for leaf slots — footnote definition bodies,
+//     table cells, blockquote bodies (Blockquote uses Block), single-
+//     paragraph prose, any slot where richer structure has no benefit
+//     or where richer structure could visually impersonate realm chrome.
+//
+//   - BlockRich — full-richness. Preserves user-authored headings,
+//     lists, quotes, HR, setext. Use for user content the realm intends
+//     to compose with full block-level structure, typically inside a
+//     sandbox container (`<gno-card>`, `<gno-foreign>`) or a CSS-demoted
+//     region. BlockRich's qualifying-setext defense prevents the
+//     cross-boundary attack (user content reaching back to promote
+//     realm chrome to a heading), but inner-heading visual containment
+//     is the realm's CSS responsibility. gnoweb does not yet ship CSS
+//     rules that demote headings inside sandbox containers — until they
+//     land, BlockRich + sandbox renders inner headings at literal size.
+//
+// Do NOT compose Block and BlockRich in either direction. Pick one
+// helper at the right level.
+//
+// # Extending
+//
+// A new helper added to this package MUST:
+//
+//  1. Be panic-free for any string input.
+//  2. Strip bidi+zero-width before any other transform (so display
+//     equals storage end-to-end).
+//  3. Declare its idempotence class in the table above.
+//  4. Document the markdown / HTML lexical slot it targets.
+//  5. Reject rather than partially-sanitize when input is structurally
+//     invalid (return "" — never half-process an address or URL).
+//  6. Pick exactly one of the two return-value contracts and stick to
+//     it: escapers always return a transformed string and never reject
+//     (any input is OK — the transformation makes it safe); validators
+//     return the cleaned input verbatim on accept or "" on reject and
+//     never half-process. Mixing the contracts within one helper is a
+//     bug — callers can't reason about whether "" means "input was
+//     already empty" or "input was rejected".
+package sanitize
+
+import (
+	"chain/markdown"
+	"html"
+	"strings"
+)
+
+// ----- Re-exports of the public chain/markdown natives -----
+//
+// These are general-purpose data-hygiene primitives, not markdown-specific.
+// The other helpers in this package call them internally, so realms emitting
+// markdown rarely need to call them directly. Reach for these when you have
+// a non-markdown use case — e.g. normalizing a username before storage,
+// canonicalizing a search query, or stripping invisible characters from
+// any user string that will be displayed or compared.
+
+// StripBidiAndZeroWidth removes Unicode bidi controls and zero-width
+// characters (U+200B-D, U+200E-F, U+202A-E, U+2066-9, U+FEFF) from s.
+// Use it when storing or comparing user-supplied strings outside of a
+// markdown context — for example, before saving a display name to state,
+// or before hashing a search query. Idempotent: calling twice gives the
+// same result.
+//
+// Thin wrapper over chain/markdown.StripBidiAndZeroWidth.
+func StripBidiAndZeroWidth(s string) string {
+	return markdown.StripBidiAndZeroWidth(s)
+}
+
+// NormalizeBreaks unifies CR-LF and lone CR to LF (CommonMark §2.2 line
+// endings only — does NOT touch U+2028/U+2029). Use it when comparing
+// or hashing user input that may have been authored on different
+// platforms (Windows CRLF vs. Unix LF), so equivalent strings normalize
+// to the same bytes. Idempotent.
+//
+// Thin wrapper over chain/markdown.NormalizeBreaks.
+func NormalizeBreaks(s string) string {
+	return markdown.NormalizeBreaks(s)
+}
+
+// ----- Escapers -----
+
+// InlineText prepares an arbitrary user string for an INLINE markdown
+// slot — anywhere the rendered output stays on a single line and lives
+// inside a larger markdown construct.
+//
+// Use for:
+//   - link text:        [InlineText(label)](url)
+//   - heading text:     # InlineText(title)
+//   - bold/italic body: **InlineText(name)**
+//   - image alt text:   ![InlineText(alt)](src)
+//   - single-line block-context slots:
+//     > [!NOTE] InlineText(title)
+//     > Author: InlineText(name)
+//
+// Multi-paragraph prose belongs in Block, not InlineText. InlineText
+// folds every newline to a single space (so paragraph structure is
+// erased) and escapes inline-active CommonMark punctuation:
+//
+//	\ * _ [ ] ( ) ~ > - + . ! ` # < &
+//
+// Two characters are intentionally NOT escaped:
+//
+//   - `|` — only meaningful in GFM table rows. Leaving it literal here
+//     lets TableCell (which calls InlineText then escapes `|` itself)
+//     avoid double-escaping pipes into `\\|`.
+//   - `=` — only meaningful as a setext heading underline, which is a
+//     line-level construct. Escaping `=` inline would mangle expressions
+//     like `x = 1` for no benefit.
+//
+// Not idempotent (see package doc).
+func InlineText(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	s = markdown.NormalizeBreaks(s)       // CM §2.2 \r\n / \r → \n
+	s = foldNewlinesAndSeparators(s, ' ') // \n + NEL + U+2028/U+2029 → space
+	return markdown.EscapeInline(s)
+}
+
+// Block prepares user content for a top-level BLOCK markdown context
+// where paragraphs, line breaks, code blocks, and other block structure
+// should survive — but where the content must NOT be able to inject
+// new top-level constructs (headings, lists, blockquotes,
+// link-reference definitions, setext underlines, gnoweb extension
+// delimiters, GFM table rows).
+//
+// Output shape: every non-empty result begins AND ends with "\n\n" —
+// CM §4.8 blank lines on both sides — so user content is guaranteed
+// to occupy its own paragraph(s), isolated from any realm chrome that
+// precedes OR follows it. This bounds CM §4.6 HTML block types 6 and
+// 7 (`<div>`, `<table>`, `<form>`, arbitrary `<foo>` tags) which
+// close on a blank line and are NOT escaped in any mode, and it
+// defeats first-line setext promotion (`===`/`---`) that strict-mode
+// escapes miss when the previous line is blank in the user input but
+// non-blank in the concatenated realm output. Empty input (or input
+// that strips entirely, e.g. a lone LRD) returns "" — no envelope is
+// emitted.
+//
+// Use for any multi-paragraph user-supplied prose that the realm
+// concatenates into its rendered output:
+//   - post bodies, comments, replies
+//   - profile bios, About sections
+//   - proposal descriptions, governance motions
+//   - changelog entries, release notes
+//
+// What Block does with each kind of attacker input:
+//
+//	User attempt                                          | Block's response
+//	------------------------------------------------------|----------------------------------------------------
+//	  --- preserved verbatim ---                          |
+//	[text](url) inline link, ![alt](src) image            | preserved verbatim
+//	------------------------------------------------------|----------------------------------------------------
+//	  --- escaped / stripped / folded ---                 |
+//	# heading at line-start                               | escaped → literal `# heading`
+//	> quoted at line-start                                | escaped → literal `>`
+//	- item, * item, + item, 1. item at line-start         | escaped
+//	---, ***, ___ (3+) at line-start                      | escaped
+//	=== or --- on its own line after non-blank text       | escaped (no setext promotion of the line above)
+//	<gno-card>, <gno-columns>, any <gno-…>/</gno-…> at    | escaped (wildcard match) → literal text
+//	  line-start                                          |
+//	| a | b | GFM table row (line-leading `|`)            | escaped → literal `| a | b |`
+//	<!--, <script>, <pre>, <style>, <textarea>, <?…?>,    | escaped (\<…) → literal text;
+//	  <!DOCTYPE…>, <![CDATA[…]]> at line-start            |   blocks goldmark from opening a
+//	  (CM §4.6 HTML block types 1-5)                      |   blank-line-NON-terminating HTML block
+//	[text][realm-label] ref-link USE                      | both bracket pairs escaped → \[text\]\[realm-label\]
+//	[^name] footnote-ref                                  | both brackets escaped → \[^name\]
+//	[label] bare shortcut-ref                             | both brackets escaped → \[label\]
+//	[label]: url link-reference definition                | whole region stripped (incl. multi-line label
+//	  (incl. [lab\nel]: url multi-line)                   |   `[lab\nel]: url` and any title continuation)
+//	[label\]: url (backslash-escaped `]`)                 | NOT stripped; brackets escaped → paragraph text
+//	code fence opened without close                       | autoclosed at end of input
+//	NUL byte (\x00)                                       | replaced with U+FFFD
+//	U+2028 / U+2029 / U+0085 (NEL)                        | folded to `\n`
+//	bidi/zero-width controls                              | stripped
+//
+// COMPOSITION GOTCHA: Block's EOF fence-autoclose appends a final
+// fence line. If you wrap Block's output with a line-prefixing
+// builder like md.Blockquote (which prepends `> ` per line) or
+// md.Nested, that closing fence becomes a prefixed line. The output
+// is still safe (the fence still closes correctly) but may render
+// awkwardly. If pixel-perfect output matters, strip a trailing blank
+// fence line after Block.
+//
+// Why backslash and not a space for `<gno-…>` lines: gnoweb's
+// extension parsers call `util.TrimLeftSpace` on the line before tag
+// matching, which would strip a leading space and let the tag match
+// anyway. A leading `\` survives the trim (only ASCII whitespace +
+// form-feed are stripped) and is consumed by the inline escape phase
+// before Type-7 HTML block detection can fire (Type-7 requires the
+// first non-whitespace char to be `<`).
+//
+// Inline emphasis, code spans, inline links, and soft line breaks
+// within a paragraph are PRESERVED — users can format. Pipes that
+// are NOT at line-start stay literal so prose can still write things
+// like `a | b`.
+//
+// Idempotent: Block(Block(s)) is byte-identical to Block(s). The
+// bracket walker strips LRDs on the first pass; remaining `[`/`]`
+// outside inline-link/image spans are escaped to `\[`/`\]`, and
+// already-escaped brackets are preserved on subsequent passes
+// (pass-2 backslash-parity tracking). Still, wrap each user-supplied
+// string exactly once — chained sanitization adds no value and
+// burns gas.
+func Block(s string) string {
+	s = markdown.NormalizeBreaks(s)
+	s = markdown.StripBidiAndZeroWidth(s)
+	s = replaceNULWithFFFD(s)
+	s = markdown.EscapeBlockHazards(s)
+	// Symmetric "\n\n" envelope — same pattern BlockRich uses for the
+	// same reasons (see BlockRich docstring "Cross-paragraph safety").
+	// Strict mode escapes most line-leading hazards (setext, GFM table
+	// row, CM §4.6 HTML types 1-5, list/heading/HR markers), but two
+	// hazards remain that only a blank-line break can close:
+	//
+	//   - CM §4.6 HTML block types 6 and 7 (`<div>`, `<table>`,
+	//     `<form>`, arbitrary `<foo>` tags) are NOT escaped in any mode
+	//     — they close on a blank line per CM. Without a trailing
+	//     "\n\n", a `<div>` at the end of user content extends into
+	//     appended realm chrome.
+	//
+	//   - First-line setext: strict mode's setext escape only fires
+	//     when the previous line is non-blank IN THE USER'S INPUT.
+	//     A user whose first line is `===` slips past, and concatenated
+	//     after `chrome\n` would promote chrome to H1. The leading
+	//     "\n\n" forces a paragraph break so chrome cannot be merged.
+	//
+	// TrimLeft/TrimRight + fixed wrap is idempotent: Block(Block(s)) is
+	// byte-identical to Block(s). Empty post-escape result short-
+	// circuits to "" so realm concatenation doesn't leak stray blank
+	// lines for trivially empty inputs (e.g. lone LRD that strips
+	// entirely).
+	s = strings.TrimLeft(s, "\n")
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	return "\n\n" + s + "\n\n"
+}
+
+// BlockRich is the permissive counterpart of Block. Both are safe
+// sanitizers — the distinction is what markdown structure survives:
+//
+//   - Block escapes line-leading block markers (`#`, `>`, `-`, `*`,
+//     `+`, `1.`), thematic breaks (`---`/`***`/`___`), and setext
+//     underlines (`===`/`---`). User content becomes paragraph-shaped.
+//   - BlockRich PRESERVES all of those, so user content can compose
+//     headings, lists, quotes, horizontal rules, and setext-styled
+//     headings. Realm-binding defenses stay on (extension delimiters
+//     `<gno-…>`, the bracket walker for link / LRD / ref /
+//     footnote / shortcut, fence autoclose, NUL / bidi /
+//     Unicode-separator folding). GFM table-row openers are
+//     PRESERVED (see "Tables" below).
+//
+// Cross-paragraph safety: BlockRich's output begins with "\n\n"
+// AND ends with "\n\n" — CM §4.8 blank lines on both sides — so
+// user content is guaranteed to occupy its own paragraph(s),
+// isolated from anything the realm emits before OR after. Symmetric
+// isolation closes four distinct attacks:
+//
+//   - Cross-paragraph setext promotion (backward). User content
+//     `body\n===\nmore` concatenated after realm chrome (no
+//     trailing `\n`) would, without paragraph isolation, place
+//     "chrome\nbody" in one paragraph; the `===` setext underline
+//     would then promote that merged paragraph to H1, hijacking
+//     realm chrome. The leading "\n\n" forces a paragraph break.
+//
+//   - Cross-paragraph GFM table promotion (backward). User content
+//     beginning with `|---|---|` (a table delimiter row) would,
+//     without a blank-line break, retroactively turn the preceding
+//     realm line into a `<thead>`. Paragraph isolation prevents
+//     the table-detection scan from crossing the boundary.
+//
+//   - Cross-paragraph GFM table promotion (forward). Realm chrome
+//     appended immediately after BlockRich(user) that begins with
+//     `|---|` would, without a trailing blank line, extend user's
+//     last line into a table header and pull realm chrome into the
+//     body row. The trailing "\n\n" prevents the merge.
+//
+//   - Lazy paragraph continuation (forward). Paragraph-shaped realm
+//     chrome appended immediately after BlockRich(user) would, via
+//     CM §5.2, merge into user's trailing paragraph and inherit any
+//     block-level decoration it carries.
+//
+// First-line qualifying-setext escape (the
+// `neuterLeadingSetextIfQualifying` pre-pass) remains in place as
+// belt-and-suspenders: if the first non-blank line of user input
+// matches the CM §4.3 setext-underline pattern (run of `=` or `-`
+// with 0-3 leading spaces and only trailing whitespace), BlockRich
+// inserts `\` before the first `=`/`-`. This is redundant given
+// paragraph isolation but harmless and inexpensive.
+//
+// # Tables
+//
+// BlockRich preserves line-leading `|` so user content can
+// compose GFM tables:
+//
+//	| Header A | Header B |
+//	|----------|----------|
+//	| cell a   | cell b   |
+//
+// renders as a real `<table>` element. Strict Block continues to
+// escape line-leading `|` (each row becomes literal `\| a | b |`
+// text). When the realm authors the table itself and inserts user
+// content into a specific cell, use TableCell — NOT BlockRich —
+// to sanitize that cell value.
+//
+// What attacker input produces what (full table, same rows as Block
+// except where marked CHANGED):
+//
+//	User attempt                                  | BlockRich response
+//	----------------------------------------------|--------------------------------------------------
+//	  --- preserved (compose freely) ---          |
+//	# heading at line-start                       | preserved [CHANGED from Block]
+//	> quoted at line-start                        | preserved [CHANGED]
+//	- item, * item, + item, 1. item               | preserved [CHANGED]
+//	---, ***, ___ thematic break                  | preserved [CHANGED]
+//	=== or --- setext underline                   | preserved when preceded by user text;
+//	                                              | escaped (\===/\---) if the first non-blank
+//	                                              | line of input [CHANGED]
+//	| a | b | GFM table row (line-leading |)      | preserved → renders as <table> when followed by
+//	                                              | a delimiter row [CHANGED]
+//	[text](url), ![alt](src)                      | preserved verbatim [SAME]
+//	----------------------------------------------|--------------------------------------------------
+//	  --- escaped / stripped / folded ---         |
+//	<gno-card>, any <gno-…>/</gno-…> at line-start| escaped (wildcard match) [SAME]
+//	<!--, <script>, <pre>, <style>, <textarea>,   | escaped (\<…) [SAME] — Types 1-5 don't close
+//	  <?…?>, <!DOCTYPE…>, <![CDATA[…]]>           |   on blank lines, so `\n\n` envelope
+//	  at line-start (CM §4.6 HTML block types 1-5)|   doesn't isolate them; explicit escape
+//	[text][realm-label] ref-link USE              | both pairs escaped [SAME]
+//	[^name] footnote-ref                          | both brackets escaped [SAME]
+//	[label] bare shortcut-ref                     | both brackets escaped [SAME]
+//	[label]: url link-reference definition        | whole region stripped [SAME]
+//	[label\]: url (escaped `]`)                   | not stripped; brackets escaped [SAME]
+//	code fence opened without close               | autoclosed at end of input [SAME]
+//	NUL byte (\x00)                               | replaced with U+FFFD [SAME]
+//	U+2028 / U+2029 / U+0085 (NEL)                | folded to `\n` [SAME]
+//	bidi/zero-width controls                      | stripped [SAME]
+//
+// Use BlockRich for user content the realm intends to compose with
+// full block-level richness — typically inside a sandbox container
+// (`<gno-card>`, `<gno-foreign>`) or a CSS-demoted region where inner
+// headings render visually distinct from realm chrome. The realm
+// must own the visual containment: concatenating BlockRich's output
+// directly into a top-level page still lets the user write `# heading`
+// at document level. BlockRich's cross-boundary setext defense prevents
+// the worst case (reaching backwards into realm bytes), but visual
+// containment of inner headings is the realm's CSS responsibility.
+// gnoweb does not yet ship CSS rules that demote inner headings inside
+// `<gno-card>` / `<gno-foreign>` — until those rules land, realms
+// using BlockRich + a sandbox should be aware that inner headings
+// render at their literal level.
+//
+// Idempotent: BlockRich(BlockRich(s)) is byte-identical to
+// BlockRich(s). The TrimLeft-then-"\n\n"-prepend pattern strips
+// any leading newlines and reapplies exactly two, so the leading
+// shape is stable across passes; the qualifying-setext escape is
+// stable (a line beginning with `\` no longer matches the setext
+// pattern); and the bracket walker treats already-escaped
+// `\[`/`\]` as ordinary bytes. Empty input (or input that strips
+// to empty, e.g. a lone link-reference definition) returns "" —
+// realm concatenation doesn't get a stray blank line.
+// Still, wrap each user-supplied string exactly once — chained
+// sanitization adds no value and burns gas.
+//
+// Realm-discipline boundary: BlockRich defends user input against
+// every cross-paragraph attack listed above, but it CANNOT defend
+// against malformed REALM chrome. Specifically, callers should emit
+// realm chrome at flush-left column 0 around `BlockRich(user)`. If
+// the realm chrome BEFORE the call contains an unclosed CM §4.6
+// Type 1 HTML tag (`<script>`, `<pre>`, `<style>`, `<textarea>`),
+// the `\n\n` envelope does NOT close it (Type 1 closes only on the
+// matching close tag), and user-controlled `</tag>` content can
+// then prematurely terminate it. Indented chrome (4+ leading
+// spaces, list-item continuations, footnote-definition body) can
+// likewise extend across the envelope into user content. Keep
+// chrome flush-left and Type 1 tags closed within the chrome.
+//
+// PREVIEW: BlockquoteRich is currently the only in-tree caller of
+// BlockRich; the API and the `"\n\n"` output shape may evolve once
+// direct callers emerge.
+func BlockRich(s string) string {
+	s = markdown.NormalizeBreaks(s)
+	s = markdown.StripBidiAndZeroWidth(s)
+	s = replaceNULWithFFFD(s)
+	// Fold Unicode separators (U+2028, U+2029, U+0085 NEL) to '\n'
+	// BEFORE the setext-qualifying check. The native
+	// EscapeBlockHazardsRich also folds them internally, but the Gno
+	// helper below needs to see the folded form to correctly identify
+	// the first non-blank line — otherwise an attacker can hide the
+	// `===` setext underline behind a U+2028 / U+2029 / U+0085 and
+	// reach back to promote realm chrome above it.
+	s = foldSeparatorsToNewline(s)
+	s = neuterLeadingSetextIfQualifying(s)
+	s = markdown.EscapeBlockHazardsRich(s)
+	// Ensure the output BOTH starts AND ends with "\n\n" — CM §4.8
+	// blank lines on each side — so user content is GUARANTEED to
+	// occupy its own paragraph(s), isolated from anything the realm
+	// emits before OR after. Symmetric isolation closes four attacks:
+	//
+	//  Backward (closed by leading "\n\n"):
+	//   1. Deeper-setext: user content `body\n===\nmore` concatenated
+	//      after realm chrome (no trailing `\n`) would otherwise place
+	//      "chrome\nbody" in one paragraph; the `===` setext underline
+	//      would then promote that merged paragraph to H1, hijacking
+	//      realm chrome.
+	//   2. GFM table-row promotion: user content beginning with
+	//      `|---|---|` (a table delimiter row) would, without a blank-
+	//      line break, retroactively promote the preceding realm line
+	//      into a `<thead>` cell.
+	//
+	//  Forward (closed by trailing "\n\n"):
+	//   3. GFM table-row promotion in reverse: realm appending its own
+	//      chrome immediately after BlockRich(user), where chrome
+	//      starts with `|---|`, would extend user's last line into a
+	//      table header and pull realm chrome into the body row.
+	//   4. Lazy paragraph continuation: realm appending paragraph-
+	//      shaped chrome immediately after BlockRich(user) would, via
+	//      CM §5.2 lazy-continuation, merge into user's trailing
+	//      paragraph and inherit any block-level decoration it carries.
+	//
+	// `neuterLeadingSetextIfQualifying` above is now belt-and-
+	// suspenders for the first-line setext case: even if the blank-
+	// line guarantee were somehow defeated by an exotic CM consumer,
+	// the first-line escape still blocks the simplest setext shape.
+	//
+	// Empty post-escape result short-circuits to "" so realm
+	// concatenation doesn't leak stray blank lines for trivially empty
+	// inputs (e.g. a lone link-reference definition that strips
+	// entirely).
+	//
+	// Idempotency: TrimLeft and TrimRight strip ALL leading/trailing
+	// "\n"s, then the wrap adds exactly two on each side. Stable
+	// across passes.
+	s = strings.TrimLeft(s, "\n")
+	s = strings.TrimRight(s, "\n")
+	if s == "" {
+		return ""
+	}
+	return "\n\n" + s + "\n\n"
+}
+
+// foldSeparatorsToNewline replaces U+0085 NEL (0xC2 0x85),
+// U+2028 (0xE2 0x80 0xA8), and U+2029 (0xE2 0x80 0xA9) with '\n'.
+// Leaves '\n' bytes alone. Used by BlockRich so the qualifying-setext
+// pre-pass and the native both see the same line structure.
+func foldSeparatorsToNewline(s string) string {
+	// Cheap pre-check: only the 0xC2 / 0xE2 lead bytes can trigger.
+	if !containsAnyByteForFold(s) {
+		return s
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c == 0xC2 && i+1 < len(s) && s[i+1] == 0x85 {
+			out = append(out, '\n')
+			i += 2
+			continue
+		}
+		if c == 0xE2 && i+2 < len(s) && s[i+1] == 0x80 && (s[i+2] == 0xA8 || s[i+2] == 0xA9) {
+			out = append(out, '\n')
+			i += 3
+			continue
+		}
+		out = append(out, c)
+		i++
+	}
+	return string(out)
+}
+
+func containsAnyByteForFold(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0xC2 || s[i] == 0xE2 {
+			return true
+		}
+	}
+	return false
+}
+
+// neuterLeadingSetextIfQualifying scans s for the first non-blank
+// line. If that line matches the CommonMark §4.3 setext-underline
+// pattern (0-3 leading spaces, then a run of all `=` or all `-`,
+// then optional trailing whitespace, then `\n` or EOF), the function
+// returns s with a `\` inserted before the first `=`/`-`. Otherwise
+// returns s unchanged. The escape prevents a realm-emitted line above
+// BlockRich's output from being retroactively promoted to a heading.
+func neuterLeadingSetextIfQualifying(s string) string {
+	pos := 0
+	for pos < len(s) {
+		// Walk to the first non-whitespace byte of the current line.
+		lineStart := pos
+		i := pos
+		for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+			i++
+		}
+		if i >= len(s) || s[i] == '\n' {
+			// Blank line; advance to next line.
+			if i >= len(s) {
+				return s
+			}
+			pos = i + 1
+			continue
+		}
+		// First non-blank line. Check setext-underline shape.
+		if i-lineStart > 3 {
+			return s // 4+ leading spaces = indented code, not setext
+		}
+		c := s[i]
+		if c != '=' && c != '-' {
+			return s // not a setext underline candidate
+		}
+		j := i + 1
+		for j < len(s) && s[j] == c {
+			j++
+		}
+		for j < len(s) && (s[j] == ' ' || s[j] == '\t') {
+			j++
+		}
+		if j < len(s) && s[j] != '\n' {
+			return s // mixed content on the line — not setext
+		}
+		return s[:i] + "\\" + s[i:]
+	}
+	return s
+}
+
+// Blockquote wraps user content as a CommonMark blockquote: each line
+// of the cleaned content gets a "> " prefix so the renderer displays
+// it inside a `<blockquote>` element.
+//
+// Use for any multi-paragraph user-supplied text that the realm wants
+// to render as a quotation: cited posts, attached responses, error
+// snapshots that should visually stand out.
+//
+// The content is first cleaned by Block (bidi-strip, line-ending
+// normalize, NUL→U+FFFD, bracket walker for link/image/LRD spans,
+// block-marker escape, code-fence auto-close at EOF, Unicode-separator
+// fold). Block's "\n\n" cross-paragraph envelope is then stripped —
+// the `> ` marker creates the container boundary, so the envelope
+// would only line-prefix to empty `> ` lines top and bottom — and
+// every remaining line is prefixed with "> ". The user content can
+// still use inline emphasis, code spans, and nested fenced code blocks
+// inside the quote; what it cannot do is open new top-level structure
+// (heading, list, blockquote, GFM table row, etc.) or escape the
+// quote.
+//
+// Output shape — every non-empty result begins with "\n" and ends
+// with "\n\n" (same shape as BlockquoteRich):
+//
+//   - Leading "\n" guarantees a clean blockquote opener even when the
+//     realm concatenates `chrome + Blockquote(user)` without its own
+//     newline separator.
+//   - Trailing "\n\n" (blank line) cleanly ends the blockquote so a
+//     realm appending `Blockquote(user) + chrome` cannot pull chrome
+//     bytes into the quote via CommonMark §5.2 lazy continuation.
+//
+// Empty input (or input that strips entirely, e.g. a lone LRD)
+// returns "" — no blockquote is emitted.
+//
+// Composition gotcha: Block's EOF code-fence auto-close (added when
+// user content opens a ``` ``` ``` fence without closing it) becomes a
+// "> ```" line at the end of the blockquote. Goldmark parses this
+// correctly as the close of a fenced block inside the quote — the
+// output is structurally safe — but the markdown source looks unusual
+// to a human reviewer. If aesthetic output matters, ensure user
+// content closes its own fences.
+//
+// Not idempotent (see package doc): wraps with `> ` per line, so
+// calling twice double-wraps and the outer call's Block step escapes
+// the inner `>` prefixes.
+//
+// Do NOT compose with BlockRich in either direction:
+//   - Blockquote(BlockRich(s)) double-sanitizes: BlockRich preserves
+//     `#`/`>`/etc., then Blockquote's Block step escapes them again.
+//   - BlockRich(Blockquote(s)) doesn't make sense: Blockquote already
+//     line-prefixed with `> `; BlockRich expects raw user content.
+//
+// For a quoted body that can contain headings, lists, nested quotes,
+// or thematic breaks, use BlockquoteRich.
+func Blockquote(text string) string {
+	text = Block(text)
+	// Block wraps its output with "\n\n" on each side for cross-
+	// paragraph isolation. Inside a blockquote both wraps are redundant
+	// — the `> ` marker creates the container boundary — and they
+	// would line-prefix to two useless `> ` empty quoted lines top and
+	// bottom. Strip ALL leading and trailing "\n"s so the body starts
+	// and ends clean; this helper re-wraps with `\n` + body + `\n\n`
+	// below (same shape as BlockquoteRich).
+	text = strings.TrimLeft(text, "\n")
+	if text == "" {
+		return ""
+	}
+	text = strings.TrimRight(text, "\n")
+	if text == "" {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteByte('\n')
+	for _, line := range strings.Split(text, "\n") {
+		sb.WriteString("> ")
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+// BlockquoteRich is the permissive counterpart of Blockquote. Both
+// wrap user content as a CommonMark blockquote (each line prefixed
+// with `> `), but they differ in what block-level structure inside
+// the quote survives:
+//
+//   - Blockquote escapes line-leading block markers, so the quoted
+//     body is paragraph-shaped — `# x` inside a Blockquote stays a
+//     literal `#`.
+//   - BlockquoteRich PRESERVES line-leading block markers, so the
+//     quoted body can compose ATX headings, lists, thematic breaks,
+//     nested blockquotes (`> > nested`), and other block-level
+//     structure. Realm-binding defenses stay on (extension delimiters,
+//     GFM table-row openers, bracket walker, fence autoclose,
+//     NUL / bidi / Unicode-separator folding).
+//
+// Output shape — every non-empty result begins with "\n" and ends
+// with "\n\n":
+//
+//   - Leading "\n" guarantees a clean blockquote opener even when the
+//     realm concatenates `chrome + BlockquoteRich(user)` without its
+//     own newline separator. Without the leading "\n", chrome ending
+//     mid-line followed by "> quoted" would render `>` as literal
+//     paragraph text instead of opening a blockquote.
+//   - Trailing "\n\n" (blank line) cleanly ends the blockquote so a
+//     realm appending `BlockquoteRich(user) + chrome` cannot pull
+//     chrome bytes into the quote via CommonMark §5.2 lazy
+//     continuation. Without the trailing blank line, paragraph chrome
+//     immediately after BlockquoteRich would render inside the quote.
+//   - BlockRich's own leading "\n\n" (paragraph-isolation blank line)
+//     is stripped before line-prefixing — otherwise the output would
+//     carry one or two redundant empty `> ` quoted lines at the top.
+//     A single "\n" is then re-prepended at the BlockquoteRich
+//     boundary so `chrome + BlockquoteRich(user)` still lands the
+//     first `>` at column 0.
+//   - The cross-boundary setext defense BlockRich provides is
+//     redundant inside a blockquote: a setext underline inside `> `
+//     content can only promote a line in the same blockquote, never
+//     reach realm bytes (different CM container). BlockRich still
+//     applies it, harmlessly.
+//
+// What attacker input produces what (rows that differ from
+// Blockquote are marked CHANGED):
+//
+//	User attempt                                  | BlockquoteRich response
+//	----------------------------------------------|------------------------------------------------
+//	  --- preserved inside `> ` quote ---         |
+//	# heading                                     | preserved as `> # heading` [CHANGED]
+//	> nested quote                                | preserved as `> > nested quote` [CHANGED]
+//	- item, * item, + item, 1. item               | preserved as `> - item` etc. [CHANGED]
+//	---, ***, ___ thematic break                  | preserved [CHANGED]
+//	=== or --- setext underline                   | preserved when preceded by user text;
+//	                                              | escaped (\===/\---) if first non-blank
+//	                                              | line of input [CHANGED]
+//	| a | b | GFM table row (line-leading |)      | preserved → renders as <table> inside the
+//	                                              | blockquote when followed by a delimiter row [CHANGED]
+//	[text](url), ![alt](src)                      | preserved verbatim [SAME]
+//	----------------------------------------------|------------------------------------------------
+//	  --- escaped / stripped / folded ---         |
+//	<gno-card>, any <gno-…>/</gno-…> at line-start| escaped (wildcard match) [SAME]
+//	<!--, <script>, <pre>, <style>, <textarea>,   | escaped (\<…) [SAME] — CM §4.6 Types 1-5
+//	  <?…?>, <!DOCTYPE…>, <![CDATA[…]]>           |   don't close on blank lines; without escape
+//	  at line-start                               |   they would swallow chrome past the `> ` quote
+//	[text][realm-label] ref-link USE              | both pairs escaped [SAME]
+//	[^name] footnote-ref                          | both brackets escaped [SAME]
+//	[label] bare shortcut-ref                     | both brackets escaped [SAME]
+//	[label]: url link-reference definition        | whole region stripped [SAME]
+//	code fence opened without close               | autoclosed at end of input [SAME]
+//	NUL byte (\x00)                               | replaced with U+FFFD [SAME]
+//	U+2028 / U+2029 / U+0085 (NEL)                | folded to `\n` [SAME]
+//	bidi/zero-width controls                      | stripped [SAME]
+//
+// Use BlockquoteRich when the realm wants to render user content as
+// a quotation that itself reads like authored markdown — the visual
+// CSS containment of `<blockquote>` already demotes inner headings
+// relative to realm chrome, so the "inner headings need a sandbox"
+// caveat that applies to BlockRich at top level does not apply here.
+//
+// Not idempotent: like Blockquote, calling twice double-wraps —
+// `BlockquoteRich(BlockquoteRich(s))` produces `> > content`,
+// nesting the quote a level deeper each pass.
+//
+// Empty input (or input that reduces to nothing after BlockRich,
+// e.g. a lone link-reference definition) returns "" — no blockquote
+// is emitted and neither the leading "\n" nor the trailing "\n\n"
+// shape applies.
+func BlockquoteRich(text string) string {
+	text = BlockRich(text)
+	// BlockRich wraps user content with "\n\n" on each side for
+	// cross-paragraph isolation. Inside a blockquote both wraps are
+	// redundant — the `> ` marker creates the container boundary —
+	// and they would line-prefix to two useless `> ` empty quoted
+	// lines top and bottom. Strip ALL leading and trailing "\n"s so
+	// the body starts and ends clean; this helper re-wraps with `\n`
+	// + body + `\n\n` below.
+	text = strings.TrimLeft(text, "\n")
+	if text == "" {
+		return ""
+	}
+	// Strip ALL trailing newlines so the loop produces exactly one
+	// `> line` per content line, then append `\n\n` at the end so the
+	// blockquote terminates cleanly (see "Output shape" above).
+	text = strings.TrimRight(text, "\n")
+	if text == "" {
+		return ""
+	}
+	var sb strings.Builder
+	// Leading "\n" so `chrome + BlockquoteRich(user)` cannot land the
+	// first `>` mid-line.
+	sb.WriteByte('\n')
+	for _, line := range strings.Split(text, "\n") {
+		sb.WriteString("> ")
+		sb.WriteString(line)
+		sb.WriteByte('\n')
+	}
+	// Trailing blank line so `BlockquoteRich(user) + chrome` cannot
+	// pull chrome into the quote via lazy continuation.
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+// LinkTitle prepares user content for a CommonMark link-title or
+// image-title slot — the optional quoted text after the URL in any of
+// these forms:
+//
+//	[text](url "TITLE")
+//	![alt](src "TITLE")
+//	[label]: url "TITLE"
+//
+// Escapes the inline-active set plus `"` and `'` (the title delimiters
+// that aren't already in the inline set; `(` and `)` are), so the
+// caller can choose any of the three title-quote styles safely.
+//
+// Pick the right helper for the slot — markdown title and HTML
+// attribute share the look but use different escape rules:
+//
+//	[text](url "X")              → LinkTitle      (markdown title)
+//	<a title="X">                → HTMLEscape     (HTML attribute)
+//	<h5>X</h5>                   → HTMLEscape     (HTML element body)
+//
+// Swapping HTMLEscape for LinkTitle is wrong: HTML's `&amp;` written
+// inside a markdown title renders as the literal characters `&amp;`.
+// Swapping LinkTitle for HTMLEscape is wrong: markdown's `\"` survives
+// into the rendered HTML as a literal backslash-quote.
+//
+// Not idempotent (see package doc).
+func LinkTitle(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	s = markdown.NormalizeBreaks(s)
+	s = foldNewlinesAndSeparators(s, ' ')
+	return markdown.EscapeTitle(s)
+}
+
+// TableCell prepares user content for a GFM table cell — the bytes
+// between two `|` column delimiters in a table row like
+// `| cell-a | cell-b | cell-c |`. An unescaped `|` inside cell
+// content would open a new column, letting a malicious user shift
+// every column to its right.
+//
+// On top of InlineText's behavior, TableCell:
+//   - escapes `|` to `\|` so user content can't end the cell early.
+//   - replaces tabs with single spaces. CommonMark expands tabs to
+//     the next multiple-of-4 column boundary (variable 1-4 spaces),
+//     which would shift the displayed cell-content width unpredictably
+//     and confuse table alignment.
+//
+// Not idempotent (see package doc).
+func TableCell(s string) string {
+	s = InlineText(s)
+	s = strings.ReplaceAll(s, "\t", " ")
+	s = strings.ReplaceAll(s, "|", `\|`)
+	return s
+}
+
+// HTMLEscape prepares user content for an HTML lexical slot inside
+// markdown — covers attribute values, element bodies, and HTML
+// comment bodies:
+//
+//	<gno-card type="..." caption="X">         attribute value
+//	<gno-alert title="X">                     attribute value
+//	<h5>X</h5>                                element body
+//	<details><summary>X</summary>...          element body
+//	<!-- X -->                                comment body (safe: `>`
+//	                                          becomes `&gt;`, so user
+//	                                          cannot inject `-->`)
+//
+// HTMLEscape escapes the union of attribute-breaking and body-breaking
+// characters (`<`, `>`, `&`, `"`, `'`), so one function safely serves
+// every HTML lexical context. Callers don't have to remember which
+// subset to use for which slot.
+//
+// Pick the right helper — markdown title and HTML attribute share
+// the look but use different escape rules:
+//
+//	[text](url "X")              → LinkTitle      (markdown title)
+//	<span title="X">             → HTMLEscape     (HTML attribute)
+//	<h5>X</h5>                   → HTMLEscape     (HTML element body)
+//
+// Swapping InlineText for HTMLEscape is wrong: markdown's backslash
+// escapes survive into the rendered HTML as literal `\*`. Swapping
+// LinkTitle for HTMLEscape is also wrong: `&amp;` written inside a
+// markdown title renders as the literal characters `&amp;`.
+//
+// Not idempotent (see package doc): calling twice produces
+// `&amp;` → `&amp;amp;`.
+func HTMLEscape(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	s = markdown.NormalizeBreaks(s)
+	s = foldNewlinesAndSeparators(s, ' ')
+	s = replaceNULWithFFFD(s)
+	return html.EscapeString(s)
+}
+
+// ----- URL filters -----
+
+// URL validates a URL for use as a link href, percent-encodes unsafe
+// bytes, and rejects anything outside the allowlist of schemes.
+//
+// Allowlist:
+//   - http, https
+//   - mailto (rejected if contains ?body= or &body= — prefill phishing)
+//   - any URL WITHOUT a scheme — relative paths (`/path`, `./rel`,
+//     `bare-path`), query-only (`?q=v`), fragment-only (`#anchor`).
+//     A `:` appearing inside the URL (e.g. `/path:foo`, `?q=a:b`) is
+//     NOT a scheme separator per RFC 3986 — only `:` immediately after
+//     a leading `[a-zA-Z][a-zA-Z0-9+.-]*` counts.
+//
+// Rejected (have an unknown scheme):
+//   - javascript:, data:, vbscript:, blob:, file:, etc.
+//   - `//host/...` (protocol-relative — tracking-pixel vector)
+//
+// Returns "" if the URL is empty after trim or fails the allowlist.
+func URL(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !linkSchemeAllowed(s) {
+		return ""
+	}
+	return markdown.PercentEncodeURL(s)
+}
+
+// ImageURL validates a URL for use as an image src. Kept separate from
+// URL — not a parameterized variant — because the allowlist shapes
+// differ qualitatively (data:image/* vs. mailto:) and a single boolean
+// flag would invite callers to pass the wrong default.
+//
+// Allowlist:
+//   - http, https
+//   - schemeless relative URLs starting with /, ./, or ..
+//     (rejects // protocol-relative — tracking-pixel vector)
+//   - data:image/svg+xml, data:image/png, data:image/jpeg,
+//     data:image/gif, data:image/webp
+//
+// Any other data: subtype is rejected — data:text/html etc. would
+// render as inline HTML and execute embedded scripts.
+//
+// DEPLOYMENT PRECONDITION: data: URIs encode the bytes of the image
+// directly into the markup, so a malicious sender can construct an
+// image whose pixel dimensions are arbitrarily large at minimal byte
+// cost. The deploying gnoweb instance MUST clamp rendered image
+// dimensions via CSS (e.g. `max-width: 100%; max-height: <bound>`).
+// Without that cap, a single image can blow out the page layout or
+// exhaust the browser's memory.
+//
+// Returns "" if the URL is empty after trim or fails the allowlist.
+func ImageURL(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if !imageSchemeAllowed(s) {
+		return ""
+	}
+	return markdown.PercentEncodeURL(s)
+}
+
+// ----- Validators -----
+
+// userNameCharsets builds the [2]uint64 bitmaps for the r/sys/users
+// charset: first [a-z], rest [a-z0-9_-]. Initialized once at package
+// init.
+var (
+	userNameFirstLo, userNameFirstHi           uint64
+	userNameRestLo, userNameRestHi             uint64
+	footnoteLabelFirstLo, footnoteLabelFirstHi uint64
+	footnoteLabelRestLo, footnoteLabelRestHi   uint64
+	langFirstLo, langFirstHi                   uint64
+	langRestLo, langRestHi                     uint64
+	bechHrpFirstLo, bechHrpFirstHi             uint64
+	bechHrpRestLo, bechHrpRestHi               uint64
+	bechDataFirstLo, bechDataFirstHi           uint64
+	bechDataRestLo, bechDataRestHi             uint64
+)
+
+func init() {
+	// UserName: first [a-z], rest [a-z0-9_-].
+	for c := byte('a'); c <= 'z'; c++ {
+		setBit(&userNameFirstLo, &userNameFirstHi, c)
+		setBit(&userNameRestLo, &userNameRestHi, c)
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		setBit(&userNameRestLo, &userNameRestHi, c)
+	}
+	setBit(&userNameRestLo, &userNameRestHi, '_')
+	setBit(&userNameRestLo, &userNameRestHi, '-')
+
+	// FootnoteLabel: [A-Za-z0-9_-] for both first and rest.
+	for c := byte('A'); c <= 'Z'; c++ {
+		setBit(&footnoteLabelFirstLo, &footnoteLabelFirstHi, c)
+		setBit(&footnoteLabelRestLo, &footnoteLabelRestHi, c)
+	}
+	for c := byte('a'); c <= 'z'; c++ {
+		setBit(&footnoteLabelFirstLo, &footnoteLabelFirstHi, c)
+		setBit(&footnoteLabelRestLo, &footnoteLabelRestHi, c)
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		setBit(&footnoteLabelFirstLo, &footnoteLabelFirstHi, c)
+		setBit(&footnoteLabelRestLo, &footnoteLabelRestHi, c)
+	}
+	for _, c := range []byte{'_', '-'} {
+		setBit(&footnoteLabelFirstLo, &footnoteLabelFirstHi, c)
+		setBit(&footnoteLabelRestLo, &footnoteLabelRestHi, c)
+	}
+
+	// LanguageName: [a-zA-Z0-9_+-] for both first and rest.
+	for c := byte('A'); c <= 'Z'; c++ {
+		setBit(&langFirstLo, &langFirstHi, c)
+		setBit(&langRestLo, &langRestHi, c)
+	}
+	for c := byte('a'); c <= 'z'; c++ {
+		setBit(&langFirstLo, &langFirstHi, c)
+		setBit(&langRestLo, &langRestHi, c)
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		setBit(&langFirstLo, &langFirstHi, c)
+		setBit(&langRestLo, &langRestHi, c)
+	}
+	for _, c := range []byte{'_', '+', '-'} {
+		setBit(&langFirstLo, &langFirstHi, c)
+		setBit(&langRestLo, &langRestHi, c)
+	}
+
+	// Bech HRP (when prefix==""): [a-z], 1-16 chars.
+	for c := byte('a'); c <= 'z'; c++ {
+		setBit(&bechHrpFirstLo, &bechHrpFirstHi, c)
+		setBit(&bechHrpRestLo, &bechHrpRestHi, c)
+	}
+
+	// Bech data part: [a-z0-9], 6-90 chars.
+	for c := byte('a'); c <= 'z'; c++ {
+		setBit(&bechDataFirstLo, &bechDataFirstHi, c)
+		setBit(&bechDataRestLo, &bechDataRestHi, c)
+	}
+	for c := byte('0'); c <= '9'; c++ {
+		setBit(&bechDataFirstLo, &bechDataFirstHi, c)
+		setBit(&bechDataRestLo, &bechDataRestHi, c)
+	}
+}
+
+func setBit(lo, hi *uint64, c byte) {
+	if c < 64 {
+		*lo |= 1 << c
+	} else {
+		*hi |= 1 << (c - 64)
+	}
+}
+
+// UserName validates the r/sys/users-registration charset:
+// ^[a-z][a-z0-9]*([_-][a-z0-9]+)*$ length ≤ 64.
+//
+// The native MatchCharsetN enforces the leading-letter + tail-charset
+// shape and length bound; this helper also performs the bidi-strip
+// pre-pass. The "no consecutive [_-]" rule from r/sys/users is NOT
+// enforced here (it's a registration-policy rule, not a sanitization
+// concern — registrations go through r/sys/users itself).
+//
+// Returns the (bidi-stripped) input if valid, "" otherwise. On a ""
+// return, do not emit the user-mention markup at all (e.g. skip the
+// `[@user](/u/user)` link); falling back to the raw user-supplied
+// string would defeat the validation.
+func UserName(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	if markdown.MatchCharsetN(s, userNameFirstLo, userNameFirstHi, userNameRestLo, userNameRestHi, 1, 64) {
+		return s
+	}
+	return ""
+}
+
+// BechString validates a bech32-style address-like string.
+//
+// A bech32 string has the shape `<hrp>1<data>`: a human-readable
+// prefix (HRP) that names the family (e.g. `g` for gno addresses,
+// `gpub` for gno pubkeys, `cosmos` for cosmos addresses), the
+// separator character `1`, then a data part carrying the encoded
+// payload as lowercase alphanumerics.
+//
+// If prefix != "", requires s to start with prefix+"1" exactly, and the
+// data part to match ^[a-z0-9]{6,90}$. Use this when you know the
+// expected family:
+//
+//	sanitize.BechString(addr, "g")     // only g1...     (addresses)
+//	sanitize.BechString(pk,   "gpub")  // only gpub1...  (pubkeys)
+//
+// If prefix == "", accepts any reasonable bech32 shape:
+// ^[a-z]{1,16}1[a-z0-9]{6,90}$.
+//
+// Syntactic only — does NOT verify the bech32 checksum. Use a true
+// bech32 decoder if you need that. Returns the cleaned input on
+// accept, "" on reject; on "" return, do not emit the address-link
+// markup (the user-supplied bytes have failed shape validation and
+// should not appear unmodified in output).
+func BechString(s, prefix string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	if s == "" {
+		return ""
+	}
+	if prefix != "" {
+		// HRP must be lowercase ASCII letters.
+		for i := 0; i < len(prefix); i++ {
+			c := prefix[i]
+			if c < 'a' || c > 'z' {
+				return ""
+			}
+		}
+		need := prefix + "1"
+		if !strings.HasPrefix(s, need) {
+			return ""
+		}
+		data := s[len(need):]
+		if markdown.MatchCharsetN(data, bechDataFirstLo, bechDataFirstHi, bechDataRestLo, bechDataRestHi, 6, 90) {
+			return s
+		}
+		return ""
+	}
+	// prefix == "" — accept any 1-16 char lowercase HRP, then '1', then data.
+	sep := strings.IndexByte(s, '1')
+	if sep < 1 || sep > 16 {
+		return ""
+	}
+	hrp := s[:sep]
+	if !markdown.MatchCharsetN(hrp, bechHrpFirstLo, bechHrpFirstHi, bechHrpRestLo, bechHrpRestHi, 1, 16) {
+		return ""
+	}
+	data := s[sep+1:]
+	if markdown.MatchCharsetN(data, bechDataFirstLo, bechDataFirstHi, bechDataRestLo, bechDataRestHi, 6, 90) {
+		return s
+	}
+	return ""
+}
+
+// FootnoteLabel validates an identifier used as a footnote name, link-
+// reference-definition label, or {#id} anchor: ^[A-Za-z0-9_-]{1,64}$.
+// Strips bidi/zero-width first. Returns s if valid, "" otherwise.
+//
+// Use for every shape where a markdown identifier is treated as an
+// opaque key by the parser:
+//
+//   - footnote-definition labels:        [^FootnoteLabel(name)]: body
+//   - footnote-reference labels:         see [^FootnoteLabel(name)]
+//   - link-reference-definition labels:  [FootnoteLabel(label)]: url
+//   - reference-link USE labels:         [text][FootnoteLabel(label)]
+//   - goldmark auto-anchor {#id}:        # Heading {#FootnoteLabel(id)}
+//
+// The shared validator name reflects the shared charset and shared
+// security goal — keep untrusted bytes out of any parser-managed
+// identifier slot.
+//
+// On "" return, omit the footnote / LRD / anchor entirely rather than
+// emitting it with raw user bytes.
+func FootnoteLabel(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	if markdown.MatchCharsetN(s, footnoteLabelFirstLo, footnoteLabelFirstHi, footnoteLabelRestLo, footnoteLabelRestHi, 1, 64) {
+		return s
+	}
+	return ""
+}
+
+// LanguageName validates the language tag (a.k.a. "info string") for
+// a fenced code block — the `go` in:
+//
+//	```go
+//	fmt.Println("hi")
+//	```
+//
+// Charset: ^[a-zA-Z0-9_+-]{1,32}$ — letters, digits, `_`, `+`, `-`,
+// up to 32 bytes. Strips bidi/zero-width first.
+//
+// Returns the cleaned input if valid, "" otherwise. A "" return means
+// the caller should emit a language-less fence (``` without a tag)
+// rather than letting the user pick the syntax highlighter — which
+// could otherwise be used to inject newlines or block markers into
+// what becomes the opening fence line.
+func LanguageName(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	if markdown.MatchCharsetN(s, langFirstLo, langFirstHi, langRestLo, langRestHi, 1, 32) {
+		return s
+	}
+	return ""
+}
+
+// NestedPrefix validates a prefix string for line-prefixing builders
+// like md.Nested, which prepends `prefix` to every line of content
+// to render the content as a nested/indented sub-block.
+//
+// Allowed: any string matching `^[ \t>]*$` — spaces, tabs, blockquote
+// `>` chars only. Anything else (a `#`, a `-`, a letter) would let a
+// caller turn benign sub-content into a heading, list, or paragraph
+// at the wrong nesting level.
+//
+// Returns s if valid, "" otherwise. Strips bidi/zero-width first —
+// otherwise an invisible character hidden inside a `>` prefix would
+// be replicated on every nested content line, producing per-line
+// display-vs-storage divergence.
+//
+// On "" return, fall back to a known-safe prefix literal (e.g.
+// `"> "`) or skip the nesting entirely. Do not emit the raw
+// user-supplied prefix.
+func NestedPrefix(s string) string {
+	s = markdown.StripBidiAndZeroWidth(s)
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != ' ' && c != '\t' && c != '>' {
+			return ""
+		}
+	}
+	return s
+}
+
+// ----- Primitive -----
+
+// CodeFence returns a string of backticks long enough to wrap content
+// as a CommonMark fenced code block without the content's own backticks
+// closing the fence prematurely.
+//
+// Returned length N = max(minCount, longestBacktickRunInContent + 1).
+// Use N backticks both before and after the content:
+//
+//	fence := sanitize.CodeFence(userCode, 3)
+//	out += fence + "\n" + userCode + "\n" + fence + "\n"
+//
+// Typical minCount values:
+//   - 1 for inline code spans (`x`)
+//   - 3 for block fenced code (CommonMark §4.5 requires ≥3)
+//
+// `minCount < 1` is clamped to 1. Empty content returns
+// strings.Repeat("`", max(minCount, 1)). Never panics.
+//
+// Most realms should reach for InlineCode / CodeBlock /
+// LanguageCodeBlock below, which call CodeFence internally and emit
+// the full code block for you. Call CodeFence directly only when
+// you're rolling a custom fence emitter (e.g. a renderer that needs
+// the fence length but emits the body differently).
+func CodeFence(content string, minCount int) string {
+	return markdown.CodeFence(content, minCount)
+}
+
+// InlineCode wraps user content as a CommonMark inline code span — the
+// `code` in “ `code` “. Use for any user-derived token, identifier,
+// or short literal that should render in monospace inside running
+// prose: variable names, hashes, hex addresses, token symbols, error
+// codes, package paths, transaction IDs.
+//
+// Inline code spans cannot span lines (a `\n` inside the content would
+// end the span and leave the surrounding backticks as literal text),
+// so all line breaks — CR / CRLF / LF, NEL (U+0085), U+2028, U+2029 —
+// are folded to a single space. If you want each line of user content
+// on its own row, use CodeBlock instead.
+//
+// Behavior:
+//   - Bidi/zero-width controls are stripped (browsers honor bidi marks
+//     inside `<code>`, so leaving them would let stored bytes display
+//     as something different).
+//   - NUL is replaced with U+FFFD.
+//   - The wrapping fence is one backtick longer than the longest
+//     backtick run in the content, so internal backticks can never
+//     close the span prematurely.
+//   - A single space pad is added on each side when content starts or
+//     ends with “ ` “ or space, so leading/trailing backticks render
+//     literally rather than fusing with the fence (the renderer
+//     strips one space from each side per CommonMark spec).
+//
+// Empty input returns "" rather than a literal two-backtick string
+// (which CommonMark parses as text, not as an empty code span). If
+// you use InlineCode as link text and it returns "", omit the link
+// entirely.
+//
+// Not idempotent (see package doc): wraps with a fence, so calling
+// twice double-wraps.
+func InlineCode(content string) string {
+	content = markdown.StripBidiAndZeroWidth(content)
+	content = markdown.NormalizeBreaks(content)
+	content = foldNewlinesAndSeparators(content, ' ')
+	content = replaceNULWithFFFD(content)
+	if content == "" {
+		return ""
+	}
+	fence := markdown.CodeFence(content, 1)
+	pad := ""
+	if content[0] == '`' || content[0] == ' ' ||
+		content[len(content)-1] == '`' || content[len(content)-1] == ' ' {
+		pad = " "
+	}
+	return fence + pad + content + pad + fence
+}
+
+// CodeBlock wraps user content as a CommonMark fenced code block.
+// Use for any user-derived multi-line snippet that should render as a
+// code block: log excerpts, JSON dumps, error backtraces, config
+// snippets, posted code samples.
+//
+// Behavior:
+//   - Bidi/zero-width controls are stripped.
+//   - CR/CRLF line endings are normalized to LF; Unicode separators
+//     (NEL U+0085, U+2028, U+2029) are folded to LF for line-count
+//     consistency.
+//   - NUL is replaced with U+FFFD per CM §2.3.
+//   - The wrapping fence is at least 3 backticks (CM §4.5 minimum) and
+//     sized to outscan internal backticks — an attacker cannot embed
+//     a closing fence in the content.
+//
+// Empty content emits an empty fenced block ("```\n\n```\n"), which is
+// valid CommonMark and renders as an empty `<pre><code></code></pre>`.
+//
+// Not idempotent (see package doc).
+func CodeBlock(content string) string {
+	content = markdown.StripBidiAndZeroWidth(content)
+	content = markdown.NormalizeBreaks(content)
+	content = foldNewlinesAndSeparators(content, '\n')
+	content = replaceNULWithFFFD(content)
+	fence := markdown.CodeFence(content, 3)
+	return fence + "\n" + content + "\n" + fence + "\n"
+}
+
+// LanguageCodeBlock wraps user content as a fenced code block tagged
+// with a programming-language hint (the "info string" after the
+// opening fence, e.g. `go` in ```` ```go ````) so the renderer can
+// apply syntax highlighting.
+//
+// An invalid `language` tag silently falls back to a tagless fence —
+// the helper never returns an error or panics. If a realm author is
+// debugging "why is my Go highlighting gone?", the input failed the
+// language validator (charset ^[a-zA-Z0-9_+-]{1,32}$ after bidi-strip).
+// This fallback exists because an unvalidated tag could contain a
+// newline that injects content (e.g. a heading) onto what becomes the
+// opening fence line.
+//
+// Content is cleaned exactly as in CodeBlock (bidi-strip, CR/CRLF
+// normalize to LF, NEL/U+2028/U+2029 fold to LF, NUL→U+FFFD, fence
+// sized to outscan internal backticks).
+//
+// Not idempotent (see package doc).
+func LanguageCodeBlock(language, content string) string {
+	content = markdown.StripBidiAndZeroWidth(content)
+	content = markdown.NormalizeBreaks(content)
+	content = foldNewlinesAndSeparators(content, '\n')
+	content = replaceNULWithFFFD(content)
+	fence := markdown.CodeFence(content, 3)
+	lang := LanguageName(language) // "" on reject
+	return fence + lang + "\n" + content + "\n" + fence + "\n"
+}
+
+// ----- Reference-style definitions -----
+
+// FootnoteDefinition emits a GFM footnote definition — the
+// `[^name]: body` form that introduces a footnote whose body is rendered
+// in the page footer (or wherever the renderer chooses to place it).
+// Other parts of the markdown reference the footnote by writing
+// `[^name]` inline.
+//
+// Use for any realm-rendered footnote where the body text comes from
+// user input. The realm picks the footnote name (passed as `name`,
+// validated by FootnoteLabel — failure here returns ""); the user's
+// content goes in `text`, which is sanitized via Block.
+//
+// Contract:
+//   - `name`: passed raw, validated as a FootnoteLabel
+//     (^[A-Za-z0-9_-]{1,64}$). Reject → return "".
+//   - `text`: passed raw multi-paragraph user prose, cleaned via Block
+//     (bidi-strip, line-ending normalize, LRD strip, block-marker
+//     escape, ref-link USE escape, fence auto-close).
+//
+// Empty body → returns "" (a label without body is not a valid
+// footnote definition; the markdown would parse as a paragraph
+// containing the label).
+//
+// Output shape:
+//
+//	[^name]:
+//	    line 1 of body
+//	    line 2 of body
+//	    ...
+//
+// The label sits on its own line and each body line gets a 4-space
+// indent — the GFM continuation rule that keeps multi-paragraph body
+// text bound to the footnote rather than detaching as a new paragraph.
+//
+// Not idempotent (see package doc): composes Block internally; passing
+// already-sanitized body text double-escapes.
+func FootnoteDefinition(name, text string) string {
+	label := FootnoteLabel(name)
+	if label == "" {
+		return ""
+	}
+	// Block now wraps with "\n\n" on both sides for cross-paragraph
+	// isolation; inside a footnote-definition's 4-space-indented body
+	// the wrap would line-prefix to blank padding lines, so strip ALL
+	// leading and trailing "\n"s before continuation-indenting.
+	body := strings.Trim(Block(text), "\n")
+	if body == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("[^")
+	b.WriteString(label)
+	b.WriteString("]:\n")
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" {
+			b.WriteByte('\n')
+		} else {
+			b.WriteString("    ")
+			b.WriteString(line)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// LinkReferenceDefinition emits a CommonMark link reference definition
+// (CM §4.7) — the `[label]: url "title"` form that other parts of the
+// markdown reference by writing `[text][label]` or `[label]` (shortcut).
+//
+// Use for any realm-rendered LRD where the realm owns the label but
+// any of the URL or title come from user input. The user content for
+// the URL goes through URL (allowlist-based — reject → ""); the title
+// goes through LinkTitle (escape).
+//
+// Contract:
+//   - `label`: passed raw, validated as a FootnoteLabel
+//     (^[A-Za-z0-9_-]{1,64}$). Realms should choose a namespaced label
+//     using dashes (e.g. `r-myrealm-help`) so shortcut-reference
+//     invocations from user content can't collide with bare prose
+//     (`[help]`, `[click here]`). `/` is not in the FootnoteLabel
+//     charset; reject → return "".
+//   - `url`: passed raw, sanitized via URL. If URL rejects, the LRD is
+//     skipped (return "").
+//   - `title`: passed raw, sanitized via LinkTitle. Empty title → no
+//     title clause emitted.
+//
+// The output is framed with leading and trailing blank lines so that
+// the definition cannot accidentally fuse with adjacent paragraph
+// content into a setext underline or a continuation line.
+//
+// Not idempotent (see package doc).
+func LinkReferenceDefinition(label, url, title string) string {
+	lbl := FootnoteLabel(label)
+	if lbl == "" {
+		return ""
+	}
+	safeURL := URL(url)
+	if safeURL == "" {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\n[")
+	b.WriteString(lbl)
+	b.WriteString("]: ")
+	b.WriteString(safeURL)
+	if title != "" {
+		b.WriteString(" \"")
+		b.WriteString(LinkTitle(title))
+		b.WriteString("\"")
+	}
+	b.WriteString("\n\n")
+	return b.String()
+}
+
+// ----- internal helpers -----
+
+// linkSchemeAllowed returns true if s passes the URL helper's scheme
+// allowlist. See URL's doc for the policy.
+func linkSchemeAllowed(s string) bool {
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return true
+	}
+	if strings.HasPrefix(s, "mailto:") {
+		// Reject prefill phishing via ?body= or &body=.
+		if strings.Contains(s, "?body=") || strings.Contains(s, "&body=") {
+			return false
+		}
+		return true
+	}
+	if strings.HasPrefix(s, "//") {
+		// Protocol-relative — reject (tracking-pixel vector).
+		return false
+	}
+	// Any URL with an unknown scheme (RFC 3986: `^[a-zA-Z][a-zA-Z0-9+.-]*:`)
+	// is rejected — this blocks `javascript:`, `data:`, `vbscript:`, `blob:`,
+	// and anything else not handled above. URLs without a scheme are
+	// treated as relative and accepted (bare path, query-only, fragment).
+	if hasURLScheme(s) {
+		return false
+	}
+	return true
+}
+
+// hasURLScheme reports whether s begins with a scheme followed by ':'
+// per RFC 3986 (^[a-zA-Z][a-zA-Z0-9+.-]*:). A `:` appearing later in
+// the URL (e.g. `/path:foo` or `?q=a:b`) does not count.
+func hasURLScheme(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	c := s[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+		return false
+	}
+	for i := 1; i < len(s); i++ {
+		c := s[i]
+		if c == ':' {
+			return true
+		}
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') || c == '+' || c == '.' || c == '-') {
+			return false
+		}
+	}
+	return false
+}
+
+// imageSchemeAllowed returns true if s passes the ImageURL helper's
+// scheme allowlist. Tighter than linkSchemeAllowed: no mailto/tel,
+// only data:image/<subset>.
+func imageSchemeAllowed(s string) bool {
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		return true
+	}
+	if strings.HasPrefix(s, "//") {
+		return false
+	}
+	if strings.HasPrefix(s, "/") || strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+		return true
+	}
+	if strings.HasPrefix(s, "data:") {
+		// Only the curated image/* subset. CSS must enforce sizing.
+		for _, p := range []string{
+			"data:image/svg+xml",
+			"data:image/png",
+			"data:image/jpeg",
+			"data:image/gif",
+			"data:image/webp",
+		} {
+			if strings.HasPrefix(s, p) {
+				return true
+			}
+		}
+		return false
+	}
+	return false
+}
+
+// foldNewlinesAndSeparators replaces \n, U+0085 NEL, U+2028 LINE SEPARATOR,
+// U+2029 PARAGRAPH SEPARATOR with the given replacement byte (typically
+// space for inline-context helpers).
+//
+// NormalizeBreaks has already folded \r\n and \r to \n before this runs,
+// so \n is the canonical break byte to substitute.
+func foldNewlinesAndSeparators(s string, replacement byte) string {
+	if !needsSeparatorFold(s) {
+		return s
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c == '\n' {
+			out = append(out, replacement)
+			i++
+			continue
+		}
+		// U+0085 NEL: 0xC2 0x85
+		if c == 0xC2 && i+1 < len(s) && s[i+1] == 0x85 {
+			out = append(out, replacement)
+			i += 2
+			continue
+		}
+		// U+2028 (0xE2 0x80 0xA8) or U+2029 (0xE2 0x80 0xA9)
+		if c == 0xE2 && i+2 < len(s) && s[i+1] == 0x80 && (s[i+2] == 0xA8 || s[i+2] == 0xA9) {
+			out = append(out, replacement)
+			i += 3
+			continue
+		}
+		out = append(out, c)
+		i++
+	}
+	return string(out)
+}
+
+func needsSeparatorFold(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '\n' || c == 0xC2 || c == 0xE2 {
+			return true
+		}
+	}
+	return false
+}
+
+// replaceNULWithFFFD substitutes any NUL byte with the UTF-8 encoding
+// of U+FFFD REPLACEMENT CHARACTER per CM §2.3.
+func replaceNULWithFFFD(s string) string {
+	if !strings.ContainsRune(s, 0) {
+		return s
+	}
+	return strings.ReplaceAll(s, "\x00", "\ufffd")
+}

--- a/vendored/gno.land/p/nt/markdown/sanitize/v0/sanitize_test.gno
+++ b/vendored/gno.land/p/nt/markdown/sanitize/v0/sanitize_test.gno
@@ -1,0 +1,464 @@
+package sanitize
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestStripBidiAndZeroWidthRe(t *testing.T) {
+	// Re-export sanity check.
+	if got := StripBidiAndZeroWidth("a\u200Bb"); got != "ab" {
+		t.Errorf("re-export StripBidiAndZeroWidth failed: got %q", got)
+	}
+}
+
+func TestNormalizeBreaksRe(t *testing.T) {
+	if got := NormalizeBreaks("a\r\nb"); got != "a\nb" {
+		t.Errorf("re-export NormalizeBreaks failed: got %q", got)
+	}
+}
+
+func TestInlineText(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"a*b", `a\*b`},
+		{"a|b", "a|b"},                    // | NOT escaped
+		{"a=b", "a=b"},                    // = NOT escaped
+		{"line1\nline2", "line1 line2"},   // newline folded
+		{"line1\r\nline2", "line1 line2"}, // CRLF normalized then folded
+		{"a\u2028b", "a b"},               // U+2028 folded
+		{"a\u0085b", "a b"},               // NEL folded
+		{"a\u200Bb", "ab"},                // ZWSP stripped
+		{"hello *world*", `hello \*world\*`},
+	}
+	for _, c := range cases {
+		if got := InlineText(c.in); got != c.want {
+			t.Errorf("InlineText(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBlock(t *testing.T) {
+	// Block wraps every non-empty output with "\n\n" — CM §4.8 blank
+	// lines — on BOTH sides, so user content is paragraph-isolated
+	// from any realm chrome that precedes OR follows it. Bounds CM
+	// §4.6 HTML block types 6/7 (`<div>`, `<table>`, …) which are not
+	// escaped in any mode and would otherwise consume appended chrome.
+	cases := []struct{ in, want string }{
+		{"hello world\n", "\n\nhello world\n\n"},
+		{"# heading\n", "\n\n\\# heading\n\n"},
+		{"> quote\n", "\n\n\\> quote\n\n"},
+		{"| a | b |\n", "\n\n\\| a | b |\n\n"}, // GFM table-row escaped in strict mode
+		// CM §4.6 HTML block types 1-5 — escaped (blank-line-NON-terminating).
+		{"<script>x</script>\n", "\n\n\\<script>x</script>\n\n"},
+		{"<!-- comment -->\n", "\n\n\\<!-- comment -->\n\n"},
+		{"<?php x ?>\n", "\n\n\\<?php x ?>\n\n"},
+		{"<!DOCTYPE html>\n", "\n\n\\<!DOCTYPE html>\n\n"},
+		{"```\ncode\n", "\n\n```\ncode\n```\n\n"}, // fence auto-close at EOF
+		// Empty / strip-to-empty inputs short-circuit (no stray blank line).
+		{"[x]: y\n", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := Block(c.in)
+		if got != c.want {
+			t.Errorf("Block(%q) = %q, want %q", c.in, got, c.want)
+		}
+		// Idempotency: Block(Block(in)) must be byte-identical to
+		// Block(in) for every input in the table.
+		twice := Block(got)
+		if twice != got {
+			t.Errorf("Block not idempotent for %q: Block(once)=%q, Block(twice)=%q", c.in, got, twice)
+		}
+	}
+}
+
+func TestBlockRich(t *testing.T) {
+	// BlockRich wraps every non-empty output with "\n\n" — CM §4.8
+	// blank lines — on BOTH sides, so user content is paragraph-
+	// isolated from any realm chrome that precedes OR follows it.
+	cases := []struct{ in, want string }{
+		// Block-level markdown that Block escapes — preserved by BlockRich.
+		{"hello world\n", "\n\nhello world\n\n"},
+		{"# heading\n", "\n\n# heading\n\n"},
+		{"> quote\n", "\n\n> quote\n\n"},
+		{"- item\n", "\n\n- item\n\n"},
+		{"1. item\n", "\n\n1. item\n\n"},
+		{"---\n", "\n\n\\---\n\n"},                       // first-line setext-h2 → escaped by qualifying-setext pre-pass
+		{"***\n", "\n\n***\n\n"},                         // thematic break NOT setext-h2 — preserved
+		{"text\n===\n", "\n\ntext\n===\n\n"},             // deeper setext preserved (user-authored above)
+		{"body\n===\nmore\n", "\n\nbody\n===\nmore\n\n"}, // cross-paragraph backward attack: realm `chrome\n\nbody\n===\nmore` keeps realm in its own paragraph
+		// GFM tables PRESERVED in Rich mode.
+		{"| a | b |\n", "\n\n| a | b |\n\n"},
+		{"| H |\n|---|\n| a |\n", "\n\n| H |\n|---|\n| a |\n\n"}, // full table renders as <table>
+		// Realm-binding defenses STILL ON.
+		{"<gno-card>\n", "\n\n\\<gno-card>\n\n"},
+		// CM §4.6 HTML block types 1-5 — escaped in Rich mode too
+		// (defense is mode-independent).
+		{"<script>x</script>\n", "\n\n\\<script>x</script>\n\n"},
+		{"<!-- comment -->\n", "\n\n\\<!-- comment -->\n\n"},
+		{"<?php x ?>\n", "\n\n\\<?php x ?>\n\n"},
+		{"<!DOCTYPE html>\n", "\n\n\\<!DOCTYPE html>\n\n"},
+		{"[t][l]\n", "\n\n\\[t\\]\\[l\\]\n\n"},
+		{"[^name]\n", "\n\n\\[^name\\]\n\n"},
+		// LRD-only input strips to nothing; empty-after-escape short-
+		// circuits to "" so realm concatenation doesn't leak a stray
+		// blank line.
+		{"[x]: y\n", ""},
+		{"", ""}, // empty input → empty output, no stray blank line
+		{"```\ncode\n", "\n\n```\ncode\n```\n\n"},
+	}
+	for _, c := range cases {
+		got := BlockRich(c.in)
+		if got != c.want {
+			t.Errorf("BlockRich(%q) = %q, want %q", c.in, got, c.want)
+		}
+		// Idempotency: BlockRich(BlockRich(in)) must be byte-identical
+		// to BlockRich(in) for every input in the table.
+		twice := BlockRich(got)
+		if twice != got {
+			t.Errorf("BlockRich not idempotent for %q: BlockRich(once)=%q, BlockRich(twice)=%q", c.in, got, twice)
+		}
+	}
+}
+
+func TestBlockRich_LeadingBlankLineGuaranteed(t *testing.T) {
+	// Every non-empty result begins with "\n\n" so `chrome +
+	// BlockRich(user)` cannot place the user's first line in the same
+	// paragraph as the realm's last line (which would let a deeper
+	// `===` or `|---|` in user content retroactively promote realm
+	// chrome).
+	for _, in := range []string{"x", "x\n", "# h", "- i\n- j", "| a |\n|---|\n| 1 |"} {
+		got := BlockRich(in)
+		if got == "" {
+			continue
+		}
+		if !strings.HasPrefix(got, "\n\n") {
+			t.Errorf("BlockRich(%q) = %q; expected leading '\\n\\n'", in, got)
+		}
+	}
+}
+
+func TestBlockRich_TrailingBlankLineGuaranteed(t *testing.T) {
+	// Every non-empty result ends with "\n\n" so `BlockRich(user) +
+	// chrome` cannot extend user's last paragraph into the realm's
+	// next line (CM §5.2 lazy continuation, or a realm-supplied
+	// `|---|` row retroactively promoting user's last line into a
+	// `<thead>` header).
+	for _, in := range []string{"x", "x\n", "# h", "- i\n- j", "| H |\n|---|\n| a |"} {
+		got := BlockRich(in)
+		if got == "" {
+			continue
+		}
+		if !strings.HasSuffix(got, "\n\n") {
+			t.Errorf("BlockRich(%q) = %q; expected trailing '\\n\\n'", in, got)
+		}
+	}
+}
+
+func TestBlockquoteRich(t *testing.T) {
+	// BlockquoteRich strips BlockRich's leading "\n", line-prefixes
+	// each remaining line with "> ", and emits "\n" on both ends:
+	// leading "\n" prevents `chrome + BlockquoteRich(user)` from
+	// landing the first `>` mid-line; trailing "\n\n" (blank line)
+	// prevents `BlockquoteRich(user) + chrome` from pulling chrome
+	// into the quote via CM §5.2 lazy continuation.
+	cases := []struct{ name, in, want string }{
+		{"plain text", "hello world\n", "\n> hello world\n\n"},
+		{"atx heading preserved", "# heading\n", "\n> # heading\n\n"},
+		{"nested blockquote", "> nested\n", "\n> > nested\n\n"},
+		{"list item preserved", "- item\n", "\n> - item\n\n"},
+		{"ordered list preserved", "1. item\n", "\n> 1. item\n\n"},
+		{"first-line setext escaped", "---\n", "\n> \\---\n\n"},
+		{"deeper setext preserved", "text\n===\n", "\n> text\n> ===\n\n"},
+		{"thematic break asterisks preserved", "***\n", "\n> ***\n\n"},
+		// Realm-binding defenses still on.
+		{"gno extension escaped", "<gno-card>\n", "\n> \\<gno-card>\n\n"},
+		{"ref-link use escaped", "[t][l]\n", "\n> \\[t\\]\\[l\\]\n\n"},
+		{"footnote escaped", "[^name]\n", "\n> \\[^name\\]\n\n"},
+		// LRDs are stripped by BlockRich entirely; trimming the
+		// resulting bare "\n" leaves empty input and the helper
+		// returns "" without emitting a blockquote.
+		{"lrd alone strips to empty", "[x]: y\n", ""},
+		// Code fence autoclose at EOF lands inside the quote.
+		{"unclosed fence autoclosed", "```\ncode\n", "\n> ```\n> code\n> ```\n\n"},
+		// Multi-paragraph preserves the inner blank line (rendered
+		// as a quoted blank line `> \n`).
+		{"multi-paragraph preserves blank", "a\n\nb\n", "\n> a\n> \n> b\n\n"},
+		// Empty / blank-only input collapses cleanly to "".
+		{"empty input", "", ""},
+		// CRLF normalized through BlockRich.
+		{"crlf normalized", "a\r\nb\n", "\n> a\n> b\n\n"},
+		// NUL replaced with U+FFFD by BlockRich.
+		{"nul replaced", "x\x00y\n", "\n> x\uFFFDy\n\n"},
+		// Multiple trailing newlines collapse to the single trailing
+		// blank line shape — output never ends with more than `\n\n`.
+		{"multiple trailing newlines collapse", "foo\n\n\n", "\n> foo\n\n"},
+		// Internal tabs are preserved (BlockRich does not touch them).
+		{"internal tab preserved", "a\tb\n", "\n> a\tb\n\n"},
+		// Whitespace-only input still yields a blockquote (the user
+		// wrote literal spaces). The line-prefix loop emits `> ` plus
+		// the original two spaces.
+		{"whitespace-only input", "  ", "\n>   \n\n"},
+	}
+	for _, c := range cases {
+		got := BlockquoteRich(c.in)
+		if got != c.want {
+			t.Errorf("%s: BlockquoteRich(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestBlockquoteRich_DoubleWrapNestsQuote(t *testing.T) {
+	// Not idempotent: calling twice nests the quote one level
+	// deeper. The aggressive TrimRight in BlockquoteRich also
+	// collapses the inner trailing blank line, so the second pass
+	// produces a clean `> > foo` nesting (no `> ` quoted blank in
+	// the middle) plus the outer trailing blank line.
+	once := BlockquoteRich("foo\n")
+	twice := BlockquoteRich(once)
+	if want := "\n> > foo\n\n"; twice != want {
+		t.Errorf("BlockquoteRich(BlockquoteRich(%q)) = %q, want %q", "foo\n", twice, want)
+	}
+}
+
+func TestBlockquoteRich_LeadingNewlineGuaranteed(t *testing.T) {
+	// Every non-empty result starts with "\n" so realm concatenation
+	// like `chrome + BlockquoteRich(user)` doesn't place `>` mid-line.
+	for _, in := range []string{"x", "x\n", "# h", "- i\n- j"} {
+		got := BlockquoteRich(in)
+		if got == "" {
+			continue
+		}
+		if got[0] != '\n' {
+			t.Errorf("BlockquoteRich(%q) = %q; expected leading '\\n'", in, got)
+		}
+	}
+}
+
+func TestBlockquoteRich_TrailingBlankLineGuaranteed(t *testing.T) {
+	// Every non-empty result ends with "\n\n" so realm concatenation
+	// like `BlockquoteRich(user) + "more text"` doesn't pull "more
+	// text" into the quote via CM §5.2 lazy continuation.
+	for _, in := range []string{"x", "x\n", "# h", "- i\n- j", "para\n\nmore"} {
+		got := BlockquoteRich(in)
+		if got == "" {
+			continue
+		}
+		if !strings.HasSuffix(got, "\n\n") {
+			t.Errorf("BlockquoteRich(%q) = %q; expected trailing '\\n\\n'", in, got)
+		}
+	}
+}
+
+func TestBlockquoteRich_NoStrayEmptyQuotedLine(t *testing.T) {
+	// BlockRich's own leading "\n" must be stripped before
+	// line-prefixing — otherwise the output would start with a
+	// useless `> \n` empty quoted line.
+	got := BlockquoteRich("foo\n")
+	if strings.HasPrefix(got, "\n> \n") {
+		t.Errorf("BlockquoteRich leaked BlockRich's leading '\\n' as `> \\n`: %q", got)
+	}
+}
+
+func TestNeuterLeadingSetextIfQualifying(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{"leading-setext-h1", "===\nbody\n", "\\===\nbody\n"},
+		{"leading-setext-h2", "---\nbody\n", "\\---\nbody\n"},
+		{"leading-setext-indented", "   ===\nbody\n", "   \\===\nbody\n"},
+		{"leading-setext-indented-4", "    ===\nbody\n", "    ===\nbody\n"}, // indented code
+		{"leading-setext-trailing-ws", "===   \nbody\n", "\\===   \nbody\n"},
+		{"leading-setext-mixed-chars", "=-=-\nbody\n", "=-=-\nbody\n"},         // mixed; not setext
+		{"leading-setext-has-content", "=== text\nbody\n", "=== text\nbody\n"}, // mixed content
+		{"setext-deeper-untouched", "title\n===\nfoo\n", "title\n===\nfoo\n"},
+		{"leading-thematic-asterisk", "***\nbody\n", "***\nbody\n"}, // not setext, untouched
+		{"leading-thematic-underscore", "___\nbody\n", "___\nbody\n"},
+		{"leading-blank-then-setext", "\n===\nbody\n", "\n\\===\nbody\n"},
+		{"leading-blank-ws-then-setext", "   \n===\nbody\n", "   \n\\===\nbody\n"},
+		{"text-first", "hello\n===\n", "hello\n===\n"}, // text before === — user-authored
+		{"empty", "", ""},
+		{"all-blank", "   \n\n", "   \n\n"},
+		{"only-equals", "===", "\\==="},
+	}
+	for _, c := range cases {
+		if got := neuterLeadingSetextIfQualifying(c.in); got != c.want {
+			t.Errorf("%s: neuterLeadingSetextIfQualifying(%q) = %q, want %q", c.name, c.in, got, c.want)
+		}
+	}
+}
+
+func TestLinkTitle(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`he said "hi"`, `he said \"hi\"`},
+		{`it's nice`, `it\'s nice`},
+		{"line1\nline2", "line1 line2"},
+	}
+	for _, c := range cases {
+		if got := LinkTitle(c.in); got != c.want {
+			t.Errorf("LinkTitle(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTableCell(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain cell", "plain cell"},
+		{"a|b", `a\|b`},
+		{"a\tb", "a b"},
+		{"a*b|c", `a\*b\|c`},
+	}
+	for _, c := range cases {
+		if got := TableCell(c.in); got != c.want {
+			t.Errorf("TableCell(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestHTMLEscape(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{"<script>", "&lt;script&gt;"},
+		{`a & b`, "a &amp; b"},
+		{`"quoted"`, "&#34;quoted&#34;"},
+	}
+	for _, c := range cases {
+		if got := HTMLEscape(c.in); got != c.want {
+			t.Errorf("HTMLEscape(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"https://example.com/x", "https://example.com/x"},
+		{"http://example.com", "http://example.com"},
+		{"mailto:a@b.com", "mailto:a@b.com"},
+		{"mailto:a@b.com?body=phish", ""}, // prefill phishing rejected
+		{"//evil.com", ""},                // protocol-relative rejected
+		{"javascript:alert(1)", ""},       // bad scheme
+		{"/r/foo", "/r/foo"},              // relative
+		{"./local", "./local"},
+		{"#section", "#section"}, // fragment-only
+		{"", ""},
+		{"   ", ""},
+		{"https://a.com/path with space", "https://a.com/path%20with%20space"},
+	}
+	for _, c := range cases {
+		if got := URL(c.in); got != c.want {
+			t.Errorf("URL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestImageURL(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"https://example.com/img.png", "https://example.com/img.png"},
+		{"mailto:a@b.com", ""}, // mailto rejected for images
+		{"data:image/svg+xml,<svg/>", "data:image/svg+xml,%3Csvg/%3E"},
+		{"data:image/png;base64,XXX", "data:image/png;base64,XXX"},
+		{"data:text/html,<script>", ""}, // bad data subset
+		{"javascript:alert(1)", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := ImageURL(c.in); got != c.want {
+			t.Errorf("ImageURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestUserName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"alice", "alice"},
+		{"alice123", "alice123"},
+		{"alice_bob-cat", "alice_bob-cat"},
+		{"Alice", ""},  // uppercase first
+		{"1alice", ""}, // digit first
+		{"", ""},
+		{"a\u200Blice", "alice"}, // bidi stripped, then matches
+	}
+	for _, c := range cases {
+		if got := UserName(c.in); got != c.want {
+			t.Errorf("UserName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestBechString(t *testing.T) {
+	addrG := "g1abc123def456ghi789jkl012mno345p"
+	cases := []struct {
+		s, prefix string
+		want      string
+	}{
+		{addrG, "g", addrG},
+		{addrG, "", addrG},  // any prefix
+		{addrG, "gpub", ""}, // wrong prefix
+		{"gpub1abc123def456ghijklmn", "gpub", "gpub1abc123def456ghijklmn"},
+		{"gpub1abc123def456ghijklmn", "", "gpub1abc123def456ghijklmn"},
+		{"b1xyz789abc123def456", "", "b1xyz789abc123def456"}, // any-prefix mode allows b1...
+		{"g1ABC", "g", ""}, // uppercase rejected
+		{"x", "g", ""},
+		{"", "g", ""},
+	}
+	for _, c := range cases {
+		if got := BechString(c.s, c.prefix); got != c.want {
+			t.Errorf("BechString(%q,%q) = %q, want %q", c.s, c.prefix, got, c.want)
+		}
+	}
+}
+
+func TestFootnoteLabel(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"note1", "note1"},
+		{"Note_A-1", "Note_A-1"},
+		{"with space", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := FootnoteLabel(c.in); got != c.want {
+			t.Errorf("FootnoteLabel(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLanguageName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"go", "go"},
+		{"c++", "c++"},
+		{"python3", "python3"},
+		{"objective-c", "objective-c"},
+		{"with space", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := LanguageName(c.in); got != c.want {
+			t.Errorf("LanguageName(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNestedPrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"  ", "  "},
+		{"\t", "\t"},
+		{"> ", "> "},
+		{"> > ", "> > "},
+		{"## ", ""}, // markdown-active prefix rejected
+		{"- ", ""},
+	}
+	for _, c := range cases {
+		if got := NestedPrefix(c.in); got != c.want {
+			t.Errorf("NestedPrefix(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestCodeFence(t *testing.T) {
+	if got := CodeFence("```", 3); got != "````" {
+		t.Errorf("CodeFence: got %q, want %q", got, "````")
+	}
+	if got := CodeFence("", 3); got != "```" {
+		t.Errorf("CodeFence empty: got %q, want %q", got, "```")
+	}
+}

--- a/vendored/gno.land/p/nt/mux/v0/README.md
+++ b/vendored/gno.land/p/nt/mux/v0/README.md
@@ -1,0 +1,8 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+# mux
+
+Package `mux` provides a simple routing and rendering library for handling dynamic path-based requests in Gno contracts, similar to `http.ServeMux` in Go.

--- a/vendored/gno.land/p/nt/mux/v0/doc.gno
+++ b/vendored/gno.land/p/nt/mux/v0/doc.gno
@@ -1,0 +1,40 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package mux provides a simple routing and rendering library for handling dynamic path-based requests in Gno contracts.
+//
+// The `mux` package aims to offer similar functionality to `http.ServeMux` in Go, but for Gno's Render() requests.
+// It allows you to define routes with dynamic parts and associate them with corresponding handler functions for rendering outputs.
+//
+// Usage:
+// 1. Create a new Router instance using `NewRouter()` to handle routing and rendering logic.
+// 2. Register routes and their associated handler functions using the `Handle(route, handler)` method.
+// 3. Implement the rendering logic within the handler functions, utilizing the `Request` and `ResponseWriter` types.
+// 4. Use the `Render(path)` method to process a given path and execute the corresponding handler function to obtain the rendered output.
+//
+// Route Patterns:
+// Routes can include dynamic parts enclosed in braces, such as "users/{id}" or "hello/{name}". The `Request` object's `GetVar(key)`
+// method allows you to extract the value of a specific variable from the path based on routing rules.
+//
+// Example:
+//
+//	router := mux.NewRouter()
+//
+//	// Define a route with a variable and associated handler function
+//	router.HandleFunc("hello/{name}", func(res *mux.ResponseWriter, req *mux.Request) {
+//		name := req.GetVar("name")
+//		if name != "" {
+//			res.Write("Hello, " + name + "!")
+//		} else {
+//			res.Write("Hello, world!")
+//		}
+//	})
+//
+//	// Render the output for the "/hello/Alice" path
+//	output := router.Render("hello/Alice")
+//	// Output: "Hello, Alice!"
+//
+// Note: The `mux` package provides a basic routing and rendering mechanism for simple use cases. For more advanced routing features,
+// consider using more specialized libraries or frameworks.
+package mux

--- a/vendored/gno.land/p/nt/mux/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/mux/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/mux/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/mux/v0/handler.gno
+++ b/vendored/gno.land/p/nt/mux/v0/handler.gno
@@ -1,0 +1,26 @@
+package mux
+
+// Handler stores a route pattern with one of two handler shapes.
+// Fn (HandlerFunc, no rlm) is set by HandleFunc; FnRlm (HandlerFuncRlm,
+// rlm-aware non-crossing) is set by HandleFuncRlm. Exactly one is set
+// per route. RenderRlm dispatches FnRlm with the supplied rlm; Render
+// dispatches Fn and panics if the matched route was registered with
+// HandleFuncRlm (caller used the wrong dispatch method).
+type Handler struct {
+	Pattern string
+	Fn      HandlerFunc
+	FnRlm   HandlerFuncRlm
+}
+
+type HandlerFunc func(*ResponseWriter, *Request)
+
+// HandlerFuncRlm is the rlm-aware handler shape — non-crossing
+// (`_ int, rlm realm` first params) so callers thread cur as data
+// for the handler to forward to downstream crossing functions.
+type HandlerFuncRlm func(_ int, rlm realm, res *ResponseWriter, req *Request)
+
+type ErrHandlerFunc func(*ResponseWriter, *Request) error
+
+type NotFoundHandler func(*ResponseWriter, *Request)
+
+// TODO: AutomaticIndex

--- a/vendored/gno.land/p/nt/mux/v0/helpers.gno
+++ b/vendored/gno.land/p/nt/mux/v0/helpers.gno
@@ -1,0 +1,5 @@
+package mux
+
+func defaultNotFoundHandler(res *ResponseWriter, req *Request) {
+	res.Write("404")
+}

--- a/vendored/gno.land/p/nt/mux/v0/request.gno
+++ b/vendored/gno.land/p/nt/mux/v0/request.gno
@@ -1,0 +1,54 @@
+package mux
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Request represents an incoming request.
+type Request struct {
+	// Path is request path name.
+	//
+	// Note: use RawPath to obtain a raw path with query string.
+	Path string
+
+	// RawPath contains a whole request path, including query string.
+	RawPath string
+
+	// HandlerPath is handler rule that matches a request.
+	HandlerPath string
+
+	// Query contains the parsed URL query parameters.
+	Query url.Values
+}
+
+// GetVar retrieves a variable from the path based on routing rules.
+func (r *Request) GetVar(key string) string {
+	handlerParts := strings.Split(r.HandlerPath, "/")
+	reqParts := strings.Split(r.Path, "/")
+	reqIndex := 0
+	for handlerIndex := 0; handlerIndex < len(handlerParts); handlerIndex++ {
+		handlerPart := handlerParts[handlerIndex]
+		switch {
+		case handlerPart == "*":
+			// If a wildcard "*" is found, consume all remaining segments
+			wildcardParts := reqParts[reqIndex:]
+			reqIndex = len(reqParts)                // Consume all remaining segments
+			return strings.Join(wildcardParts, "/") // Return all remaining segments as a string
+		case strings.HasPrefix(handlerPart, "{") && strings.HasSuffix(handlerPart, "}"):
+			// If a variable of the form {param} is found we compare it with the key
+			parameter := handlerPart[1 : len(handlerPart)-1]
+			if parameter == key {
+				return reqParts[reqIndex]
+			}
+			reqIndex++
+		default:
+			if reqIndex >= len(reqParts) || handlerPart != reqParts[reqIndex] {
+				return ""
+			}
+			reqIndex++
+		}
+	}
+
+	return ""
+}

--- a/vendored/gno.land/p/nt/mux/v0/request_test.gno
+++ b/vendored/gno.land/p/nt/mux/v0/request_test.gno
@@ -1,0 +1,48 @@
+package mux
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func TestRequest_GetVar(t *testing.T) {
+	cases := []struct {
+		handlerPath    string
+		reqPath        string
+		getVarKey      string
+		expectedOutput string
+	}{
+
+		{"users/{id}", "users/123", "id", "123"},
+		{"users/123", "users/123", "id", ""},
+		{"users/{id}", "users/123", "nonexistent", ""},
+		{"users/{userId}/posts/{postId}", "users/123/posts/456", "userId", "123"},
+		{"users/{userId}/posts/{postId}", "users/123/posts/456", "postId", "456"},
+
+		// Wildcards
+		{"*", "users/123", "*", "users/123"},
+		{"*", "users/123/posts/456", "*", "users/123/posts/456"},
+		{"*", "users/123/posts/456/comments/789", "*", "users/123/posts/456/comments/789"},
+		{"users/*", "users/john/posts", "*", "john/posts"},
+		{"users/*/comments", "users/jane/comments", "*", "jane/comments"},
+		{"api/*/posts/*", "api/v1/posts/123", "*", "v1/posts/123"},
+
+		// wildcards and parameters
+		{"api/{version}/*", "api/v1/user/settings", "version", "v1"},
+	}
+	for _, tt := range cases {
+		name := ufmt.Sprintf("%s-%s", tt.handlerPath, tt.reqPath)
+		t.Run(name, func(t *testing.T) {
+			req := &Request{
+				HandlerPath: tt.handlerPath,
+				Path:        tt.reqPath,
+			}
+			output := req.GetVar(tt.getVarKey)
+			uassert.Equal(t, tt.expectedOutput, output,
+				"handler: %q, path: %q, key: %q",
+				tt.handlerPath, tt.reqPath, tt.getVarKey)
+		})
+	}
+}

--- a/vendored/gno.land/p/nt/mux/v0/response.gno
+++ b/vendored/gno.land/p/nt/mux/v0/response.gno
@@ -1,0 +1,20 @@
+package mux
+
+import "strings"
+
+// ResponseWriter represents the response writer.
+type ResponseWriter struct {
+	output strings.Builder
+}
+
+// Write appends data to the response output.
+func (rw *ResponseWriter) Write(data string) {
+	rw.output.WriteString(data)
+}
+
+// Output returns the final response output.
+func (rw *ResponseWriter) Output() string {
+	return rw.output.String()
+}
+
+// TODO: func (rw *ResponseWriter) Header()...

--- a/vendored/gno.land/p/nt/mux/v0/router.gno
+++ b/vendored/gno.land/p/nt/mux/v0/router.gno
@@ -1,0 +1,171 @@
+package mux
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Router handles the routing and rendering logic.
+type Router struct {
+	routes          []Handler
+	NotFoundHandler NotFoundHandler
+}
+
+// NewRouter creates a new Router instance.
+func NewRouter() *Router {
+	return &Router{
+		routes:          make([]Handler, 0),
+		NotFoundHandler: defaultNotFoundHandler,
+	}
+}
+
+// Render renders the output for the given path using the registered route handler.
+func (r *Router) Render(reqPath string) string {
+	clearPath, rawQuery, _ := strings.Cut(reqPath, "?")
+	query, _ := url.ParseQuery(rawQuery)
+	reqParts := strings.Split(clearPath, "/")
+
+	for _, route := range r.routes {
+		patParts := strings.Split(route.Pattern, "/")
+		wildcard := false
+		for _, part := range patParts {
+			if part == "*" {
+				wildcard = true
+				break
+			}
+		}
+		if !wildcard && len(patParts) != len(reqParts) {
+			continue
+		}
+
+		match := true
+		for i := 0; i < len(patParts); i++ {
+			patPart := patParts[i]
+			reqPart := reqParts[i]
+
+			if patPart == "*" {
+				break
+			}
+			if strings.HasPrefix(patPart, "{") && strings.HasSuffix(patPart, "}") {
+				continue
+			}
+			if patPart != reqPart {
+				match = false
+				break
+			}
+		}
+		if match {
+			req := &Request{
+				Path:        clearPath,
+				RawPath:     reqPath,
+				HandlerPath: route.Pattern,
+				Query:       query,
+			}
+			res := &ResponseWriter{}
+			if route.Fn == nil {
+				panic("Router.Render: route " + route.Pattern + " was registered via HandleFuncRlm; use RenderRlm to dispatch")
+			}
+			route.Fn(res, req)
+			return res.Output()
+		}
+	}
+
+	// not found
+	req := &Request{Path: reqPath, Query: query}
+	res := &ResponseWriter{}
+	r.NotFoundHandler(res, req)
+	return res.Output()
+}
+
+// RenderRlm is the rlm-aware counterpart of Render. Dispatches matched
+// routes registered via HandleFuncRlm with the supplied rlm; routes
+// registered via the legacy HandleFunc still work — rlm is ignored.
+// Use this when the router carries any rlm-aware handlers.
+func (r *Router) RenderRlm(_ int, rlm realm, reqPath string) string {
+	clearPath, rawQuery, _ := strings.Cut(reqPath, "?")
+	query, _ := url.ParseQuery(rawQuery)
+	reqParts := strings.Split(clearPath, "/")
+
+	for _, route := range r.routes {
+		patParts := strings.Split(route.Pattern, "/")
+		wildcard := false
+		for _, part := range patParts {
+			if part == "*" {
+				wildcard = true
+				break
+			}
+		}
+		if !wildcard && len(patParts) != len(reqParts) {
+			continue
+		}
+
+		match := true
+		for i := 0; i < len(patParts); i++ {
+			patPart := patParts[i]
+			reqPart := reqParts[i]
+
+			if patPart == "*" {
+				break
+			}
+			if strings.HasPrefix(patPart, "{") && strings.HasSuffix(patPart, "}") {
+				continue
+			}
+			if patPart != reqPart {
+				match = false
+				break
+			}
+		}
+		if match {
+			req := &Request{
+				Path:        clearPath,
+				RawPath:     reqPath,
+				HandlerPath: route.Pattern,
+				Query:       query,
+			}
+			res := &ResponseWriter{}
+			if route.FnRlm != nil {
+				route.FnRlm(0, rlm, res, req)
+			} else {
+				route.Fn(res, req)
+			}
+			return res.Output()
+		}
+	}
+
+	// not found
+	req := &Request{Path: reqPath, Query: query}
+	res := &ResponseWriter{}
+	r.NotFoundHandler(res, req)
+	return res.Output()
+}
+
+// HandleFunc registers a route and its handler function.
+func (r *Router) HandleFunc(pattern string, fn HandlerFunc) {
+	route := Handler{Pattern: pattern, Fn: fn}
+	r.routes = append(r.routes, route)
+}
+
+// HandleFuncRlm registers a route with a rlm-aware handler. Dispatch
+// must use Router.RenderRlm — calling Router.Render on a route registered
+// via HandleFuncRlm panics (no rlm to supply).
+func (r *Router) HandleFuncRlm(pattern string, fn HandlerFuncRlm) {
+	route := Handler{Pattern: pattern, FnRlm: fn}
+	r.routes = append(r.routes, route)
+}
+
+// HandleErrFunc registers a route and its error handler function.
+func (r *Router) HandleErrFunc(pattern string, fn ErrHandlerFunc) {
+	// Convert ErrHandlerFunc to regular HandlerFunc
+	handler := func(res *ResponseWriter, req *Request) {
+		if err := fn(res, req); err != nil {
+			res.Write("Error: " + err.Error())
+		}
+	}
+
+	r.HandleFunc(pattern, handler)
+}
+
+// SetNotFoundHandler sets custom message for 404 defaultNotFoundHandler.
+func (r *Router) SetNotFoundHandler(handler NotFoundHandler) {
+	r.NotFoundHandler = handler
+}

--- a/vendored/gno.land/p/nt/mux/v0/router_test.gno
+++ b/vendored/gno.land/p/nt/mux/v0/router_test.gno
@@ -1,0 +1,118 @@
+package mux
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+)
+
+func TestRouter_Render(t *testing.T) {
+	cases := []struct {
+		label          string
+		path           string
+		expectedOutput string
+		setupHandler   func(t *testing.T, r *Router)
+	}{
+		{
+			label:          "route with named parameter",
+			path:           "hello/Alice",
+			expectedOutput: "Hello, Alice!",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("hello/{name}", func(rw *ResponseWriter, req *Request) {
+					name := req.GetVar("name")
+					uassert.Equal(t, "Alice", name)
+					rw.Write("Hello, " + name + "!")
+				})
+			},
+		},
+		{
+			label:          "static route",
+			path:           "hi",
+			expectedOutput: "Hi, earth!",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("hi", func(rw *ResponseWriter, req *Request) {
+					uassert.Equal(t, req.Path, "hi")
+					rw.Write("Hi, earth!")
+				})
+			},
+		},
+		{
+			label:          "route with named parameter and query string",
+			path:           "hello/foo/bar?foo=bar&baz",
+			expectedOutput: "foo bar",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("hello/{key}/{val}", func(rw *ResponseWriter, req *Request) {
+					key := req.GetVar("key")
+					val := req.GetVar("val")
+					uassert.Equal(t, "foo", key)
+					uassert.Equal(t, "bar", val)
+					uassert.Equal(t, "hello/foo/bar?foo=bar&baz", req.RawPath)
+					uassert.Equal(t, "hello/foo/bar", req.Path)
+					uassert.Equal(t, "bar", req.Query.Get("foo"))
+					uassert.Empty(t, req.Query.Get("baz"))
+					rw.Write(key + " " + val)
+				})
+			},
+		},
+		{
+			// TODO: finalize how router should behave with double slash in path.
+			label:          "double slash in nested route",
+			path:           "a/foo//",
+			expectedOutput: "test foo",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("a/{key}", func(rw *ResponseWriter, req *Request) {
+					// Assert not called
+					uassert.False(t, true, "unexpected handler called")
+				})
+
+				r.HandleFunc("a/{key}/{val}/", func(rw *ResponseWriter, req *Request) {
+					key := req.GetVar("key")
+					val := req.GetVar("val")
+					uassert.Equal(t, key, "foo")
+					uassert.Empty(t, val)
+					rw.Write("test " + key)
+				})
+			},
+		},
+		{
+			label:          "wildcard in route",
+			path:           "hello/Alice/Bob",
+			expectedOutput: "Matched: Alice/Bob",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("hello/*", func(rw *ResponseWriter, req *Request) {
+					path := req.GetVar("*")
+					uassert.Equal(t, "Alice/Bob", path)
+					uassert.Equal(t, "hello/Alice/Bob", req.Path)
+					rw.Write("Matched: " + path)
+				})
+			},
+		},
+		{
+			label:          "wildcard in route with query string",
+			path:           "hello/Alice/Bob?foo=bar",
+			expectedOutput: "Matched: Alice/Bob",
+			setupHandler: func(t *testing.T, r *Router) {
+				r.HandleFunc("hello/*", func(rw *ResponseWriter, req *Request) {
+					path := req.GetVar("*")
+					uassert.Equal(t, "Alice/Bob", path)
+					uassert.Equal(t, "hello/Alice/Bob?foo=bar", req.RawPath)
+					uassert.Equal(t, "hello/Alice/Bob", req.Path)
+					uassert.Equal(t, "bar", req.Query.Get("foo"))
+					rw.Write("Matched: " + path)
+				})
+			},
+		},
+		// TODO: {"hello", "Hello, world!"},
+		// TODO: hello/, /hello, hello//Alice, hello/Alice/, hello/Alice/Bob, etc
+	}
+	for _, tt := range cases {
+		t.Run(tt.label, func(t *testing.T) {
+			router := NewRouter()
+			tt.setupHandler(t, router)
+			output := router.Render(tt.path)
+			if output != tt.expectedOutput {
+				t.Errorf("Expected output %q, but got %q", tt.expectedOutput, output)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/nt/seqid/v0/README.md
+++ b/vendored/gno.land/p/nt/seqid/v0/README.md
@@ -1,0 +1,42 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+
+# seqid
+
+```
+package seqid // import "gno.land/p/nt/seqid/v0"
+
+Package seqid provides a simple way to have sequential IDs which will be ordered
+correctly when inserted in an AVL tree.
+
+Sample usage:
+
+    var id seqid.ID
+    var users avl.Tree
+
+    func NewUser() {
+    	users.Set(id.Next().Binary(), &User{ ... })
+    }
+
+TYPES
+
+type ID uint64
+    An ID is a simple sequential ID generator.
+
+func FromBinary(b string) (ID, bool)
+    FromBinary creates a new ID from the given string.
+
+func (i ID) Binary() string
+    Binary returns a big-endian binary representation of the ID, suitable to be
+    used as an AVL key.
+
+func (i *ID) Next() ID
+    Next advances the ID i. It will panic if increasing ID would overflow.
+
+func (i *ID) TryNext() (ID, bool)
+    TryNext increases i by 1 and returns its value. It returns true if
+    successful, or false if the increment would result in an overflow.
+```

--- a/vendored/gno.land/p/nt/seqid/v0/doc.gno
+++ b/vendored/gno.land/p/nt/seqid/v0/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package seqid provides a simple way to have sequential IDs which will be
+// ordered correctly when inserted in an AVL tree.
+package seqid

--- a/vendored/gno.land/p/nt/seqid/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/seqid/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/seqid/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/seqid/v0/seqid.gno
+++ b/vendored/gno.land/p/nt/seqid/v0/seqid.gno
@@ -1,0 +1,91 @@
+// Package seqid provides a simple way to have sequential IDs which will be
+// ordered correctly when inserted in an AVL tree.
+//
+// Sample usage:
+//
+//	var id seqid.ID
+//	var users avl.Tree
+//
+//	func NewUser() {
+//		users.Set(id.Next().String(), &User{ ... })
+//	}
+package seqid
+
+import (
+	"encoding/binary"
+
+	"gno.land/p/nt/cford32/v0"
+)
+
+// An ID is a simple sequential ID generator.
+type ID uint64
+
+// Next advances the ID i.
+// It will panic if increasing ID would overflow.
+func (i *ID) Next() ID {
+	next, ok := i.TryNext()
+	if !ok {
+		panic("seqid: next ID overflows uint64")
+	}
+	return next
+}
+
+const maxID ID = 1<<64 - 1
+
+// TryNext increases i by 1 and returns its value.
+// It returns true if successful, or false if the increment would result in
+// an overflow.
+func (i *ID) TryNext() (ID, bool) {
+	if *i == maxID {
+		// Addition will overflow.
+		return 0, false
+	}
+	*i++
+	return *i, true
+}
+
+// Binary returns a big-endian binary representation of the ID,
+// suitable to be used as an AVL key.
+func (i ID) Binary() string {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(i))
+	return string(buf)
+}
+
+// String encodes i using cford32's compact encoding. For more information,
+// see the documentation for package [gno.land/p/nt/cford32/v0].
+//
+// The result of String will be a 7-byte string for IDs [0,2^34), and a
+// 13-byte string for all values following that. All generated string IDs
+// follow the same lexicographic order as their number values; that is, for any
+// two IDs (x, y) such that x < y, x.String() < y.String().
+// As such, this string representation is suitable to be used as an AVL key.
+func (i ID) String() string {
+	return string(cford32.PutCompact(uint64(i)))
+}
+
+// FromBinary creates a new ID from the given string, expected to be a binary
+// big-endian encoding of an ID (such as that of [ID.Binary]).
+// The second return value is true if the conversion was successful.
+func FromBinary(b string) (ID, bool) {
+	if len(b) != 8 {
+		return 0, false
+	}
+	return ID(binary.BigEndian.Uint64([]byte(b))), true
+}
+
+// FromString creates a new ID from the given string, expected to be a string
+// representation using cford32, such as that returned by [ID.String].
+//
+// The encoding scheme used by cford32 allows the same ID to have many
+// different representations (though the one returned by [ID.String] is only
+// one, deterministic and safe to be used in AVL). The encoding scheme is
+// "human-centric" and is thus case insensitive, and maps some ambiguous
+// characters to be the same, ie. L = I = 1, O = 0. For this reason, when
+// parsing user input to retrieve a key (encoded as a string), always sanitize
+// it first using FromString, then run String(), instead of using the user's
+// input directly.
+func FromString(b string) (ID, error) {
+	n, err := cford32.Uint64([]byte(b))
+	return ID(n), err
+}

--- a/vendored/gno.land/p/nt/seqid/v0/seqid_test.gno
+++ b/vendored/gno.land/p/nt/seqid/v0/seqid_test.gno
@@ -1,0 +1,68 @@
+package seqid
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestID(t *testing.T) {
+	var i ID
+
+	for j := 0; j < 100; j++ {
+		i.Next()
+	}
+	if i != 100 {
+		t.Fatalf("invalid: wanted %d got %d", 100, i)
+	}
+}
+
+func TestID_Overflow(t *testing.T) {
+	i := ID(maxID)
+
+	defer func() {
+		err := recover()
+		if !strings.Contains(fmt.Sprint(err), "next ID overflows") {
+			t.Errorf("did not overflow")
+		}
+	}()
+
+	i.Next()
+}
+
+func TestID_Binary(cur realm, t *testing.T) {
+	var i ID
+	prev := i.Binary()
+
+	for j := 0; j < 1000; j++ {
+		cur := i.Next().Binary()
+		if cur <= prev {
+			t.Fatalf("cur %x > prev %x", cur, prev)
+		}
+		prev = cur
+	}
+}
+
+func TestID_String(cur realm, t *testing.T) {
+	var i ID
+	prev := i.String()
+
+	for j := 0; j < 1000; j++ {
+		cur := i.Next().String()
+		if cur <= prev {
+			t.Fatalf("cur %s > prev %s", cur, prev)
+		}
+		prev = cur
+	}
+
+	// Test for when cford32 switches over to the long encoding.
+	i = 1<<34 - 512
+	for j := 0; j < 1024; j++ {
+		cur := i.Next().String()
+		// println(cur)
+		if cur <= prev {
+			t.Fatalf("cur %s > prev %s", cur, prev)
+		}
+		prev = cur
+	}
+}

--- a/vendored/gno.land/p/nt/testutils/v0/README.md
+++ b/vendored/gno.land/p/nt/testutils/v0/README.md
@@ -1,0 +1,8 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+# testutils
+
+Package `testutils` provides testing utilities for Gno packages and realms, including test address generation and cryptographic helpers.

--- a/vendored/gno.land/p/nt/testutils/v0/access.gno
+++ b/vendored/gno.land/p/nt/testutils/v0/access.gno
@@ -1,0 +1,43 @@
+package testutils
+
+// for testing access. see tests/files/access*.go
+
+// NOTE: non-package variables cannot be overridden, except during init().
+var (
+	TestVar1 int
+	testVar2 int
+)
+
+func init() {
+	TestVar1 = 123
+	testVar2 = 456
+}
+
+type TestAccessStruct struct {
+	PublicField  string
+	privateField string
+}
+
+func (tas TestAccessStruct) PublicMethod() string {
+	return tas.PublicField + "/" + tas.privateField
+}
+
+func (tas TestAccessStruct) privateMethod() string {
+	return tas.PublicField + "/" + tas.privateField
+}
+
+func NewTestAccessStruct(pub, priv string) TestAccessStruct {
+	return TestAccessStruct{
+		PublicField:  pub,
+		privateField: priv,
+	}
+}
+
+// see access6.g0 etc.
+type PrivateInterface interface {
+	privateMethod() string
+}
+
+func PrintPrivateInterface(pi PrivateInterface) {
+	println("testutils.PrintPrivateInterface", pi.privateMethod())
+}

--- a/vendored/gno.land/p/nt/testutils/v0/crypto.gno
+++ b/vendored/gno.land/p/nt/testutils/v0/crypto.gno
@@ -1,0 +1,20 @@
+package testutils
+
+import "crypto/bech32"
+
+func TestAddress(name string) address {
+	if len(name) > 20 {
+		panic("address name cannot be greater than 20 bytes")
+	}
+	addr := []byte("____________________")
+	copy(addr[:], name)
+	converted, err := bech32.ConvertBits(addr, 8, 5, true)
+	if err != nil {
+		panic(err)
+	}
+	enc, err := bech32.Encode("g", converted)
+	if err != nil {
+		panic(err)
+	}
+	return address(enc)
+}

--- a/vendored/gno.land/p/nt/testutils/v0/crypto_test.gno
+++ b/vendored/gno.land/p/nt/testutils/v0/crypto_test.gno
@@ -1,0 +1,12 @@
+package testutils
+
+import (
+	"testing"
+)
+
+func TestTestAddress(t *testing.T) {
+	testAddr := TestAddress("author1")
+	if string(testAddr) != "g1v96hg6r0wgc47h6lta047h6lta047h6lm33tq6" {
+		panic("not equal")
+	}
+}

--- a/vendored/gno.land/p/nt/testutils/v0/doc.gno
+++ b/vendored/gno.land/p/nt/testutils/v0/doc.gno
@@ -1,0 +1,6 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package testutils provides testing utilities for Gno packages and realms.
+package testutils

--- a/vendored/gno.land/p/nt/testutils/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/testutils/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/testutils/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/testutils/v0/misc.gno
+++ b/vendored/gno.land/p/nt/testutils/v0/misc.gno
@@ -1,0 +1,6 @@
+package testutils
+
+// WrapCall adds a frame to the call stack, for testing call stack depth.
+func WrapCall(fn func()) {
+	fn()
+}

--- a/vendored/gno.land/p/nt/uassert/v0/README.md
+++ b/vendored/gno.land/p/nt/uassert/v0/README.md
@@ -1,0 +1,8 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+# uassert
+
+Package `uassert` provides assertion helpers for testing Gno packages and realms.

--- a/vendored/gno.land/p/nt/uassert/v0/doc.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/doc.gno
@@ -1,0 +1,4 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+package uassert // import "gno.land/p/nt/uassert/v0"

--- a/vendored/gno.land/p/nt/uassert/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/uassert/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/uassert/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/uassert/v0/helpers.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/helpers.gno
@@ -1,0 +1,51 @@
+package uassert
+
+import "strings"
+
+func fail(t TestingT, customMsgs []string, failureMessage string, args ...any) bool {
+	customMsg := ""
+	if len(customMsgs) > 0 {
+		customMsg = strings.Join(customMsgs, " ")
+	}
+	if customMsg != "" {
+		failureMessage += " - " + customMsg
+	}
+	t.Errorf(failureMessage, args...)
+	return false
+}
+
+func checkDidPanic(f any, rlm realm) (didPanic bool, message string) {
+	didPanic = true
+	defer func() {
+		r := recover()
+
+		if r == nil {
+			message = "nil"
+			return
+		}
+
+		err, ok := r.(error)
+		if ok {
+			message = err.Error()
+			return
+		}
+
+		errStr, ok := r.(string)
+		if ok {
+			message = errStr
+			return
+		}
+
+		message = "recover: unsupported type"
+	}()
+	switch f := f.(type) {
+	case func():
+		f()
+	case func(realm):
+		f(cross(rlm))
+	default:
+		panic("f must be of type func() or func(realm)")
+	}
+	didPanic = false
+	return
+}

--- a/vendored/gno.land/p/nt/uassert/v0/mock_test.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/mock_test.gno
@@ -1,0 +1,61 @@
+package uassert_test
+
+import (
+	"fmt"
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+)
+
+type mockTestingT struct {
+	fmt  string
+	args []any
+}
+
+// --- interface mock
+
+var _ uassert.TestingT = (*mockTestingT)(nil)
+
+func (mockT *mockTestingT) Helper()                      { /* noop */ }
+func (mockT *mockTestingT) Skip(args ...any)             { /* not implmented */ }
+func (mockT *mockTestingT) Fail()                        { /* not implmented */ }
+func (mockT *mockTestingT) FailNow()                     { /* not implmented */ }
+func (mockT *mockTestingT) Logf(fmt string, args ...any) { /* noop */ }
+
+func (mockT *mockTestingT) Fatalf(fmt string, args ...any) {
+	mockT.fmt = "fatal: " + fmt
+	mockT.args = args
+}
+
+func (mockT *mockTestingT) Errorf(fmt string, args ...any) {
+	mockT.fmt = "error: " + fmt
+	mockT.args = args
+}
+
+// --- helpers
+
+func (mockT *mockTestingT) actualString() string {
+	res := fmt.Sprintf(mockT.fmt, mockT.args...)
+	mockT.reset()
+	return res
+}
+
+func (mockT *mockTestingT) reset() {
+	mockT.fmt = ""
+	mockT.args = nil
+}
+
+func (mockT *mockTestingT) equals(t *testing.T, expected string) {
+	actual := mockT.actualString()
+
+	if expected != actual {
+		t.Errorf("mockT differs:\n- expected: %s\n- actual:   %s\n", expected, actual)
+	}
+}
+
+func (mockT *mockTestingT) empty(t *testing.T) {
+	if mockT.fmt != "" || mockT.args != nil {
+		actual := mockT.actualString()
+		t.Errorf("mockT should be empty, got %s", actual)
+	}
+}

--- a/vendored/gno.land/p/nt/uassert/v0/types.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/types.gno
@@ -1,0 +1,11 @@
+package uassert
+
+type TestingT interface {
+	Helper()
+	Skip(args ...any)
+	Fatalf(fmt string, args ...any)
+	Errorf(fmt string, args ...any)
+	Logf(fmt string, args ...any)
+	Fail()
+	FailNow()
+}

--- a/vendored/gno.land/p/nt/uassert/v0/uassert.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/uassert.gno
@@ -1,0 +1,681 @@
+// uassert is an adapted lighter version of https://github.com/stretchr/testify/assert.
+package uassert
+
+import (
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/ufmt/v0"
+	"gno.land/p/onbloc/diff"
+)
+
+// NoError asserts that a function returned no error (i.e. `nil`).
+func NoError(t TestingT, err error, msgs ...string) bool {
+	t.Helper()
+	if err != nil {
+		return fail(t, msgs, "unexpected error: %s", err.Error())
+	}
+	return true
+}
+
+// Error asserts that a function returned an error (i.e. not `nil`).
+func Error(t TestingT, err error, msgs ...string) bool {
+	t.Helper()
+	if err == nil {
+		return fail(t, msgs, "an error is expected but got nil")
+	}
+	return true
+}
+
+// ErrorContains asserts that a function returned an error (i.e. not `nil`)
+// and that the error contains the specified substring.
+func ErrorContains(t TestingT, err error, contains string, msgs ...string) bool {
+	t.Helper()
+
+	if !Error(t, err, msgs...) {
+		return false
+	}
+
+	actual := err.Error()
+	if !strings.Contains(actual, contains) {
+		return fail(t, msgs, "error %q does not contain %q", actual, contains)
+	}
+
+	return true
+}
+
+// True asserts that the specified value is true.
+func True(t TestingT, value bool, msgs ...string) bool {
+	t.Helper()
+	if !value {
+		return fail(t, msgs, "should be true")
+	}
+	return true
+}
+
+// False asserts that the specified value is false.
+func False(t TestingT, value bool, msgs ...string) bool {
+	t.Helper()
+	if value {
+		return fail(t, msgs, "should be false")
+	}
+	return true
+}
+
+// ErrorIs asserts the given error matches the target error
+func ErrorIs(t TestingT, err, target error, msgs ...string) bool {
+	t.Helper()
+
+	if err == nil || target == nil {
+		return err == target
+	}
+
+	// XXX: if errors.Is(err, target) return true
+
+	if err.Error() != target.Error() {
+		return fail(t, msgs, "error mismatch, expected %s, got %s", target.Error(), err.Error())
+	}
+
+	return true
+}
+
+// AbortsWithMessage asserts that the code inside the specified func aborts
+// (panics when crossing another realm).
+// Use PanicsWithMessage for asserting local panics within the same realm.
+//
+// `rlm` is threaded into the callback via cross(rlm) when f is func(realm).
+// It is ignored for func() callbacks. /p/ production code cannot declare
+// crossing functions, so rlm is taken as the second (non-first) parameter
+// — callers pass `cur` directly.
+//
+// NOTE: This relies on gno's `revive` mechanism to catch aborts.
+func AbortsWithMessage(t TestingT, rlm realm, msg string, f any, msgs ...string) bool {
+	t.Helper()
+
+	var didAbort bool
+	var abortValue any
+	var r any
+
+	switch f := f.(type) {
+	case func():
+		r = revive(f) // revive() captures the value passed to panic()
+	case func(realm):
+		r = revive(func() { f(cross(rlm)) })
+	default:
+		panic("f must be of type func() or func(realm)")
+	}
+	if r != nil {
+		didAbort = true
+		abortValue = r
+	}
+
+	if !didAbort {
+		// If the function didn't abort as expected
+		return fail(t, msgs, "func should abort")
+	}
+
+	// Check if the abort value matches the expected message string
+	abortStr := ufmt.Sprintf("%v", abortValue)
+	if abortStr != msg {
+		return fail(t, msgs, "func should abort with message:\t%q\n\tActual abort value:\t%q", msg, abortStr)
+	}
+
+	// Success: function aborted with the expected message
+	return true
+}
+
+// AbortsContains asserts that the code inside the specified func aborts
+// (panics when crossing another realm) and the abort message contains the specified substring.
+// See AbortsWithMessage for `rlm` semantics.
+func AbortsContains(t TestingT, rlm realm, substr string, f any, msgs ...string) bool {
+	t.Helper()
+
+	var didAbort bool
+	var abortValue any
+	var r any
+
+	if fn, ok := f.(func()); ok {
+		r = revive(fn)
+	} else if fn, ok := f.(func(realm)); ok {
+		r = revive(func() { fn(cross(rlm)) })
+	} else {
+		panic("f must be of type func() or func(realm)")
+	}
+	if r != nil {
+		didAbort = true
+		abortValue = r
+	}
+
+	if !didAbort {
+		return fail(t, msgs, "func should abort")
+	}
+
+	abortStr := ufmt.Sprintf("%v", abortValue)
+	if !strings.Contains(abortStr, substr) {
+		return fail(t, msgs, "func should abort with message containing:\t%q\n\tActual abort value:\t%q", substr, abortStr)
+	}
+
+	return true
+}
+
+// NotAborts asserts that the code inside the specified func does NOT abort
+// when crossing an execution boundary.
+// Note: Consider using NotPanics which checks for both panics and aborts.
+// See AbortsWithMessage for `rlm` semantics.
+func NotAborts(t TestingT, rlm realm, f any, msgs ...string) bool {
+	t.Helper()
+
+	var didAbort bool
+	var abortValue any
+	var r any
+
+	switch f := f.(type) {
+	case func():
+		r = revive(f) // revive() captures the value passed to panic()
+	case func(realm):
+		r = revive(func() { f(cross(rlm)) })
+	default:
+		panic("f must be of type func() or func(realm)")
+	}
+	if r != nil {
+		didAbort = true
+		abortValue = r
+	}
+
+	if didAbort {
+		// Fail if the function aborted when it shouldn't have
+		// Attempt to format the abort value in the error message
+		return fail(t, msgs, "func should not abort\\n\\tAbort value:\\t%v", abortValue)
+	}
+
+	// Success: function did not abort
+	return true
+}
+
+// PanicsWithMessage asserts that the code inside the specified func panics
+// locally within the same execution realm.
+// Use AbortsWithMessage for asserting panics that cross execution boundaries (aborts).
+// See AbortsWithMessage for `rlm` semantics.
+func PanicsWithMessage(t TestingT, rlm realm, msg string, f any, msgs ...string) bool {
+	t.Helper()
+
+	didPanic, panicValue := checkDidPanic(f, rlm)
+	if !didPanic {
+		return fail(t, msgs, "func should panic\n\tPanic value:\t%v", panicValue)
+	}
+
+	// Check if the abort value matches the expected message string
+	panicStr := ufmt.Sprintf("%v", panicValue)
+	if panicStr != msg {
+		return fail(t, msgs, "func should panic with message:\t%q\n\tActual panic value:\t%q", msg, panicStr)
+	}
+	return true
+}
+
+// PanicsContains asserts that the code inside the specified func panics
+// locally within the same execution realm and the panic message contains the specified substring.
+// See AbortsWithMessage for `rlm` semantics.
+func PanicsContains(t TestingT, rlm realm, substr string, f any, msgs ...string) bool {
+	t.Helper()
+
+	didPanic, panicValue := checkDidPanic(f, rlm)
+	if !didPanic {
+		return fail(t, msgs, "func should panic\n\tPanic value:\t%v", panicValue)
+	}
+
+	panicStr := ufmt.Sprintf("%v", panicValue)
+	if !strings.Contains(panicStr, substr) {
+		return fail(t, msgs, "func should panic with message containing:\t%q\n\tActual panic value:\t%q", substr, panicStr)
+	}
+	return true
+}
+
+// NotPanics asserts that the code inside the specified func does NOT panic
+// (within the same realm) or abort (due to a cross-realm panic).
+// See AbortsWithMessage for `rlm` semantics.
+func NotPanics(t TestingT, rlm realm, f any, msgs ...string) bool {
+	t.Helper()
+
+	var panicVal any
+	var didPanic bool
+	var abortVal any
+
+	// Use revive to catch cross-realm aborts
+	abortVal = revive(func() {
+		// Use defer+recover to catch same-realm panics
+		defer func() {
+			if r := recover(); r != nil {
+				didPanic = true
+				panicVal = r
+			}
+		}()
+		// Execute the function
+		switch f := f.(type) {
+		case func():
+			f()
+		case func(realm):
+			f(cross(rlm))
+		default:
+			panic("f must be of type func() or func(realm)")
+		}
+	})
+
+	// Check if revive caught an abort
+	if abortVal != nil {
+		return fail(t, msgs, "func should not abort\n\tAbort value:\t%+v", abortVal)
+	}
+
+	// Check if recover caught a panic
+	if didPanic {
+		// Format panic value for message
+		panicMsg := ""
+		if panicVal == nil {
+			panicMsg = "nil"
+		} else if err, ok := panicVal.(error); ok {
+			panicMsg = err.Error()
+		} else if str, ok := panicVal.(string); ok {
+			panicMsg = str
+		} else {
+			// Fallback for other types
+			panicMsg = "panic: unsupported type"
+		}
+		return fail(t, msgs, "func should not panic\n\tPanic value:\t%s", panicMsg)
+	}
+
+	return true // No panic or abort occurred
+}
+
+// Equal asserts that two objects are equal.
+func Equal(t TestingT, expected, actual any, msgs ...string) bool {
+	t.Helper()
+
+	if expected == nil || actual == nil {
+		return expected == actual
+	}
+
+	// XXX: errors
+	// XXX: slices
+	// XXX: pointers
+
+	equal := false
+	ok_ := false
+	es, as := "unsupported type", "unsupported type"
+
+	switch ev := expected.(type) {
+	case string:
+		if av, ok := actual.(string); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = ev, av
+			if !equal {
+				dif := diff.MyersDiff(ev, av)
+				return fail(t, msgs, "uassert.Equal: strings are different\n\tDiff: %s", diff.Format(dif))
+			}
+		}
+	case address:
+		if av, ok := actual.(address); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = string(ev), string(av)
+		}
+	case int:
+		if av, ok := actual.(int); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.Itoa(ev), strconv.Itoa(av)
+		}
+	case int8:
+		if av, ok := actual.(int8); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int16:
+		if av, ok := actual.(int16); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int32:
+		if av, ok := actual.(int32); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int64:
+		if av, ok := actual.(int64); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case uint:
+		if av, ok := actual.(uint); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint8:
+		if av, ok := actual.(uint8); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint16:
+		if av, ok := actual.(uint16); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint32:
+		if av, ok := actual.(uint32); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint64:
+		if av, ok := actual.(uint64); ok {
+			equal = ev == av
+			ok_ = true
+			es, as = strconv.FormatUint(ev, 10), strconv.FormatUint(av, 10)
+		}
+	case bool:
+		if av, ok := actual.(bool); ok {
+			equal = ev == av
+			ok_ = true
+			if ev {
+				es, as = "true", "false"
+			} else {
+				es, as = "false", "true"
+			}
+		}
+	case float32:
+		if av, ok := actual.(float32); ok {
+			equal = ev == av
+			ok_ = true
+		}
+	case float64:
+		if av, ok := actual.(float64); ok {
+			equal = ev == av
+			ok_ = true
+		}
+	default:
+		return fail(t, msgs, "uassert.Equal: unsupported type")
+	}
+
+	/*
+		// XXX: implement stringer and other well known similar interfaces
+		type stringer interface{ String() string }
+		if ev, ok := expected.(stringer); ok {
+			if av, ok := actual.(stringer); ok {
+				equal = ev.String() == av.String()
+				ok_ = true
+			}
+		}
+	*/
+
+	if !ok_ {
+		return fail(t, msgs, "uassert.Equal: different types") // XXX: display the types
+	}
+	if !equal {
+		return fail(t, msgs, "uassert.Equal: same type but different value\n\texpected: %s\n\tactual:   %s", es, as)
+	}
+
+	return true
+}
+
+// NotEqual asserts that two objects are not equal.
+func NotEqual(t TestingT, expected, actual any, msgs ...string) bool {
+	t.Helper()
+
+	if expected == nil || actual == nil {
+		return expected != actual
+	}
+
+	// XXX: errors
+	// XXX: slices
+	// XXX: pointers
+
+	notEqual := false
+	ok_ := false
+	es, as := "unsupported type", "unsupported type"
+
+	switch ev := expected.(type) {
+	case string:
+		if av, ok := actual.(string); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = ev, av
+		}
+	case address:
+		if av, ok := actual.(address); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = string(ev), string(av)
+		}
+	case int:
+		if av, ok := actual.(int); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.Itoa(ev), strconv.Itoa(av)
+		}
+	case int8:
+		if av, ok := actual.(int8); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int16:
+		if av, ok := actual.(int16); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int32:
+		if av, ok := actual.(int32); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case int64:
+		if av, ok := actual.(int64); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.Itoa(int(ev)), strconv.Itoa(int(av))
+		}
+	case uint:
+		if av, ok := actual.(uint); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint8:
+		if av, ok := actual.(uint8); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint16:
+		if av, ok := actual.(uint16); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint32:
+		if av, ok := actual.(uint32); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.FormatUint(uint64(ev), 10), strconv.FormatUint(uint64(av), 10)
+		}
+	case uint64:
+		if av, ok := actual.(uint64); ok {
+			notEqual = ev != av
+			ok_ = true
+			es, as = strconv.FormatUint(ev, 10), strconv.FormatUint(av, 10)
+		}
+	case bool:
+		if av, ok := actual.(bool); ok {
+			notEqual = ev != av
+			ok_ = true
+			if ev {
+				es, as = "true", "false"
+			} else {
+				es, as = "false", "true"
+			}
+		}
+	case float32:
+		if av, ok := actual.(float32); ok {
+			notEqual = ev != av
+			ok_ = true
+		}
+	case float64:
+		if av, ok := actual.(float64); ok {
+			notEqual = ev != av
+			ok_ = true
+		}
+	default:
+		return fail(t, msgs, "uassert.NotEqual: unsupported type")
+	}
+
+	/*
+		// XXX: implement stringer and other well known similar interfaces
+		type stringer interface{ String() string }
+		if ev, ok := expected.(stringer); ok {
+			if av, ok := actual.(stringer); ok {
+				notEqual = ev.String() != av.String()
+				ok_ = true
+			}
+		}
+	*/
+
+	if !ok_ {
+		return fail(t, msgs, "uassert.NotEqual: different types") // XXX: display the types
+	}
+	if !notEqual {
+		return fail(t, msgs, "uassert.NotEqual: same type and same value\n\texpected: %s\n\tactual:   %s", es, as)
+	}
+
+	return true
+}
+
+func isNumberEmpty(n any) (isNumber, isEmpty bool) {
+	switch n := n.(type) {
+	// NOTE: the cases are split individually, so that n becomes of the
+	// asserted type; the type of '0' was correctly inferred and converted
+	// to the corresponding type, int, int8, etc.
+	case int:
+		return true, n == 0
+	case int8:
+		return true, n == 0
+	case int16:
+		return true, n == 0
+	case int32:
+		return true, n == 0
+	case int64:
+		return true, n == 0
+	case uint:
+		return true, n == 0
+	case uint8:
+		return true, n == 0
+	case uint16:
+		return true, n == 0
+	case uint32:
+		return true, n == 0
+	case uint64:
+		return true, n == 0
+	case float32:
+		return true, n == 0
+	case float64:
+		return true, n == 0
+	}
+	return false, false
+}
+
+func Empty(t TestingT, obj any, msgs ...string) bool {
+	t.Helper()
+
+	isNumber, isEmpty := isNumberEmpty(obj)
+	if isNumber {
+		if !isEmpty {
+			return fail(t, msgs, "uassert.Empty: not empty number: %d", obj)
+		}
+	} else {
+		switch val := obj.(type) {
+		case string:
+			if val != "" {
+				return fail(t, msgs, "uassert.Empty: not empty string: %s", val)
+			}
+		case address:
+			var zeroAddr address
+			if val != zeroAddr {
+				return fail(t, msgs, "uassert.Empty: not empty address: %s", string(val))
+			}
+		default:
+			return fail(t, msgs, "uassert.Empty: unsupported type")
+		}
+	}
+	return true
+}
+
+func NotEmpty(t TestingT, obj any, msgs ...string) bool {
+	t.Helper()
+	isNumber, isEmpty := isNumberEmpty(obj)
+	if isNumber {
+		if isEmpty {
+			return fail(t, msgs, "uassert.NotEmpty: empty number: %d", obj)
+		}
+	} else {
+		switch val := obj.(type) {
+		case string:
+			if val == "" {
+				return fail(t, msgs, "uassert.NotEmpty: empty string: %s", val)
+			}
+		case address:
+			var zeroAddr address
+			if val == zeroAddr {
+				return fail(t, msgs, "uassert.NotEmpty: empty address: %s", string(val))
+			}
+		default:
+			return fail(t, msgs, "uassert.NotEmpty: unsupported type")
+		}
+	}
+	return true
+}
+
+// Nil asserts that the value is nil.
+func Nil(t TestingT, value any, msgs ...string) bool {
+	t.Helper()
+	if value != nil {
+		return fail(t, msgs, "should be nil")
+	}
+	return true
+}
+
+// NotNil asserts that the value is not nil.
+func NotNil(t TestingT, value any, msgs ...string) bool {
+	t.Helper()
+	if value == nil {
+		return fail(t, msgs, "should not be nil")
+	}
+	return true
+}
+
+// TypedNil asserts that the value is a typed-nil (nil pointer) value.
+func TypedNil(t TestingT, value any, msgs ...string) bool {
+	t.Helper()
+	if value == nil {
+		return fail(t, msgs, "should be typed-nil but got nil instead")
+	}
+	if !istypednil(value) {
+		return fail(t, msgs, "should be typed-nil")
+	}
+	return true
+}
+
+// NotTypedNil asserts that the value is not a typed-nil (nil pointer) value.
+func NotTypedNil(t TestingT, value any, msgs ...string) bool {
+	t.Helper()
+	if istypednil(value) {
+		return fail(t, msgs, "should not be typed-nil")
+	}
+	return true
+}

--- a/vendored/gno.land/p/nt/uassert/v0/uassert_test.gno
+++ b/vendored/gno.land/p/nt/uassert/v0/uassert_test.gno
@@ -1,0 +1,566 @@
+package uassert_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	tests "gno.land/r/tests/vm"
+)
+
+// cur is a zero-value realm used as a placeholder when forwarding to
+// uassert/urequire dispatch helpers that gained an `rlm realm` param.
+// These tests pass `func()` callbacks (no crossing inside the callback),
+// so rlm is ignored — a nil realm here is safe.
+var cur realm
+var _ uassert.TestingT = (*testing.T)(nil)
+
+func TestMock(t *testing.T) {
+	mockT := new(mockTestingT)
+	mockT.empty(t)
+	uassert.NoError(mockT, errors.New("foo"))
+	mockT.equals(t, "error: unexpected error: foo")
+	uassert.NoError(mockT, errors.New("foo"), "custom message")
+	mockT.equals(t, "error: unexpected error: foo - custom message")
+	uassert.NoError(mockT, errors.New("foo"), "custom", "message")
+	mockT.equals(t, "error: unexpected error: foo - custom message")
+}
+
+func TestNoError(t *testing.T) {
+	mockT := new(mockTestingT)
+	uassert.True(t, uassert.NoError(mockT, nil))
+	mockT.empty(t)
+	uassert.False(t, uassert.NoError(mockT, errors.New("foo bar")))
+	mockT.equals(t, "error: unexpected error: foo bar")
+}
+
+func TestError(t *testing.T) {
+	mockT := new(mockTestingT)
+	uassert.True(t, uassert.Error(mockT, errors.New("foo bar")))
+	mockT.empty(t)
+	uassert.False(t, uassert.Error(mockT, nil))
+	mockT.equals(t, "error: an error is expected but got nil")
+}
+
+func TestErrorContains(t *testing.T) {
+	mockT := new(mockTestingT)
+
+	// nil error
+	var err error
+	uassert.False(t, uassert.ErrorContains(mockT, err, ""), "ErrorContains should return false for nil arg")
+}
+
+func TestTrue(t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.True(mockT, true) {
+		t.Error("True should return true")
+	}
+	mockT.empty(t)
+	if uassert.True(mockT, false) {
+		t.Error("True should return false")
+	}
+	mockT.equals(t, "error: should be true")
+}
+
+func TestFalse(t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.False(mockT, false) {
+		t.Error("False should return true")
+	}
+	mockT.empty(t)
+	if uassert.False(mockT, true) {
+		t.Error("False should return false")
+	}
+	mockT.equals(t, "error: should be false")
+}
+
+func TestPanicsWithMessage(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.PanicsWithMessage(mockT, cur, "panic", func() {
+		panic(errors.New("panic"))
+	}) {
+		t.Error("PanicsWithMessage should return true")
+	}
+	mockT.empty(t)
+
+	if uassert.PanicsWithMessage(mockT, cur, "Panic!", func() {
+		// noop
+	}) {
+		t.Error("PanicsWithMessage should return false")
+	}
+	mockT.equals(t, "error: func should panic\n\tPanic value:\tnil")
+
+	if uassert.PanicsWithMessage(mockT, cur, "at the disco", func() {
+		panic(errors.New("panic"))
+	}) {
+		t.Error("PanicsWithMessage should return false")
+	}
+	mockT.equals(t, "error: func should panic with message:\t\"at the disco\"\n\tActual panic value:\t\"panic\"")
+
+	if uassert.PanicsWithMessage(mockT, cur, "Panic!", func() {
+		panic("panic")
+	}) {
+		t.Error("PanicsWithMessage should return false")
+	}
+	mockT.equals(t, "error: func should panic with message:\t\"Panic!\"\n\tActual panic value:\t\"panic\"")
+}
+
+func TestPanicsContains(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.PanicsContains(mockT, cur, "panic", func() {
+		panic(errors.New("panic: something happened"))
+	}) {
+		t.Error("PanicsContains should return true for substring match")
+	}
+	mockT.empty(t)
+
+	if uassert.PanicsContains(mockT, cur, "notfound", func() {
+		panic(errors.New("panic: something happened"))
+	}) {
+		t.Error("PanicsContains should return false for missing substring")
+	}
+	mockT.equals(t, "error: func should panic with message containing:\t\"notfound\"\n\tActual panic value:\t\"panic: something happened\"")
+
+	if uassert.PanicsContains(mockT, cur, "panic", func() {
+		// noop
+	}) {
+		t.Error("PanicsContains should return false when no panic occurs")
+	}
+	mockT.equals(t, "error: func should panic\n\tPanic value:\tnil")
+}
+
+func TestAbortsWithMessage(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.AbortsWithMessage(mockT, cur, "abort message", func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic("abort message")
+		})
+		panic("dontcare")
+	}) {
+		t.Error("AbortsWithMessage should return true")
+	}
+	mockT.empty(t)
+
+	if uassert.AbortsWithMessage(mockT, cur, "Abort!", func() {
+		// noop
+	}) {
+		t.Error("AbortsWithMessage should return false")
+	}
+	mockT.equals(t, "error: func should abort")
+
+	if uassert.AbortsWithMessage(mockT, cur, "at the disco", func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic("abort message")
+		})
+		panic("dontcare")
+	}) {
+		t.Error("AbortsWithMessage should return false (wrong message)")
+	}
+	mockT.equals(t, "error: func should abort with message:\t\"at the disco\"\n\tActual abort value:\t\"abort message\"")
+
+	// Test that non-crossing panics don't count as abort.
+	uassert.PanicsWithMessage(mockT, cur, "non-abort panic", func() {
+		uassert.AbortsWithMessage(mockT, cur, "dontcare2", func() {
+			panic("non-abort panic")
+		})
+		t.Error("AbortsWithMessage should not have caught non-abort panic")
+	}, "non-abort panic")
+	mockT.empty(t)
+
+	// Test case where abort value is not a string
+	if uassert.AbortsWithMessage(mockT, cur, "doesn't matter", func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic(123) // abort with an integer
+		})
+		panic("dontcare")
+	}) {
+		t.Error("AbortsWithMessage should return false when abort value is not a string")
+	}
+	mockT.equals(t, "error: func should abort with message:\t\"doesn't matter\"\n\tActual abort value:\t\"123\"")
+
+	// XXX: test with Error
+}
+
+func TestAbortsContains(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.AbortsContains(mockT, cur, "abort", func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic("abort message: something happened")
+		})
+		panic("dontcare")
+	}) {
+		t.Error("AbortsContains should return true for substring match")
+	}
+	mockT.empty(t)
+
+	if uassert.AbortsContains(mockT, cur, "notfound", func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic("abort message: something happened")
+		})
+		panic("dontcare")
+	}) {
+		t.Error("AbortsContains should return false for missing substring")
+	}
+	mockT.equals(t, "error: func should abort with message containing:\t\"notfound\"\n\tActual abort value:\t\"abort message: something happened\"")
+
+	if uassert.AbortsContains(mockT, cur, "abort", func() {
+		// noop
+	}) {
+		t.Error("AbortsContains should return false when no abort occurs")
+	}
+	mockT.equals(t, "error: func should abort")
+}
+
+func TestNotAborts(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+
+	if !uassert.NotPanics(mockT, cur, func() {
+		// noop
+	}) {
+		t.Error("NotAborts should return true")
+	}
+	mockT.empty(t)
+
+	if uassert.NotPanics(mockT, cur, func() {
+		tests.ExecSwitch(cross(cur), func() {
+			panic("Abort!")
+		})
+		panic("dontcare")
+	}) {
+		t.Error("NotAborts should return false")
+	}
+	mockT.equals(t, "error: func should not abort\n\tAbort value:\tAbort!")
+}
+
+func TestNotPanics(cur realm, t *testing.T) {
+	mockT := new(mockTestingT)
+
+	if !uassert.NotPanics(mockT, cur, func() {
+		// noop
+	}) {
+		t.Error("NotPanics should return true")
+	}
+	mockT.empty(t)
+
+	if uassert.NotPanics(mockT, cur, func() {
+		panic("Panic!")
+	}) {
+		t.Error("NotPanics should return false")
+	}
+	mockT.equals(t, "error: func should not panic\n\tPanic value:\tPanic!")
+}
+
+func TestEqual(t *testing.T) {
+	mockT := new(mockTestingT)
+
+	cases := []struct {
+		expected any
+		actual   any
+		result   bool
+		remark   string
+	}{
+		// expected to be equal
+		{"Hello World", "Hello World", true, ""},
+		{123, 123, true, ""},
+		{123.5, 123.5, true, ""},
+		{nil, nil, true, ""},
+		{int32(123), int32(123), true, ""},
+		{uint64(123), uint64(123), true, ""},
+		{address("g12345"), address("g12345"), true, ""},
+		// XXX: continue
+
+		// not expected to be equal
+		{"Hello World", 42, false, ""},
+		{41, 42, false, ""},
+		{10, uint(10), false, ""},
+		// XXX: continue
+
+		// expected to raise errors
+		// XXX: todo
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("Equal(%v, %v)", c.expected, c.actual)
+		t.Run(name, func(t *testing.T) {
+			res := uassert.Equal(mockT, c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("%s should return %v: %s - %s", name, c.result, c.remark, mockT.actualString())
+			}
+		})
+	}
+}
+
+func TestNotEqual(t *testing.T) {
+	mockT := new(mockTestingT)
+
+	cases := []struct {
+		expected any
+		actual   any
+		result   bool
+		remark   string
+	}{
+		// expected to be not equal
+		{"Hello World", "Hello", true, ""},
+		{123, 124, true, ""},
+		{123.5, 123.6, true, ""},
+		{nil, 123, true, ""},
+		{int32(123), int32(124), true, ""},
+		{uint64(123), uint64(124), true, ""},
+		{address("g12345"), address("g67890"), true, ""},
+		// XXX: continue
+
+		// not expected to be not equal
+		{"Hello World", "Hello World", false, ""},
+		{123, 123, false, ""},
+		{123.5, 123.5, false, ""},
+		{nil, nil, false, ""},
+		{int32(123), int32(123), false, ""},
+		{uint64(123), uint64(123), false, ""},
+		{address("g12345"), address("g12345"), false, ""},
+		// XXX: continue
+
+		// expected to raise errors
+		// XXX: todo
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("NotEqual(%v, %v)", c.expected, c.actual)
+		t.Run(name, func(t *testing.T) {
+			res := uassert.NotEqual(mockT, c.expected, c.actual)
+
+			if res != c.result {
+				t.Errorf("%s should return %v: %s - %s", name, c.result, c.remark, mockT.actualString())
+			}
+		})
+	}
+}
+
+type myStruct struct {
+	S string
+	I int
+}
+
+func TestEmpty(t *testing.T) {
+	mockT := new(mockTestingT)
+
+	cases := []struct {
+		obj           any
+		expectedEmpty bool
+	}{
+		// expected to be empty
+		{"", true},
+		{0, true},
+		{int(0), true},
+		{int32(0), true},
+		{int64(0), true},
+		{uint(0), true},
+		// XXX: continue
+
+		// not expected to be empty
+		{"Hello World", false},
+		{1, false},
+		{int32(1), false},
+		{uint64(1), false},
+		{address("g12345"), false},
+
+		// unsupported
+		{nil, false},
+		{myStruct{}, false},
+		{&myStruct{}, false},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("Empty(%v)", c.obj)
+		t.Run(name, func(t *testing.T) {
+			res := uassert.Empty(mockT, c.obj)
+
+			if res != c.expectedEmpty {
+				t.Errorf("%s should return %v: %s", name, c.expectedEmpty, mockT.actualString())
+			}
+		})
+	}
+}
+
+func TestEqualWithStringDiff(t *testing.T) {
+	cases := []struct {
+		name        string
+		expected    string
+		actual      string
+		shouldPass  bool
+		expectedMsg string
+	}{
+		{
+			name:        "Identical strings",
+			expected:    "Hello, world!",
+			actual:      "Hello, world!",
+			shouldPass:  true,
+			expectedMsg: "",
+		},
+		{
+			name:        "Different strings - simple",
+			expected:    "Hello, world!",
+			actual:      "Hello, World!",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: Hello, [-w][+W]orld!",
+		},
+		{
+			name:        "Different strings - complex",
+			expected:    "The quick brown fox jumps over the lazy dog",
+			actual:      "The quick brown cat jumps over the lazy dog",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: The quick brown [-fox][+cat] jumps over the lazy dog",
+		},
+		{
+			name:        "Different strings - prefix",
+			expected:    "prefix_string",
+			actual:      "string",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: [-prefix_]string",
+		},
+		{
+			name:        "Different strings - suffix",
+			expected:    "string",
+			actual:      "string_suffix",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: string[+_suffix]",
+		},
+		{
+			name:        "Empty string vs non-empty string",
+			expected:    "",
+			actual:      "non-empty",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: [+non-empty]",
+		},
+		{
+			name:        "Non-empty string vs empty string",
+			expected:    "non-empty",
+			actual:      "",
+			shouldPass:  false,
+			expectedMsg: "error: uassert.Equal: strings are different\n\tDiff: [-non-empty]",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockT := &mockTestingT{}
+			result := uassert.Equal(mockT, tc.expected, tc.actual)
+
+			if result != tc.shouldPass {
+				t.Errorf("Expected Equal to return %v, but got %v", tc.shouldPass, result)
+			}
+
+			if tc.shouldPass {
+				mockT.empty(t)
+			} else {
+				mockT.equals(t, tc.expectedMsg)
+			}
+		})
+	}
+}
+
+func TestNotEmpty(t *testing.T) {
+	mockT := new(mockTestingT)
+
+	cases := []struct {
+		obj              any
+		expectedNotEmpty bool
+	}{
+		// expected to be empty
+		{"", false},
+		{0, false},
+		{int(0), false},
+		{int32(0), false},
+		{int64(0), false},
+		{uint(0), false},
+		{address(""), false},
+
+		// not expected to be empty
+		{"Hello World", true},
+		{1, true},
+		{int32(1), true},
+		{uint64(1), true},
+		{address("g12345"), true},
+
+		// unsupported
+		{nil, false},
+		{myStruct{}, false},
+		{&myStruct{}, false},
+	}
+
+	for _, c := range cases {
+		name := fmt.Sprintf("NotEmpty(%v)", c.obj)
+		t.Run(name, func(t *testing.T) {
+			res := uassert.NotEmpty(mockT, c.obj)
+
+			if res != c.expectedNotEmpty {
+				t.Errorf("%s should return %v: %s", name, c.expectedNotEmpty, mockT.actualString())
+			}
+		})
+	}
+}
+
+func TestNil(t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.Nil(mockT, nil) {
+		t.Error("Nil should return true")
+	}
+	mockT.empty(t)
+	if uassert.Nil(mockT, 0) {
+		t.Error("Nil should return false")
+	}
+	mockT.equals(t, "error: should be nil")
+	if uassert.Nil(mockT, (*int)(nil)) {
+		t.Error("Nil should return false")
+	}
+	mockT.equals(t, "error: should be nil")
+}
+
+func TestNotNil(t *testing.T) {
+	mockT := new(mockTestingT)
+	if uassert.NotNil(mockT, nil) {
+		t.Error("NotNil should return false")
+	}
+	mockT.equals(t, "error: should not be nil")
+	if !uassert.NotNil(mockT, 0) {
+		t.Error("NotNil should return true")
+	}
+	mockT.empty(t)
+	if !uassert.NotNil(mockT, (*int)(nil)) {
+		t.Error("NotNil should return true")
+	}
+	mockT.empty(t)
+}
+
+func TestTypedNil(t *testing.T) {
+	mockT := new(mockTestingT)
+	if uassert.TypedNil(mockT, nil) {
+		t.Error("TypedNil should return false")
+	}
+	mockT.equals(t, "error: should be typed-nil but got nil instead")
+	if uassert.TypedNil(mockT, 0) {
+		t.Error("TypedNil should return false")
+	}
+	mockT.equals(t, "error: should be typed-nil")
+	if !uassert.TypedNil(mockT, (*int)(nil)) {
+		t.Error("TypedNil should return true")
+	}
+	mockT.empty(t)
+}
+
+func TestNotTypedNil(t *testing.T) {
+	mockT := new(mockTestingT)
+	if !uassert.NotTypedNil(mockT, nil) {
+		t.Error("NotTypedNil should return true")
+	}
+	mockT.empty(t)
+	if !uassert.NotTypedNil(mockT, 0) {
+		t.Error("NotTypedNil should return true")
+	}
+	mockT.empty(t)
+	if uassert.NotTypedNil(mockT, (*int)(nil)) {
+		t.Error("NotTypedNil should return false")
+	}
+	mockT.equals(t, "error: should not be typed-nil")
+}

--- a/vendored/gno.land/p/nt/ufmt/v0/README.md
+++ b/vendored/gno.land/p/nt/ufmt/v0/README.md
@@ -1,0 +1,8 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+# ufmt
+
+Package `ufmt` provides utility functions for formatting strings, similarly to the Go package `fmt`, of which only a subset is currently supported.

--- a/vendored/gno.land/p/nt/ufmt/v0/doc.gno
+++ b/vendored/gno.land/p/nt/ufmt/v0/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package ufmt provides utility functions for formatting strings, similarly to
+// the Go package "fmt", of which only a subset is currently supported.
+package ufmt

--- a/vendored/gno.land/p/nt/ufmt/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/ufmt/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/ufmt/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/ufmt/v0/ufmt.gno
+++ b/vendored/gno.land/p/nt/ufmt/v0/ufmt.gno
@@ -1,0 +1,623 @@
+// Package ufmt provides utility functions for formatting strings, similarly to
+// the Go package "fmt", of which only a subset is currently supported (hence
+// the name µfmt - micro fmt). It includes functions like Printf, Sprintf,
+// Fprintf, and Errorf.
+// Supported formatting verbs are documented in the Sprintf function.
+package ufmt
+
+import (
+	"errors"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// buffer accumulates formatted output as a byte slice.
+type buffer []byte
+
+func (b *buffer) write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) writeString(s string) {
+	*b = append(*b, s...)
+}
+
+func (b *buffer) writeByte(c byte) {
+	*b = append(*b, c)
+}
+
+func (b *buffer) writeRune(r rune) {
+	*b = utf8.AppendRune(*b, r)
+}
+
+// printer holds state for formatting operations.
+type printer struct {
+	buf buffer
+}
+
+func newPrinter() *printer {
+	return &printer{}
+}
+
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Sprint writes the given arguments with spaces between arguments.
+func Sprint(a ...any) string {
+	p := newPrinter()
+	p.doPrint(a)
+	return string(p.buf)
+}
+
+// doPrint formats arguments using default formats and writes to printer's buffer.
+// Spaces are added between arguments.
+func (p *printer) doPrint(args []any) {
+	for argNum, arg := range args {
+		if argNum > 0 {
+			p.buf.writeRune(' ')
+		}
+
+		switch v := arg.(type) {
+		case string:
+			p.buf.writeString(v)
+		case (interface{ String() string }):
+			p.buf.writeString(v.String())
+		case error:
+			p.buf.writeString(v.Error())
+		case float64:
+			p.buf.writeString(Sprintf("%f", v))
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			p.buf.writeString(Sprintf("%d", v))
+		case bool:
+			if v {
+				p.buf.writeString("true")
+			} else {
+				p.buf.writeString("false")
+			}
+		case nil:
+			p.buf.writeString("<nil>")
+		default:
+			p.buf.writeString("(unhandled)")
+		}
+	}
+}
+
+// doPrintln appends a newline after formatting arguments with doPrint.
+func (p *printer) doPrintln(a []any) {
+	p.doPrint(a)
+	p.buf.writeByte('\n')
+}
+
+// Sprintf offers similar functionality to Go's fmt.Sprintf, or the sprintf
+// equivalent available in many languages, including C/C++.
+// The number of args passed must exactly match the arguments consumed by the format.
+// A limited number of formatting verbs and features are currently supported.
+//
+// Supported verbs:
+//
+//	%s: Places a string value directly.
+//	    If the value implements the interface interface{ String() string },
+//	    the String() method is called to retrieve the value. Same about Error()
+//	    string.
+//	%c: Formats the character represented by Unicode code point
+//	%d: Formats an integer value using package "strconv".
+//	    Currently supports only uint, uint64, int, int64.
+//	%f: Formats a float value, with a default precision of 6.
+//	%e: Formats a float with scientific notation; 1.23456e+78
+//	%E: Formats a float with scientific notation; 1.23456E+78
+//	%F: The same as %f
+//	%g: Formats a float value with %e for large exponents, and %f with full precision for smaller numbers
+//	%G: Formats a float value with %G for large exponents, and %F with full precision for smaller numbers
+//	%t: Formats a boolean value to "true" or "false".
+//	%x: Formats an integer value as a hexadecimal string.
+//	    Currently supports only uint8, []uint8, [32]uint8.
+//	%c: Formats a rune value as a string.
+//	    Currently supports only rune, int.
+//	%q: Formats a string value as a quoted string.
+//	%T: Formats the type of the value.
+//	%v: Formats the value with a default representation appropriate for the value's type
+//	    - nil: <nil>
+//	    - bool: true/false
+//	    - integers: base 10
+//	    - float64: %g format
+//	    - string: verbatim
+//	    - types with String()/Error(): method result
+//	    - others: (unhandled)
+//	%%: Outputs a literal %. Does not consume an argument.
+//
+// Unsupported verbs or type mismatches produce error strings like "%!d(string=foo)".
+func Sprintf(format string, a ...any) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return string(p.buf)
+}
+
+// doPrintf parses the format string and writes formatted arguments to the buffer.
+func (p *printer) doPrintf(format string, args []any) {
+	sTor := []rune(format)
+	end := len(sTor)
+	argNum := 0
+	argLen := len(args)
+
+	for i := 0; i < end; {
+		isLast := i == end-1
+		c := sTor[i]
+
+		if isLast || c != '%' {
+			// we don't check for invalid format like a one ending with "%"
+			p.buf.writeRune(c)
+			i++
+			continue
+		}
+
+		length := -1
+		precision := -1
+		i++ // skip '%'
+
+		digits := func() string {
+			start := i
+			for i < end && sTor[i] >= '0' && sTor[i] <= '9' {
+				i++
+			}
+			if i > start {
+				return string(sTor[start:i])
+			}
+			return ""
+		}
+
+		if l := digits(); l != "" {
+			var err error
+			length, err = strconv.Atoi(l)
+			if err != nil {
+				panic("ufmt: invalid length specification")
+			}
+		}
+
+		if i < end && sTor[i] == '.' {
+			i++ // skip '.'
+			if l := digits(); l != "" {
+				var err error
+				precision, err = strconv.Atoi(l)
+				if err != nil {
+					panic("ufmt: invalid precision specification")
+				}
+			}
+		}
+
+		if i >= end {
+			panic("ufmt: invalid format string")
+		}
+
+		verb := sTor[i]
+		if verb == '%' {
+			p.buf.writeRune('%')
+			i++
+			continue
+		}
+
+		if argNum >= argLen {
+			panic("ufmt: not enough arguments")
+		}
+		arg := args[argNum]
+		argNum++
+
+		switch verb {
+		case 'v':
+			writeValue(p, verb, arg)
+		case 's':
+			writeStringWithLength(p, verb, arg, length)
+		case 'c':
+			writeChar(p, verb, arg)
+		case 'd':
+			writeInt(p, verb, arg)
+		case 'e', 'E', 'f', 'F', 'g', 'G':
+			writeFloatWithPrecision(p, verb, arg, precision)
+		case 't':
+			writeBool(p, verb, arg)
+		case 'x':
+			writeHex(p, verb, arg)
+		case 'q':
+			writeQuotedString(p, verb, arg)
+		case 'T':
+			writeType(p, arg)
+		// % handled before, as it does not consume an argument
+		default:
+			p.buf.writeString("(unhandled verb: %" + string(verb) + ")")
+		}
+
+		i++
+	}
+
+	if argNum < argLen {
+		panic("ufmt: too many arguments")
+	}
+}
+
+// writeValue handles %v formatting
+func writeValue(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case nil:
+		p.buf.writeString("<nil>")
+	case bool:
+		writeBool(p, verb, v)
+	case int:
+		p.buf.writeString(strconv.Itoa(v))
+	case int8:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int16:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int32:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int64:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case uint:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint16:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint32:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint64:
+		p.buf.writeString(strconv.FormatUint(v, 10))
+	case float64:
+		p.buf.writeString(strconv.FormatFloat(v, 'g', -1, 64))
+	case string:
+		p.buf.writeString(v)
+	case []byte:
+		p.buf.write(v)
+	case []rune:
+		p.buf.writeString(string(v))
+	case (interface{ String() string }):
+		p.buf.writeString(v.String())
+	case error:
+		p.buf.writeString(v.Error())
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+// writeStringWithLength handles %s formatting with length specification
+func writeStringWithLength(p *printer, verb rune, arg any, length int) {
+	var s string
+	switch v := arg.(type) {
+	case (interface{ String() string }):
+		s = v.String()
+	case error:
+		s = v.Error()
+	case string:
+		s = v
+	default:
+		s = fallback(verb, v)
+	}
+
+	if length > 0 && len(s) < length {
+		s = strings.Repeat(" ", length-len(s)) + s
+	}
+	p.buf.writeString(s)
+}
+
+// writeChar handles %c formatting
+func writeChar(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	// rune is int32. Exclude overflowing numeric types and dups (byte, int32):
+	case rune:
+		p.buf.writeString(string(v))
+	case int:
+		p.buf.writeRune(rune(v))
+	case int8:
+		p.buf.writeRune(rune(v))
+	case int16:
+		p.buf.writeRune(rune(v))
+	case uint:
+		p.buf.writeRune(rune(v))
+	case uint8:
+		p.buf.writeRune(rune(v))
+	case uint16:
+		p.buf.writeRune(rune(v))
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+// writeInt handles %d formatting
+func writeInt(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case int:
+		p.buf.writeString(strconv.Itoa(v))
+	case int8:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int16:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int32:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case int64:
+		p.buf.writeString(strconv.Itoa(int(v)))
+	case uint:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint16:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint32:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 10))
+	case uint64:
+		p.buf.writeString(strconv.FormatUint(v, 10))
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+// writeFloatWithPrecision handles floating-point formatting with precision
+func writeFloatWithPrecision(p *printer, verb rune, arg any, precision int) {
+	switch v := arg.(type) {
+	case float64:
+		format := byte(verb)
+		if format == 'F' {
+			format = 'f'
+		}
+		if precision < 0 {
+			switch format {
+			case 'e', 'E':
+				precision = 2
+			default:
+				precision = 6
+			}
+		}
+		p.buf = strconv.AppendFloat(p.buf, v, format, precision, 64)
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+// writeBool handles %t formatting
+func writeBool(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case bool:
+		if v {
+			p.buf.writeString("true")
+		} else {
+			p.buf.writeString("false")
+		}
+	default:
+		p.buf.writeString(fallback(verb, v))
+	}
+}
+
+// writeHex handles %x formatting
+func writeHex(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case uint8:
+		p.buf.writeString(strconv.FormatUint(uint64(v), 16))
+	default:
+		p.buf.writeString("(unhandled)")
+	}
+}
+
+// writeQuotedString handles %q formatting
+func writeQuotedString(p *printer, verb rune, arg any) {
+	switch v := arg.(type) {
+	case string:
+		p.buf.writeString(strconv.Quote(v))
+	default:
+		p.buf.writeString("(unhandled)")
+	}
+}
+
+// writeType handles %T formatting
+func writeType(p *printer, arg any) {
+	switch arg.(type) {
+	case bool:
+		p.buf.writeString("bool")
+	case int:
+		p.buf.writeString("int")
+	case int8:
+		p.buf.writeString("int8")
+	case int16:
+		p.buf.writeString("int16")
+	case int32:
+		p.buf.writeString("int32")
+	case int64:
+		p.buf.writeString("int64")
+	case uint:
+		p.buf.writeString("uint")
+	case uint8:
+		p.buf.writeString("uint8")
+	case uint16:
+		p.buf.writeString("uint16")
+	case uint32:
+		p.buf.writeString("uint32")
+	case uint64:
+		p.buf.writeString("uint64")
+	case string:
+		p.buf.writeString("string")
+	case []byte:
+		p.buf.writeString("[]byte")
+	case []rune:
+		p.buf.writeString("[]rune")
+	default:
+		p.buf.writeString("unknown")
+	}
+}
+
+// Fprintf formats according to a format specifier and writes to w.
+// Returns the number of bytes written and any write error encountered.
+func Fprintf(w io.Writer, format string, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return w.Write(p.buf)
+}
+
+// Printf formats according to a format specifier and writes to standard output.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
+func Printf(format string, a ...any) (n int, err error) {
+	var out strings.Builder
+	n, err = Fprintf(&out, format, a...)
+	print(out.String())
+	return n, err
+}
+
+// Appendf formats according to a format specifier, appends the result to the byte
+// slice, and returns the updated slice.
+func Appendf(b []byte, format string, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	return append(b, p.buf...)
+}
+
+// Fprint formats using default formats and writes to w.
+// Spaces are added between arguments.
+// Returns the number of bytes written and any write error encountered.
+func Fprint(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrint(a)
+	return w.Write(p.buf)
+}
+
+// Print formats using default formats and writes to standard output.
+// Spaces are added between arguments.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
+func Print(a ...any) (n int, err error) {
+	var out strings.Builder
+	n, err = Fprint(&out, a...)
+	print(out.String())
+	return n, err
+}
+
+// Append formats using default formats, appends to b, and returns the updated slice.
+// Spaces are added between arguments.
+func Append(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrint(a)
+	return append(b, p.buf...)
+}
+
+// Fprintln formats using default formats and writes to w with newline.
+// Returns the number of bytes written and any write error encountered.
+func Fprintln(w io.Writer, a ...any) (n int, err error) {
+	p := newPrinter()
+	p.doPrintln(a)
+	return w.Write(p.buf)
+}
+
+// Println formats using default formats and writes to standard output with newline.
+// Returns the number of bytes written and any write error encountered.
+//
+// XXX: Replace with os.Stdout handling when available.
+func Println(a ...any) (n int, err error) {
+	var out strings.Builder
+	n, err = Fprintln(&out, a...)
+	print(out.String())
+	return n, err
+}
+
+// Sprintln formats using default formats and returns the string with newline.
+// Spaces are always added between arguments.
+func Sprintln(a ...any) string {
+	p := newPrinter()
+	p.doPrintln(a)
+	return string(p.buf)
+}
+
+// Appendln formats using default formats, appends to b, and returns the updated slice.
+// Appends a newline after the last argument.
+func Appendln(b []byte, a ...any) []byte {
+	p := newPrinter()
+	p.doPrintln(a)
+	return append(b, p.buf...)
+}
+
+// This function is used to mimic Go's fmt.Sprintf
+// specific behaviour of showing verb/type mismatches,
+// where for example:
+//
+//	fmt.Sprintf("%d", "foo") gives "%!d(string=foo)"
+//
+// Here:
+//
+//	fallback("s", 8) -> "%!s(int=8)"
+//	fallback("d", nil) -> "%!d(<nil>)", and so on.f
+func fallback(verb rune, arg any) string {
+	var s string
+	switch v := arg.(type) {
+	case string:
+		s = "string=" + v
+	case (interface{ String() string }):
+		s = "string=" + v.String()
+	case error:
+		// note: also "string=" in Go fmt
+		s = "string=" + v.Error()
+	case float64:
+		s = "float64=" + Sprintf("%f", v)
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		// note: rune, byte would be dups, being aliases
+		if typename, e := typeToString(v); e == nil {
+			s = typename + "=" + Sprintf("%d", v)
+		} else {
+			panic("ufmt: unexpected type error")
+		}
+	case bool:
+		s = "bool=" + strconv.FormatBool(v)
+	case nil:
+		s = "<nil>"
+	default:
+		s = "(unhandled)"
+	}
+	return "%!" + string(verb) + "(" + s + ")"
+}
+
+// typeToString returns the name of basic Go types as string.
+func typeToString(v any) (string, error) {
+	switch v.(type) {
+	case string:
+		return "string", nil
+	case int:
+		return "int", nil
+	case int8:
+		return "int8", nil
+	case int16:
+		return "int16", nil
+	case int32:
+		return "int32", nil
+	case int64:
+		return "int64", nil
+	case uint:
+		return "uint", nil
+	case uint8:
+		return "uint8", nil
+	case uint16:
+		return "uint16", nil
+	case uint32:
+		return "uint32", nil
+	case uint64:
+		return "uint64", nil
+	case float32:
+		return "float32", nil
+	case float64:
+		return "float64", nil
+	case bool:
+		return "bool", nil
+	default:
+		return "", errors.New("unsupported type")
+	}
+}
+
+// errMsg implements the error interface for formatted error strings.
+type errMsg struct {
+	msg string
+}
+
+// Error returns the formatted error message.
+func (e *errMsg) Error() string {
+	return e.msg
+}
+
+// Errorf formats according to a format specifier and returns an error value.
+// Supports the same verbs as Sprintf. See Sprintf documentation for details.
+func Errorf(format string, args ...any) error {
+	return &errMsg{Sprintf(format, args...)}
+}

--- a/vendored/gno.land/p/nt/ufmt/v0/ufmt_test.gno
+++ b/vendored/gno.land/p/nt/ufmt/v0/ufmt_test.gno
@@ -1,0 +1,370 @@
+package ufmt
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type stringer struct{}
+
+func (stringer) String() string {
+	return "I'm a stringer"
+}
+
+func TestSprintf(t *testing.T) {
+	tru := true
+	cases := []struct {
+		format         string
+		values         []any
+		expectedOutput string
+	}{
+		{"hello %s!", []any{"planet"}, "hello planet!"},
+		{"hello %v!", []any{"planet"}, "hello planet!"},
+		{"hi %%%s!", []any{"worl%d"}, "hi %worl%d!"},
+		{"%s %c %d %t", []any{"foo", 'α', 421, true}, "foo α 421 true"},
+		{"string [%s]", []any{"foo"}, "string [foo]"},
+		{"int [%d]", []any{int(42)}, "int [42]"},
+		{"int [%v]", []any{int(42)}, "int [42]"},
+		{"int8 [%d]", []any{int8(8)}, "int8 [8]"},
+		{"int8 [%v]", []any{int8(8)}, "int8 [8]"},
+		{"int16 [%d]", []any{int16(16)}, "int16 [16]"},
+		{"int16 [%v]", []any{int16(16)}, "int16 [16]"},
+		{"int32 [%d]", []any{int32(32)}, "int32 [32]"},
+		{"int32 [%v]", []any{int32(32)}, "int32 [32]"},
+		{"int64 [%d]", []any{int64(64)}, "int64 [64]"},
+		{"int64 [%v]", []any{int64(64)}, "int64 [64]"},
+		{"uint [%d]", []any{uint(42)}, "uint [42]"},
+		{"uint [%v]", []any{uint(42)}, "uint [42]"},
+		{"uint8 [%d]", []any{uint8(8)}, "uint8 [8]"},
+		{"uint8 [%v]", []any{uint8(8)}, "uint8 [8]"},
+		{"uint16 [%d]", []any{uint16(16)}, "uint16 [16]"},
+		{"uint16 [%v]", []any{uint16(16)}, "uint16 [16]"},
+		{"uint32 [%d]", []any{uint32(32)}, "uint32 [32]"},
+		{"uint32 [%v]", []any{uint32(32)}, "uint32 [32]"},
+		{"uint64 [%d]", []any{uint64(64)}, "uint64 [64]"},
+		{"uint64 [%v]", []any{uint64(64)}, "uint64 [64]"},
+		{"float64 [%e]", []any{float64(64.1)}, "float64 [6.41e+01]"},
+		{"float64 [%E]", []any{float64(64.1)}, "float64 [6.41E+01]"},
+		{"float64 [%f]", []any{float64(64.1)}, "float64 [64.100000]"},
+		{"float64 [%F]", []any{float64(64.1)}, "float64 [64.100000]"},
+		{"float64 [%g]", []any{float64(64.1)}, "float64 [64.1]"},
+		{"float64 [%G]", []any{float64(64.1)}, "float64 [64.1]"},
+		{"bool [%t]", []any{true}, "bool [true]"},
+		{"bool [%v]", []any{true}, "bool [true]"},
+		{"bool [%t]", []any{false}, "bool [false]"},
+		{"bool [%v]", []any{false}, "bool [false]"},
+		{"no args", nil, "no args"},
+		{"finish with %", nil, "finish with %"},
+		{"stringer [%s]", []any{stringer{}}, "stringer [I'm a stringer]"},
+		{"â", nil, "â"},
+		{"Hello, World! 😊", nil, "Hello, World! 😊"},
+		{"unicode formatting: %s", []any{"😊"}, "unicode formatting: 😊"},
+		{"invalid hex [%x]", []any{"invalid"}, "invalid hex [(unhandled)]"},
+		{"rune as character [%c]", []any{rune('A')}, "rune as character [A]"},
+		{"int as character [%c]", []any{int('B')}, "int as character [B]"},
+		{"quoted string [%q]", []any{"hello"}, "quoted string [\"hello\"]"},
+		{"quoted string with escape [%q]", []any{"\thello\nworld\\"}, "quoted string with escape [\"\\thello\\nworld\\\\\"]"},
+		{"invalid quoted string [%q]", []any{123}, "invalid quoted string [(unhandled)]"},
+		{"type of bool [%T]", []any{true}, "type of bool [bool]"},
+		{"type of int [%T]", []any{123}, "type of int [int]"},
+		{"type of string [%T]", []any{"hello"}, "type of string [string]"},
+		{"type of []byte [%T]", []any{[]byte{1, 2, 3}}, "type of []byte [[]byte]"},
+		{"type of []rune [%T]", []any{[]rune{'a', 'b', 'c'}}, "type of []rune [[]rune]"},
+		{"type of unknown [%T]", []any{struct{}{}}, "type of unknown [unknown]"},
+		// mismatch printing
+		{"%s", []any{nil}, "%!s(<nil>)"},
+		{"%s", []any{421}, "%!s(int=421)"},
+		{"%s", []any{"z"}, "z"},
+		{"%s", []any{tru}, "%!s(bool=true)"},
+		{"%s", []any{'z'}, "%!s(int32=122)"},
+
+		{"%c", []any{nil}, "%!c(<nil>)"},
+		{"%c", []any{421}, "ƥ"},
+		{"%c", []any{"z"}, "%!c(string=z)"},
+		{"%c", []any{tru}, "%!c(bool=true)"},
+		{"%c", []any{'z'}, "z"},
+
+		{"%d", []any{nil}, "%!d(<nil>)"},
+		{"%d", []any{421}, "421"},
+		{"%d", []any{"z"}, "%!d(string=z)"},
+		{"%d", []any{tru}, "%!d(bool=true)"},
+		{"%d", []any{'z'}, "122"},
+
+		{"%t", []any{nil}, "%!t(<nil>)"},
+		{"%t", []any{421}, "%!t(int=421)"},
+		{"%t", []any{"z"}, "%!t(string=z)"},
+		{"%t", []any{tru}, "true"},
+		{"%t", []any{'z'}, "%!t(int32=122)"},
+
+		{"%.2f", []any{3.14159}, "3.14"},
+		{"%.4f", []any{3.14159}, "3.1416"},
+		{"%.0f", []any{3.14159}, "3"},
+		{"%.1f", []any{3.0}, "3.0"},
+		{"%.3F", []any{3.14159}, "3.142"},
+		{"%.2e", []any{314.159}, "3.14e+02"},
+		{"%.3E", []any{314.159}, "3.142E+02"},
+		{"%.3g", []any{3.14159}, "3.14"},
+		{"%.5G", []any{3.14159}, "3.1416"},
+		{"%.0f", []any{3.6}, "4"},
+		{"%.0f", []any{3.4}, "3"},
+		{"%.1f", []any{0.0}, "0.0"},
+		{"%.2f", []any{1e6}, "1000000.00"},
+		{"%.2f", []any{1e-6}, "0.00"},
+
+		{"%5s", []any{"Hello World"}, "Hello World"},
+		{"%3s", []any{"Hi"}, " Hi"},
+		{"%2s", []any{"Hello"}, "Hello"},
+		{"%1s", []any{"A"}, "A"},
+		{"%0s", []any{"Test"}, "Test"},
+		{"%5s!", []any{"Hello World"}, "Hello World!"},
+		{"_%5s_", []any{"abc"}, "_  abc_"},
+		{"%2s%4s", []any{"ab", "cde"}, "ab cde"},
+		{"%5s", []any{""}, "     "},
+		{"%3s", []any{nil}, "%!s(<nil>)"},
+		{"%2s", []any{123}, "%!s(int=123)"},
+	}
+
+	for _, tc := range cases {
+		name := fmt.Sprintf(tc.format, tc.values...)
+		t.Run(name, func(t *testing.T) {
+			got := Sprintf(tc.format, tc.values...)
+			if got != tc.expectedOutput {
+				t.Errorf("got %q, want %q.", got, tc.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestErrorf(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		args     []any
+		expected string
+	}{
+		{
+			name:     "simple string",
+			format:   "error: %s",
+			args:     []any{"something went wrong"},
+			expected: "error: something went wrong",
+		},
+		{
+			name:     "integer value",
+			format:   "value: %d",
+			args:     []any{42},
+			expected: "value: 42",
+		},
+		{
+			name:     "boolean value",
+			format:   "success: %t",
+			args:     []any{true},
+			expected: "success: true",
+		},
+		{
+			name:     "multiple values",
+			format:   "error %d: %s (success=%t)",
+			args:     []any{123, "failure occurred", false},
+			expected: "error 123: failure occurred (success=false)",
+		},
+		{
+			name:     "literal percent",
+			format:   "literal %%",
+			args:     []any{},
+			expected: "literal %",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Errorf(tt.format, tt.args...)
+			if err.Error() != tt.expected {
+				t.Errorf("Errorf(%q, %v) = %q, expected %q", tt.format, tt.args, err.Error(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestPrintErrors(t *testing.T) {
+	got := Sprintf("error: %s", errors.New("can I be printed?"))
+	expectedOutput := "error: can I be printed?"
+	if got != expectedOutput {
+		t.Errorf("got %q, want %q.", got, expectedOutput)
+	}
+}
+
+func TestSprint(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []any
+		expected string
+	}{
+		{
+			name:     "Empty args",
+			args:     []any{},
+			expected: "",
+		},
+		{
+			name:     "String args",
+			args:     []any{"Hello", "World"},
+			expected: "Hello World",
+		},
+		{
+			name:     "Integer args",
+			args:     []any{1, 2, 3},
+			expected: "1 2 3",
+		},
+		{
+			name:     "Mixed args",
+			args:     []any{"Hello", 42, true, false, "World"},
+			expected: "Hello 42 true false World",
+		},
+		{
+			name:     "Unhandled type",
+			args:     []any{"Hello", 3.14, []int{1, 2, 3}},
+			expected: "Hello 3.140000 (unhandled)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sprint(tc.args...)
+			if got != tc.expected {
+				t.Errorf("got %q, want %q.", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFprintf(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprintf(&buf, "Count: %d, Message: %s", 42, "hello")
+	if err != nil {
+		t.Fatalf("Fprintf failed: %v", err)
+	}
+
+	const expected = "Count: 42, Message: hello"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrintf(t *testing.T) {
+	n, err := Printf("The answer is %d", 42)
+	if err != nil {
+		t.Fatalf("Printf failed: %v", err)
+	}
+
+	const expected = "The answer is 42"
+	if n != len(expected) {
+		t.Errorf("Expected 14 bytes written, got %d", n)
+	}
+}
+
+func TestAppendf(t *testing.T) {
+	b := []byte("Header: ")
+	result := Appendf(b, "Value %d", 7)
+	const expected = "Header: Value 7"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestFprint(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprint(&buf, "Hello", 42, true)
+	if err != nil {
+		t.Fatalf("Fprint failed: %v", err)
+	}
+
+	const expected = "Hello 42 true"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrint(t *testing.T) {
+	n, err := Print("Mixed", 3.14, false)
+	if err != nil {
+		t.Fatalf("Print failed: %v", err)
+	}
+
+	const expected = "Mixed 3.140000 false"
+	if n != len(expected) {
+		t.Errorf("Expected 12 bytes written, got %d", n)
+	}
+}
+
+func TestAppend(t *testing.T) {
+	b := []byte{0x01, 0x02}
+	result := Append(b, "Test", 99)
+
+	const expected = "\x01\x02Test 99"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func TestFprintln(t *testing.T) {
+	var buf bytes.Buffer
+	n, err := Fprintln(&buf, "Line", 1)
+	if err != nil {
+		t.Fatalf("Fprintln failed: %v", err)
+	}
+
+	const expected = "Line 1\n"
+	if buf.String() != expected {
+		t.Errorf("Expected %q, got %q", expected, buf.String())
+	}
+	if n != len(expected) {
+		t.Errorf("Expected %d bytes written, got %d", len(expected), n)
+	}
+}
+
+// TODO: replace os.Stdout with a buffer to capture the output and test it.
+func TestPrintln(t *testing.T) {
+	n, err := Println("Output", "test")
+	if err != nil {
+		t.Fatalf("Println failed: %v", err)
+	}
+
+	const expected = "Output test\n"
+	if n != len(expected) {
+		t.Errorf("Expected 12 bytes written, got %d", n)
+	}
+}
+
+func TestSprintln(t *testing.T) {
+	result := Sprintln("Item", 42)
+
+	const expected = "Item 42\n"
+	if result != expected {
+		t.Errorf("Expected %q, got %q", expected, result)
+	}
+}
+
+func TestAppendln(t *testing.T) {
+	b := []byte("Start:")
+	result := Appendln(b, "End")
+
+	const expected = "Start:End\n"
+	if string(result) != expected {
+		t.Errorf("Expected %q, got %q", expected, string(result))
+	}
+}
+
+func assertNoError(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}

--- a/vendored/gno.land/p/nt/urequire/v0/README.md
+++ b/vendored/gno.land/p/nt/urequire/v0/README.md
@@ -1,0 +1,8 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+# urequire
+
+Package `urequire` provides test assertion functions that immediately fail the test on error, complementing the `uassert` package.

--- a/vendored/gno.land/p/nt/urequire/v0/doc.gno
+++ b/vendored/gno.land/p/nt/urequire/v0/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package urequire provides test assertion functions that immediately fail the
+// test on error, complementing the uassert package.
+package urequire

--- a/vendored/gno.land/p/nt/urequire/v0/gnomod.toml
+++ b/vendored/gno.land/p/nt/urequire/v0/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/nt/urequire/v0"
+gno = "0.9"

--- a/vendored/gno.land/p/nt/urequire/v0/urequire.gno
+++ b/vendored/gno.land/p/nt/urequire/v0/urequire.gno
@@ -1,0 +1,137 @@
+// urequire is a sister package for uassert.
+// XXX: codegen the package.
+package urequire
+
+import "gno.land/p/nt/uassert/v0"
+
+// type TestingT = uassert.TestingT // XXX: bug, should work
+
+func NoError(t uassert.TestingT, err error, msgs ...string) {
+	t.Helper()
+	if uassert.NoError(t, err, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func Error(t uassert.TestingT, err error, msgs ...string) {
+	t.Helper()
+	if uassert.Error(t, err, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func ErrorContains(t uassert.TestingT, err error, contains string, msgs ...string) {
+	t.Helper()
+	if uassert.ErrorContains(t, err, contains, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func True(t uassert.TestingT, value bool, msgs ...string) {
+	t.Helper()
+	if uassert.True(t, value, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func False(t uassert.TestingT, value bool, msgs ...string) {
+	t.Helper()
+	if uassert.False(t, value, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func ErrorIs(t uassert.TestingT, err, target error, msgs ...string) {
+	t.Helper()
+	if uassert.ErrorIs(t, err, target, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// AbortsWithMessage requires that the code inside the specified func aborts
+// (panics when crossing another realm).
+// Use PanicsWithMessage for requiring local panics within the same realm.
+// Note: This relies on gno's `revive` mechanism to catch aborts.
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func AbortsWithMessage(t uassert.TestingT, rlm realm, msg string, f any, msgs ...string) {
+	t.Helper()
+	if uassert.AbortsWithMessage(t, rlm, msg, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotAborts requires that the code inside the specified func does NOT abort
+// when crossing an execution boundary (e.g., VM call).
+// Use NotPanics for requiring the absence of local panics within the same realm.
+// Note: This relies on Gno's `revive` mechanism.
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func NotAborts(t uassert.TestingT, rlm realm, f any, msgs ...string) {
+	t.Helper()
+	if uassert.NotPanics(t, rlm, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// PanicsWithMessage requires that the code inside the specified func panics
+// locally within the same execution realm.
+// Use AbortsWithMessage for requiring panics that cross execution boundaries (aborts).
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func PanicsWithMessage(t uassert.TestingT, rlm realm, msg string, f any, msgs ...string) {
+	t.Helper()
+	if uassert.PanicsWithMessage(t, rlm, msg, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+// NotPanics requires that the code inside the specified func does NOT panic
+// locally within the same execution realm.
+// Use NotAborts for requiring the absence of panics that cross execution boundaries (aborts).
+// See uassert.AbortsWithMessage for `rlm` semantics.
+func NotPanics(t uassert.TestingT, rlm realm, f any, msgs ...string) {
+	t.Helper()
+	if uassert.NotPanics(t, rlm, f, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func Equal(t uassert.TestingT, expected, actual any, msgs ...string) {
+	t.Helper()
+	if uassert.Equal(t, expected, actual, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func NotEqual(t uassert.TestingT, expected, actual any, msgs ...string) {
+	t.Helper()
+	if uassert.NotEqual(t, expected, actual, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func Empty(t uassert.TestingT, obj any, msgs ...string) {
+	t.Helper()
+	if uassert.Empty(t, obj, msgs...) {
+		return
+	}
+	t.FailNow()
+}
+
+func NotEmpty(t uassert.TestingT, obj any, msgs ...string) {
+	t.Helper()
+	if uassert.NotEmpty(t, obj, msgs...) {
+		return
+	}
+	t.FailNow()
+}

--- a/vendored/gno.land/p/nt/urequire/v0/urequire_test.gno
+++ b/vendored/gno.land/p/nt/urequire/v0/urequire_test.gno
@@ -1,0 +1,10 @@
+package urequire
+
+import "testing"
+
+func TestPackage(t *testing.T) {
+	Equal(t, 42, 42)
+
+	// XXX: find a way to unit test this package thoroughly,
+	// especially the t.FailNow() behavior on assertion failure.
+}

--- a/vendored/gno.land/p/onbloc/diff/diff.gno
+++ b/vendored/gno.land/p/onbloc/diff/diff.gno
@@ -1,0 +1,217 @@
+// The diff package implements the Myers diff algorithm to compute the edit distance
+// and generate a minimal edit script between two strings.
+//
+// Edit distance, also known as Levenshtein distance, is a measure of the similarity
+// between two strings. It is defined as the minimum number of single-character edits (insertions,
+// deletions, or substitutions) required to change one string into the other.
+package diff
+
+import (
+	"strings"
+)
+
+// EditType represents the type of edit operation in a diff.
+type EditType uint8
+
+const (
+	// EditKeep indicates that a character is unchanged in both strings.
+	EditKeep EditType = iota
+
+	// EditInsert indicates that a character was inserted in the new string.
+	EditInsert
+
+	// EditDelete indicates that a character was deleted from the old string.
+	EditDelete
+)
+
+// Edit represent a single edit operation in a diff.
+type Edit struct {
+	// Type is the kind of edit operation.
+	Type EditType
+
+	// Char is the character involved in the edit operation.
+	Char rune
+}
+
+// MyersDiff computes the difference between two strings using Myers' diff algorithm.
+// It returns a slice of Edit operations that transform the old string into the new string.
+// This implementation finds the shortest edit script (SES) that represents the minimal
+// set of operations to transform one string into the other.
+//
+// The function handles both ASCII and non-ASCII characters correctly.
+//
+// Time complexity: O((N+M)D), where N and M are the lengths of the input strings,
+// and D is the size of the minimum edit script.
+//
+// Space complexity: O((N+M)D)
+//
+// In the worst case, where the strings are completely different, D can be as large as N+M,
+// leading to a time and space complexity of O((N+M)^2). However, for strings with many
+// common substrings, the performance is much better, often closer to O(N+M).
+//
+// Parameters:
+//   - old: the original string.
+//   - new: the modified string.
+//
+// Returns:
+//   - A slice of Edit operations representing the minimum difference between the two strings.
+func MyersDiff(old, new string) []Edit {
+	oldRunes, newRunes := []rune(old), []rune(new)
+	n, m := len(oldRunes), len(newRunes)
+
+	if n == 0 && m == 0 {
+		return []Edit{}
+	}
+
+	// old is empty
+	if n == 0 {
+		edits := make([]Edit, m)
+		for i, r := range newRunes {
+			edits[i] = Edit{Type: EditInsert, Char: r}
+		}
+		return edits
+	}
+
+	if m == 0 {
+		edits := make([]Edit, n)
+		for i, r := range oldRunes {
+			edits[i] = Edit{Type: EditDelete, Char: r}
+		}
+		return edits
+	}
+
+	max := n + m
+	v := make([]int, 2*max+1)
+	var trace [][]int
+search:
+	for d := 0; d <= max; d++ {
+		// iterate through diagonals
+		for k := -d; k <= d; k += 2 {
+			var x int
+			if k == -d || (k != d && v[max+k-1] < v[max+k+1]) {
+				x = v[max+k+1] // move down
+			} else {
+				x = v[max+k-1] + 1 // move right
+			}
+			y := x - k
+
+			// extend the path as far as possible with matching characters
+			for x < n && y < m && oldRunes[x] == newRunes[y] {
+				x++
+				y++
+			}
+
+			v[max+k] = x
+
+			// check if we've reached the end of both strings
+			if x == n && y == m {
+				trace = append(trace, append([]int(nil), v...))
+				break search
+			}
+		}
+		trace = append(trace, append([]int(nil), v...))
+	}
+
+	// backtrack to construct the edit script
+	edits := make([]Edit, 0, n+m)
+	x, y := n, m
+	for d := len(trace) - 1; d >= 0; d-- {
+		vPrev := trace[d]
+		k := x - y
+		var prevK int
+		if k == -d || (k != d && vPrev[max+k-1] < vPrev[max+k+1]) {
+			prevK = k + 1
+		} else {
+			prevK = k - 1
+		}
+		prevX := vPrev[max+prevK]
+		prevY := prevX - prevK
+
+		// add keep edits for matching characters
+		for x > prevX && y > prevY {
+			if x > 0 && y > 0 {
+				edits = append([]Edit{{Type: EditKeep, Char: oldRunes[x-1]}}, edits...)
+			}
+			x--
+			y--
+		}
+		if y > prevY {
+			if y > 0 {
+				edits = append([]Edit{{Type: EditInsert, Char: newRunes[y-1]}}, edits...)
+			}
+			y--
+		} else if x > prevX {
+			if x > 0 {
+				edits = append([]Edit{{Type: EditDelete, Char: oldRunes[x-1]}}, edits...)
+			}
+			x--
+		}
+	}
+
+	return edits
+}
+
+// Format converts a slice of Edit operations into a human-readable string representation.
+// It groups consecutive edits of the same type and formats them as follows:
+//   - Unchanged characters are left as-is
+//   - Inserted characters are wrapped in [+...]
+//   - Deleted characters are wrapped in [-...]
+//
+// This function is useful for visualizing the differences between two strings
+// in a compact and intuitive format.
+//
+// Parameters:
+//   - edits: A slice of Edit operations, typically produced by MyersDiff
+//
+// Returns:
+//   - A formatted string representing the diff
+//
+// Example output:
+//
+//	For the diff between "abcd" and "acbd", the output might be:
+//	"a[-b]c[+b]d"
+//
+// Note:
+//
+//	The function assumes that the input slice of edits is in the correct order.
+//	An empty input slice will result in an empty string.
+func Format(edits []Edit) string {
+	if len(edits) == 0 {
+		return ""
+	}
+
+	var (
+		result       strings.Builder
+		currentType  EditType
+		currentChars strings.Builder
+	)
+
+	flushCurrent := func() {
+		if currentChars.Len() > 0 {
+			switch currentType {
+			case EditKeep:
+				result.WriteString(currentChars.String())
+			case EditInsert:
+				result.WriteString("[+")
+				result.WriteString(currentChars.String())
+				result.WriteByte(']')
+			case EditDelete:
+				result.WriteString("[-")
+				result.WriteString(currentChars.String())
+				result.WriteByte(']')
+			}
+			currentChars.Reset()
+		}
+	}
+
+	for _, edit := range edits {
+		if edit.Type != currentType {
+			flushCurrent()
+			currentType = edit.Type
+		}
+		currentChars.WriteRune(edit.Char)
+	}
+	flushCurrent()
+
+	return result.String()
+}

--- a/vendored/gno.land/p/onbloc/diff/diff_test.gno
+++ b/vendored/gno.land/p/onbloc/diff/diff_test.gno
@@ -1,0 +1,183 @@
+package diff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMyersDiff(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		expected string
+	}{
+		{
+			name:     "No difference",
+			old:      "abc",
+			new:      "abc",
+			expected: "abc",
+		},
+		{
+			name:     "Simple insertion",
+			old:      "ac",
+			new:      "abc",
+			expected: "a[+b]c",
+		},
+		{
+			name:     "Simple deletion",
+			old:      "abc",
+			new:      "ac",
+			expected: "a[-b]c",
+		},
+		{
+			name:     "Simple substitution",
+			old:      "abc",
+			new:      "abd",
+			expected: "ab[-c][+d]",
+		},
+		{
+			name:     "Multiple changes",
+			old:      "The quick brown fox jumps over the lazy dog",
+			new:      "The quick brown cat jumps over the lazy dog",
+			expected: "The quick brown [-fox][+cat] jumps over the lazy dog",
+		},
+		{
+			name:     "Prefix and suffix",
+			old:      "Hello, world!",
+			new:      "Hello, beautiful world!",
+			expected: "Hello, [+beautiful ]world!",
+		},
+		{
+			name:     "Complete change",
+			old:      "abcdef",
+			new:      "ghijkl",
+			expected: "[-abcdef][+ghijkl]",
+		},
+		{
+			name:     "Empty strings",
+			old:      "",
+			new:      "",
+			expected: "",
+		},
+		{
+			name:     "Old empty",
+			old:      "",
+			new:      "abc",
+			expected: "[+abc]",
+		},
+		{
+			name:     "New empty",
+			old:      "abc",
+			new:      "",
+			expected: "[-abc]",
+		},
+		{
+			name:     "non-ascii (Korean characters)",
+			old:      "ASCII 문자가 아닌 것도 되나?",
+			new:      "ASCII 문자가 아닌 것도 됨.",
+			expected: "ASCII 문자가 아닌 것도 [-되나?][+됨.]",
+		},
+		{
+			name:     "Emoji diff",
+			old:      "Hello 👋 World 🌍",
+			new:      "Hello 👋 Beautiful 🌸 World 🌍",
+			expected: "Hello 👋 [+Beautiful 🌸 ]World 🌍",
+		},
+		{
+			name:     "Mixed multibyte and ASCII",
+			old:      "こんにちは World",
+			new:      "こんばんは World",
+			expected: "こん[-にち][+ばん]は World",
+		},
+		{
+			name:     "Chinese characters",
+			old:      "我喜欢编程",
+			new:      "我喜欢看书和编程",
+			expected: "我喜欢[+看书和]编程",
+		},
+		{
+			name:     "Combining characters",
+			old:      "e\u0301", // é (e + ´)
+			new:      "e\u0300", // è (e + `)
+			expected: "e[-\u0301][+\u0300]",
+		},
+		{
+			name:     "Right-to-Left languages",
+			old:      "שלום",
+			new:      "שלום עולם",
+			expected: "שלום[+ עולם]",
+		},
+		{
+			name:     "Normalization NFC and NFD",
+			old:      "e\u0301", // NFD (decomposed)
+			new:      "\u00e9",  // NFC (precomposed)
+			expected: "[-e\u0301][+\u00e9]",
+		},
+		{
+			name:     "Case sensitivity",
+			old:      "abc",
+			new:      "Abc",
+			expected: "[-a][+A]bc",
+		},
+		{
+			name:     "Surrogate pairs",
+			old:      "Hello 🌍",
+			new:      "Hello 🌎",
+			expected: "Hello [-🌍][+🌎]",
+		},
+		{
+			name:     "Control characters",
+			old:      "Line1\nLine2",
+			new:      "Line1\r\nLine2",
+			expected: "Line1[+\r]\nLine2",
+		},
+		{
+			name:     "Mixed scripts",
+			old:      "Hello नमस्ते こんにちは",
+			new:      "Hello สวัสดี こんにちは",
+			expected: "Hello [-नमस्ते][+สวัสดี] こんにちは",
+		},
+		{
+			name:     "Unicode normalization",
+			old:      "é",       // U+00E9 (precomposed)
+			new:      "e\u0301", // U+0065 U+0301 (decomposed)
+			expected: "[-é][+e\u0301]",
+		},
+		{
+			name:     "Directional marks",
+			old:      "Hello\u200Eworld", // LTR mark
+			new:      "Hello\u200Fworld", // RTL mark
+			expected: "Hello[-\u200E][+\u200F]world",
+		},
+		{
+			name:     "Zero-width characters",
+			old:      "ab\u200Bc", // Zero-width space
+			new:      "abc",
+			expected: "ab[-\u200B]c",
+		},
+		{
+			name:     "Worst-case scenario (completely different strings)",
+			old:      strings.Repeat("a", 1000),
+			new:      strings.Repeat("b", 1000),
+			expected: "[-" + strings.Repeat("a", 1000) + "][+" + strings.Repeat("b", 1000) + "]",
+		},
+		//{ // disabled for testing performance
+		// XXX: consider adding a flag to run such tests, not like `-short`, or switching to a `-bench`, maybe.
+		//	name:     "Very long strings",
+		//	old:      strings.Repeat("a", 10000) + "b" + strings.Repeat("a", 10000),
+		//	new:      strings.Repeat("a", 10000) + "c" + strings.Repeat("a", 10000),
+		//	expected: strings.Repeat("a", 10000) + "[-b][+c]" + strings.Repeat("a", 10000),
+		//},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diff := MyersDiff(tc.old, tc.new)
+			result := Format(diff)
+			if result != tc.expected {
+				t.Errorf("Expected: %s, got: %s", tc.expected, result)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/onbloc/diff/gnomod.toml
+++ b/vendored/gno.land/p/onbloc/diff/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/onbloc/diff"
+gno = "0.9"

--- a/vendored/gno.land/p/onbloc/json/LICENSE
+++ b/vendored/gno.land/p/onbloc/json/LICENSE
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2019 Pyzhov Stepan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendored/gno.land/p/onbloc/json/README.md
+++ b/vendored/gno.land/p/onbloc/json/README.md
@@ -1,0 +1,167 @@
+# JSON Parser
+
+The JSON parser is a package that provides functionality for parsing and processing JSON strings. This package accepts JSON strings as byte slices.
+
+Currently, gno does not [support the `reflect` package](https://docs.gno.land/resources/effective-gno#reflection-is-never-clear), so it cannot retrieve type information at runtime. Therefore, it is designed to infer and handle type information when parsing JSON strings using a state machine approach.
+
+After passing through the state machine, JSON strings are represented as the `Node` type. The `Node` type represents nodes for JSON data, including various types such as `ObjectNode`, `ArrayNode`, `StringNode`, `NumberNode`, `BoolNode`, and `NullNode`.
+
+This package provides methods for manipulating, searching, and extracting the Node type.
+
+## State Machine
+
+To parse JSON strings, a [finite state machine](https://en.wikipedia.org/wiki/Finite-state_machine) approach is used. The state machine transitions to the next state based on the current state and the input character while parsing the JSON string. Through this method, type information can be inferred and processed without reflect, and the amount of parser code can be significantly reduced.
+
+The image below shows the state transitions of the state machine according to the states and input characters.
+
+```mermaid
+stateDiagram-v2
+    [*] --> __: Start
+    __ --> ST: String
+    __ --> MI: Number
+    __ --> ZE: Zero
+    __ --> IN: Integer
+    __ --> T1: Boolean (true)
+    __ --> F1: Boolean (false)
+    __ --> N1: Null
+    __ --> ec: Empty Object End
+    __ --> cc: Object End
+    __ --> bc: Array End
+    __ --> co: Object Begin
+    __ --> bo: Array Begin
+    __ --> cm: Comma
+    __ --> cl: Colon
+    __ --> OK: Success/End
+    ST --> OK: String Complete
+    MI --> OK: Number Complete
+    ZE --> OK: Zero Complete
+    IN --> OK: Integer Complete
+    T1 --> OK: True Complete
+    F1 --> OK: False Complete
+    N1 --> OK: Null Complete
+    ec --> OK: Empty Object Complete
+    cc --> OK: Object Complete
+    bc --> OK: Array Complete
+    co --> OB: Inside Object
+    bo --> AR: Inside Array
+    cm --> KE: Expecting New Key
+    cm --> VA: Expecting New Value
+    cl --> VA: Expecting Value
+    OB --> ST: String in Object (Key)
+    OB --> ec: Empty Object
+    OB --> cc: End Object
+    AR --> ST: String in Array
+    AR --> bc: End Array
+    KE --> ST: String as Key
+    VA --> ST: String as Value
+    VA --> MI: Number as Value
+    VA --> T1: True as Value
+    VA --> F1: False as Value
+    VA --> N1: Null as Value
+    OK --> [*]: End
+```
+
+## Examples
+
+This package provides parsing functionality along with encoding and decoding functionality. The following examples demonstrate how to use this package.
+
+### Decoding
+
+Decoding (or Unmarshaling) is the functionality that converts an input byte slice JSON string into a `Node` type.
+
+The converted `Node` type allows you to modify the JSON data or search and extract data that meets specific conditions.
+
+```go
+package main
+
+import (
+    "gno.land/p/demo/json"
+    "gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+    node, err := json.Unmarshal([]byte(`{"foo": "var"}`))
+    if err != nil {
+        ufmt.Errorf("error: %v", err)
+    }
+
+    ufmt.Sprintf("node: %v", node)
+}
+```
+
+### Encoding
+
+Encoding (or Marshaling) is the functionality that converts JSON data represented as a Node type into a byte slice JSON string.
+
+> ⚠️ Caution: Converting a large `Node` type into a JSON string may _impact performance_. or might be cause _unexpected behavior_.
+
+```go
+package main
+
+import (
+    "gno.land/p/demo/json"
+    "gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+    node := ObjectNode("", map[string]*Node{
+        "foo": StringNode("foo", "bar"),
+        "baz": NumberNode("baz", 100500),
+        "qux": NullNode("qux"),
+    })
+
+    b, err := json.Marshal(node)
+    if err != nil {
+        ufmt.Errorf("error: %v", err)
+    }
+
+    ufmt.Sprintf("json: %s", string(b))
+}
+```
+
+### Searching
+
+Once the JSON data converted into a `Node` type, you can **search** and **extract** data that satisfy specific conditions. For example, you can find data with a specific type or data with a specific key.
+
+To use this functionality, you can use methods in the `GetXXX` prefixed methods. The `MustXXX` methods also provide the same functionality as the former methods, but they will **panic** if data doesn't satisfies the condition.
+
+Here is an example of finding data with a specific key. For more examples, please refer to the [node.gno](node.gno) file.
+
+```go
+package main
+
+import (
+    "gno.land/p/demo/json"
+    "gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+    root, err := Unmarshal([]byte(`{"foo": true, "bar": null}`))
+    if err != nil {
+        ufmt.Errorf("error: %v", err)
+    }
+
+    value, err := root.GetKey("foo")
+    if err != nil {
+        ufmt.Errorf("error occurred while getting key, %s", err)
+    }
+
+    if value.MustBool() != true {
+        ufmt.Errorf("value is not true")
+    }
+
+    value, err = root.GetKey("bar")
+    if err != nil {
+        t.Errorf("error occurred while getting key, %s", err)
+    }
+
+    _, err = root.GetKey("baz")
+    if err == nil {
+        t.Errorf("key baz is not exist. must be failed")
+    }
+}
+```
+
+## Contributing
+
+Please submit any issues or pull requests for this package through the GitHub repository at [gnolang/gno](<https://github.com/gnolang/gno>).

--- a/vendored/gno.land/p/onbloc/json/buffer.gno
+++ b/vendored/gno.land/p/onbloc/json/buffer.gno
@@ -1,0 +1,462 @@
+package json
+
+import (
+	"errors"
+	"io"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+type buffer struct {
+	data   []byte
+	length int
+	index  int
+
+	last  States
+	state States
+	class Classes
+}
+
+// newBuffer creates a new buffer with the given data
+func newBuffer(data []byte) *buffer {
+	return &buffer{
+		data:   data,
+		length: len(data),
+		last:   GO,
+		state:  GO,
+	}
+}
+
+// first retrieves the first non-whitespace (or other escaped) character in the buffer.
+func (b *buffer) first() (byte, error) {
+	for ; b.index < b.length; b.index++ {
+		c := b.data[b.index]
+
+		if !(c == whiteSpace || c == carriageReturn || c == newLine || c == tab) {
+			return c, nil
+		}
+	}
+
+	return 0, io.EOF
+}
+
+// current returns the byte of the current index.
+func (b *buffer) current() (byte, error) {
+	if b.index >= b.length {
+		return 0, io.EOF
+	}
+
+	return b.data[b.index], nil
+}
+
+// next moves to the next byte and returns it.
+func (b *buffer) next() (byte, error) {
+	b.index++
+	return b.current()
+}
+
+// step just moves to the next position.
+func (b *buffer) step() error {
+	_, err := b.next()
+	return err
+}
+
+// move moves the index by the given position.
+func (b *buffer) move(pos int) error {
+	newIndex := b.index + pos
+
+	if newIndex > b.length {
+		return io.EOF
+	}
+
+	b.index = newIndex
+
+	return nil
+}
+
+// slice returns the slice from the current index to the given position.
+func (b *buffer) slice(pos int) ([]byte, error) {
+	end := b.index + pos
+
+	if end > b.length {
+		return nil, io.EOF
+	}
+
+	return b.data[b.index:end], nil
+}
+
+// sliceFromIndices returns a slice of the buffer's data starting from 'start' up to (but not including) 'stop'.
+func (b *buffer) sliceFromIndices(start, stop int) []byte {
+	if start > b.length {
+		start = b.length
+	}
+
+	if stop > b.length {
+		stop = b.length
+	}
+
+	return b.data[start:stop]
+}
+
+// skip moves the index to skip the given byte.
+func (b *buffer) skip(bs byte) error {
+	for b.index < b.length {
+		if b.data[b.index] == bs && !b.backslash() {
+			return nil
+		}
+
+		b.index++
+	}
+
+	return io.EOF
+}
+
+// skipAndReturnIndex moves the buffer index forward by one and returns the new index.
+func (b *buffer) skipAndReturnIndex() (int, error) {
+	err := b.step()
+	if err != nil {
+		return 0, err
+	}
+
+	return b.index, nil
+}
+
+// skipUntil moves the buffer index forward until it encounters a byte contained in the endTokens set.
+func (b *buffer) skipUntil(endTokens map[byte]bool) (int, error) {
+	for b.index < b.length {
+		currentByte, err := b.current()
+		if err != nil {
+			return b.index, err
+		}
+
+		// Check if the current byte is in the set of end tokens.
+		if _, exists := endTokens[currentByte]; exists {
+			return b.index, nil
+		}
+
+		b.index++
+	}
+
+	return b.index, io.EOF
+}
+
+// significantTokens is a map where the keys are the significant characters in a JSON path.
+// The values in the map are all true, which allows us to use the map as a set for quick lookups.
+var significantTokens = [256]bool{
+	dot:          true, // access properties of an object
+	dollarSign:   true, // root object
+	atSign:       true, // current object
+	bracketOpen:  true, // start of an array index or filter expression
+	bracketClose: true, // end of an array index or filter expression
+}
+
+// filterTokens stores the filter expression tokens.
+var filterTokens = [256]bool{
+	aesterisk: true, // wildcard
+	andSign:   true,
+	orSign:    true,
+}
+
+// skipToNextSignificantToken advances the buffer index to the next significant character.
+// Significant characters are defined based on the JSON path syntax.
+func (b *buffer) skipToNextSignificantToken() {
+	for b.index < b.length {
+		current := b.data[b.index]
+
+		if significantTokens[current] {
+			break
+		}
+
+		b.index++
+	}
+}
+
+// backslash checks to see if the number of backslashes before the current index is odd.
+//
+// This is used to check if the current character is escaped. However, unlike the "unescape" function,
+// "backslash" only serves to check the number of backslashes.
+func (b *buffer) backslash() bool {
+	if b.index == 0 {
+		return false
+	}
+
+	count := 0
+	for i := b.index - 1; ; i-- {
+		if b.data[i] != backSlash {
+			break
+		}
+
+		count++
+
+		if i == 0 {
+			break
+		}
+	}
+
+	return count%2 != 0
+}
+
+// numIndex holds a map of valid numeric characters
+var numIndex = [256]bool{
+	'0': true,
+	'1': true,
+	'2': true,
+	'3': true,
+	'4': true,
+	'5': true,
+	'6': true,
+	'7': true,
+	'8': true,
+	'9': true,
+	'.': true,
+	'e': true,
+	'E': true,
+}
+
+// pathToken checks if the current token is a valid JSON path token.
+func (b *buffer) pathToken() error {
+	var stack []byte
+
+	inToken := false
+	inNumber := false
+	first := b.index
+
+	for b.index < b.length {
+		c := b.data[b.index]
+
+		switch {
+		case c == doubleQuote || c == singleQuote:
+			inToken = true
+			if err := b.step(); err != nil {
+				return errors.New("error stepping through buffer")
+			}
+
+			if err := b.skip(c); err != nil {
+				return errUnmatchedQuotePath
+			}
+
+			if b.index >= b.length {
+				return errUnmatchedQuotePath
+			}
+
+		case c == bracketOpen || c == parenOpen:
+			inToken = true
+			stack = append(stack, c)
+
+		case c == bracketClose || c == parenClose:
+			inToken = true
+			if len(stack) == 0 || (c == bracketClose && stack[len(stack)-1] != bracketOpen) || (c == parenClose && stack[len(stack)-1] != parenOpen) {
+				return errUnmatchedParenthesis
+			}
+
+			stack = stack[:len(stack)-1]
+
+		case pathStateContainsValidPathToken(c):
+			inToken = true
+
+		case c == plus || c == minus:
+			if inNumber || (b.index > 0 && numIndex[b.data[b.index-1]]) {
+				inToken = true
+			} else if !inToken && (b.index+1 < b.length && numIndex[b.data[b.index+1]]) {
+				inToken = true
+				inNumber = true
+			} else if !inToken {
+				return errInvalidToken
+			}
+
+		default:
+			if len(stack) != 0 || inToken {
+				inToken = true
+			} else {
+				goto end
+			}
+		}
+
+		b.index++
+	}
+
+end:
+	if len(stack) != 0 {
+		return errUnmatchedParenthesis
+	}
+
+	if first == b.index {
+		return errors.New("no token found")
+	}
+
+	if inNumber && !numIndex[b.data[b.index-1]] {
+		inNumber = false
+	}
+
+	return nil
+}
+
+func pathStateContainsValidPathToken(c byte) bool {
+	if significantTokens[c] {
+		return true
+	}
+
+	if filterTokens[c] {
+		return true
+	}
+
+	if numIndex[c] {
+		return true
+	}
+
+	if 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' {
+		return true
+	}
+
+	return false
+}
+
+func (b *buffer) numeric(token bool) error {
+	if token {
+		b.last = GO
+	}
+
+	for ; b.index < b.length; b.index++ {
+		b.class = b.getClasses(doubleQuote)
+		if b.class == __ {
+			return errInvalidToken
+		}
+
+		b.state = StateTransitionTable[b.last][b.class]
+		if b.state == __ {
+			if token {
+				break
+			}
+
+			return errInvalidToken
+		}
+
+		if b.state < __ {
+			return nil
+		}
+
+		if b.state < MI || b.state > E3 {
+			return nil
+		}
+
+		b.last = b.state
+	}
+
+	if b.last != ZE && b.last != IN && b.last != FR && b.last != E3 {
+		return errInvalidToken
+	}
+
+	return nil
+}
+
+func (b *buffer) getClasses(c byte) Classes {
+	if b.data[b.index] >= 128 {
+		return C_ETC
+	}
+
+	if c == singleQuote {
+		return QuoteAsciiClasses[b.data[b.index]]
+	}
+
+	return AsciiClasses[b.data[b.index]]
+}
+
+func (b *buffer) getState() States {
+	b.last = b.state
+
+	b.class = b.getClasses(doubleQuote)
+	if b.class == __ {
+		return __
+	}
+
+	b.state = StateTransitionTable[b.last][b.class]
+
+	return b.state
+}
+
+// string parses a string token from the buffer.
+func (b *buffer) string(search byte, token bool) error {
+	if token {
+		b.last = GO
+	}
+
+	for ; b.index < b.length; b.index++ {
+		b.class = b.getClasses(search)
+
+		if b.class == __ {
+			return errInvalidToken
+		}
+
+		b.state = StateTransitionTable[b.last][b.class]
+		if b.state == __ {
+			return errInvalidToken
+		}
+
+		if b.state < __ {
+			break
+		}
+
+		b.last = b.state
+	}
+
+	return nil
+}
+
+func (b *buffer) word(bs []byte) error {
+	var c byte
+
+	max := len(bs)
+	index := 0
+
+	for ; b.index < b.length && index < max; b.index++ {
+		c = b.data[b.index]
+
+		if c != bs[index] {
+			return errInvalidToken
+		}
+
+		index++
+		if index >= max {
+			break
+		}
+	}
+
+	if index != max {
+		return errInvalidToken
+	}
+
+	return nil
+}
+
+func numberKind2f64(value any) (result float64, err error) {
+	switch typed := value.(type) {
+	case float64:
+		result = typed
+	case float32:
+		result = float64(typed)
+	case int:
+		result = float64(typed)
+	case int8:
+		result = float64(typed)
+	case int16:
+		result = float64(typed)
+	case int32:
+		result = float64(typed)
+	case int64:
+		result = float64(typed)
+	case uint:
+		result = float64(typed)
+	case uint8:
+		result = float64(typed)
+	case uint16:
+		result = float64(typed)
+	case uint32:
+		result = float64(typed)
+	case uint64:
+		result = float64(typed)
+	default:
+		err = ufmt.Errorf("invalid number type: %T", value)
+	}
+
+	return
+}

--- a/vendored/gno.land/p/onbloc/json/buffer_test.gno
+++ b/vendored/gno.land/p/onbloc/json/buffer_test.gno
@@ -1,0 +1,593 @@
+package json
+
+import (
+	"testing"
+)
+
+func TestBufferCurrent(t *testing.T) {
+	tests := []struct {
+		name     string
+		buffer   *buffer
+		expected byte
+		wantErr  bool
+	}{
+		{
+			name: "Valid current byte",
+			buffer: &buffer{
+				data:   []byte("test"),
+				length: 4,
+				index:  1,
+			},
+			expected: 'e',
+			wantErr:  false,
+		},
+		{
+			name: "EOF",
+			buffer: &buffer{
+				data:   []byte("test"),
+				length: 4,
+				index:  4,
+			},
+			expected: 0,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.buffer.current()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.current() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("buffer.current() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBufferStep(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  *buffer
+		wantErr bool
+	}{
+		{
+			name:    "Valid step",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			wantErr: false,
+		},
+		{
+			name:    "EOF error",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 3},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.buffer.step()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.step() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBufferNext(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  *buffer
+		want    byte
+		wantErr bool
+	}{
+		{
+			name:    "Valid next byte",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			want:    'e',
+			wantErr: false,
+		},
+		{
+			name:    "EOF error",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 3},
+			want:    0,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.buffer.next()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.next() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("buffer.next() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBufferSlice(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  *buffer
+		pos     int
+		want    []byte
+		wantErr bool
+	}{
+		{
+			name:    "Valid slice -- 0 characters",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			pos:     0,
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name:    "Valid slice -- 1 character",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			pos:     1,
+			want:    []byte("t"),
+			wantErr: false,
+		},
+		{
+			name:    "Valid slice -- 2 characters",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 1},
+			pos:     2,
+			want:    []byte("es"),
+			wantErr: false,
+		},
+		{
+			name:    "Valid slice -- 3 characters",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			pos:     3,
+			want:    []byte("tes"),
+			wantErr: false,
+		},
+		{
+			name:    "Valid slice -- 4 characters",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			pos:     4,
+			want:    []byte("test"),
+			wantErr: false,
+		},
+		{
+			name:    "EOF error",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 3},
+			pos:     2,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.buffer.slice(tt.pos)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.slice() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if string(got) != string(tt.want) {
+				t.Errorf("buffer.slice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBufferMove(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  *buffer
+		pos     int
+		wantErr bool
+		wantIdx int
+	}{
+		{
+			name:    "Valid move",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 1},
+			pos:     2,
+			wantErr: false,
+			wantIdx: 3,
+		},
+		{
+			name:    "Move beyond length",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 1},
+			pos:     4,
+			wantErr: true,
+			wantIdx: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.buffer.move(tt.pos)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.move() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.buffer.index != tt.wantIdx {
+				t.Errorf("buffer.move() index = %v, want %v", tt.buffer.index, tt.wantIdx)
+			}
+		})
+	}
+}
+
+func TestBufferSkip(t *testing.T) {
+	tests := []struct {
+		name    string
+		buffer  *buffer
+		b       byte
+		wantErr bool
+	}{
+		{
+			name:    "Skip byte",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			b:       'e',
+			wantErr: false,
+		},
+		{
+			name:    "Skip to EOF",
+			buffer:  &buffer{data: []byte("test"), length: 4, index: 0},
+			b:       'x',
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.buffer.skip(tt.b)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buffer.skip() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSkipToNextSignificantToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected int
+	}{
+		{"No significant chars", []byte("abc"), 3},
+		{"One significant char at start", []byte(".abc"), 0},
+		{"Significant char in middle", []byte("ab.c"), 2},
+		{"Multiple significant chars", []byte("a$.c"), 1},
+		{"Significant char at end", []byte("abc$"), 3},
+		{"Only significant chars", []byte("$."), 0},
+		{"Empty string", []byte(""), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBuffer(tt.input)
+			b.skipToNextSignificantToken()
+			if b.index != tt.expected {
+				t.Errorf("after skipToNextSignificantToken(), got index = %v, want %v", b.index, tt.expected)
+			}
+		})
+	}
+}
+
+func mockBuffer(s string) *buffer {
+	return newBuffer([]byte(s))
+}
+
+func TestSkipAndReturnIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{"StartOfString", "", 0},
+		{"MiddleOfString", "abcdef", 1},
+		{"EndOfString", "abc", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := mockBuffer(tt.input)
+			got, err := buf.skipAndReturnIndex()
+			if err != nil && tt.input != "" { // Expect no error unless input is empty
+				t.Errorf("skipAndReturnIndex() error = %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("skipAndReturnIndex() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSkipUntil(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		tokens   map[byte]bool
+		expected int
+	}{
+		{"SkipToToken", "abcdefg", map[byte]bool{'c': true}, 2},
+		{"SkipToEnd", "abcdefg", map[byte]bool{'h': true}, 7},
+		{"SkipNone", "abcdefg", map[byte]bool{'a': true}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := mockBuffer(tt.input)
+			got, err := buf.skipUntil(tt.tokens)
+			if err != nil && got != len(tt.input) { // Expect error only if reached end without finding token
+				t.Errorf("skipUntil() error = %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("skipUntil() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSliceFromIndices(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		start    int
+		end      int
+		expected string
+	}{
+		{"FullString", "abcdefg", 0, 7, "abcdefg"},
+		{"Substring", "abcdefg", 2, 5, "cde"},
+		{"OutOfBounds", "abcdefg", 5, 10, "fg"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := mockBuffer(tt.input)
+			got := buf.sliceFromIndices(tt.start, tt.end)
+			if string(got) != tt.expected {
+				t.Errorf("sliceFromIndices() = %v, want %v", string(got), tt.expected)
+			}
+		})
+	}
+}
+
+func TestBufferToken(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		index int
+		isErr bool
+	}{
+		{
+			name:  "Simple valid path",
+			path:  "@.length",
+			index: 8,
+			isErr: false,
+		},
+		{
+			name:  "Path with array expr",
+			path:  "@['foo'].0.bar",
+			index: 14,
+			isErr: false,
+		},
+		{
+			name:  "Path with array expr and simple fomula",
+			path:  "@['foo'].[(@.length - 1)].*",
+			index: 27,
+			isErr: false,
+		},
+		{
+			name:  "Path with filter expr",
+			path:  "@['foo'].[?(@.bar == 1 & @.baz < @.length)].*",
+			index: 45,
+			isErr: false,
+		},
+		{
+			name:  "addition of foo and bar",
+			path:  "@.foo+@.bar",
+			index: 11,
+			isErr: false,
+		},
+		{
+			name:  "logical AND of foo and bar",
+			path:  "@.foo && @.bar",
+			index: 14,
+			isErr: false,
+		},
+		{
+			name:  "logical OR of foo and bar",
+			path:  "@.foo || @.bar",
+			index: 14,
+			isErr: false,
+		},
+		{
+			name:  "accessing third element of foo",
+			path:  "@.foo,3",
+			index: 7,
+			isErr: false,
+		},
+		{
+			name:  "accessing last element of array",
+			path:  "@.length-1",
+			index: 10,
+			isErr: false,
+		},
+		{
+			name:  "number 1",
+			path:  "1",
+			index: 1,
+			isErr: false,
+		},
+		{
+			name:  "float",
+			path:  "3.1e4",
+			index: 5,
+			isErr: false,
+		},
+		{
+			name:  "float with minus",
+			path:  "3.1e-4",
+			index: 6,
+			isErr: false,
+		},
+		{
+			name:  "float with plus",
+			path:  "3.1e+4",
+			index: 6,
+			isErr: false,
+		},
+		{
+			name:  "negative number",
+			path:  "-12345",
+			index: 6,
+			isErr: false,
+		},
+		{
+			name:  "negative float",
+			path:  "-3.1e4",
+			index: 6,
+			isErr: false,
+		},
+		{
+			name:  "negative float with minus",
+			path:  "-3.1e-4",
+			index: 7,
+			isErr: false,
+		},
+		{
+			name:  "negative float with plus",
+			path:  "-3.1e+4",
+			index: 7,
+			isErr: false,
+		},
+		{
+			name:  "string number",
+			path:  "'12345'",
+			index: 7,
+			isErr: false,
+		},
+		{
+			name:  "string with backslash",
+			path:  "'foo \\'bar '",
+			index: 12,
+			isErr: false,
+		},
+		{
+			name:  "string with inner double quotes",
+			path:  "'foo \"bar \"'",
+			index: 12,
+			isErr: false,
+		},
+		{
+			name:  "parenthesis 1",
+			path:  "(@abc)",
+			index: 6,
+			isErr: false,
+		},
+		{
+			name:  "parenthesis 2",
+			path:  "[()]",
+			index: 4,
+			isErr: false,
+		},
+		{
+			name:  "parenthesis mismatch",
+			path:  "[(])",
+			index: 2,
+			isErr: true,
+		},
+		{
+			name:  "parenthesis mismatch 2",
+			path:  "(",
+			index: 1,
+			isErr: true,
+		},
+		{
+			name:  "parenthesis mismatch 3",
+			path:  "())]",
+			index: 2,
+			isErr: true,
+		},
+		{
+			name:  "bracket mismatch",
+			path:  "[()",
+			index: 3,
+			isErr: true,
+		},
+		{
+			name:  "bracket mismatch 2",
+			path:  "()]",
+			index: 2,
+			isErr: true,
+		},
+		{
+			name:  "path does not close bracket",
+			path:  "@.foo[)",
+			index: 6,
+			isErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := newBuffer([]byte(tt.path))
+
+			err := buf.pathToken()
+			if tt.isErr {
+				if err == nil {
+					t.Errorf("Expected an error for path `%s`, but got none", tt.path)
+				}
+			}
+
+			if err == nil && tt.isErr {
+				t.Errorf("Expected an error for path `%s`, but got none", tt.path)
+			}
+
+			if buf.index != tt.index {
+				t.Errorf("Expected final index %d, got %d (token: `%s`) for path `%s`", tt.index, buf.index, string(buf.data[buf.index]), tt.path)
+			}
+		})
+	}
+}
+
+func TestBufferFirst(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []byte
+		expected byte
+	}{
+		{
+			name:     "Valid first byte",
+			data:     []byte("test"),
+			expected: 't',
+		},
+		{
+			name:     "Empty buffer",
+			data:     []byte(""),
+			expected: 0,
+		},
+		{
+			name:     "Whitespace buffer",
+			data:     []byte("   "),
+			expected: 0,
+		},
+		{
+			name:     "whitespace in middle",
+			data:     []byte("hello world"),
+			expected: 'h',
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := newBuffer(tt.data)
+
+			got, err := b.first()
+			if err != nil && tt.expected != 0 {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if got != tt.expected {
+				t.Errorf("Expected first byte to be %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/builder.gno
+++ b/vendored/gno.land/p/onbloc/json/builder.gno
@@ -1,0 +1,89 @@
+package json
+
+type NodeBuilder struct {
+	node *Node
+}
+
+func Builder() *NodeBuilder {
+	return &NodeBuilder{node: ObjectNode("", nil)}
+}
+
+func (b *NodeBuilder) WriteString(key, value string) *NodeBuilder {
+	b.node.AppendObject(key, StringNode("", value))
+	return b
+}
+
+func (b *NodeBuilder) WriteNumber(key string, value float64) *NodeBuilder {
+	b.node.AppendObject(key, NumberNode("", value))
+	return b
+}
+
+func (b *NodeBuilder) WriteBool(key string, value bool) *NodeBuilder {
+	b.node.AppendObject(key, BoolNode("", value))
+	return b
+}
+
+func (b *NodeBuilder) WriteNull(key string) *NodeBuilder {
+	b.node.AppendObject(key, NullNode(""))
+	return b
+}
+
+func (b *NodeBuilder) WriteObject(key string, fn func(*NodeBuilder)) *NodeBuilder {
+	nestedBuilder := &NodeBuilder{node: ObjectNode("", nil)}
+	fn(nestedBuilder)
+	b.node.AppendObject(key, nestedBuilder.node)
+	return b
+}
+
+func (b *NodeBuilder) WriteArray(key string, fn func(*ArrayBuilder)) *NodeBuilder {
+	arrayBuilder := &ArrayBuilder{nodes: []*Node{}}
+	fn(arrayBuilder)
+	b.node.AppendObject(key, ArrayNode("", arrayBuilder.nodes))
+	return b
+}
+
+func (b *NodeBuilder) Node() *Node {
+	return b.node
+}
+
+type ArrayBuilder struct {
+	nodes []*Node
+}
+
+func (ab *ArrayBuilder) WriteString(value string) *ArrayBuilder {
+	ab.nodes = append(ab.nodes, StringNode("", value))
+	return ab
+}
+
+func (ab *ArrayBuilder) WriteNumber(value float64) *ArrayBuilder {
+	ab.nodes = append(ab.nodes, NumberNode("", value))
+	return ab
+}
+
+func (ab *ArrayBuilder) WriteInt(value int) *ArrayBuilder {
+	return ab.WriteNumber(float64(value))
+}
+
+func (ab *ArrayBuilder) WriteBool(value bool) *ArrayBuilder {
+	ab.nodes = append(ab.nodes, BoolNode("", value))
+	return ab
+}
+
+func (ab *ArrayBuilder) WriteNull() *ArrayBuilder {
+	ab.nodes = append(ab.nodes, NullNode(""))
+	return ab
+}
+
+func (ab *ArrayBuilder) WriteObject(fn func(*NodeBuilder)) *ArrayBuilder {
+	nestedBuilder := &NodeBuilder{node: ObjectNode("", nil)}
+	fn(nestedBuilder)
+	ab.nodes = append(ab.nodes, nestedBuilder.node)
+	return ab
+}
+
+func (ab *ArrayBuilder) WriteArray(fn func(*ArrayBuilder)) *ArrayBuilder {
+	nestedArrayBuilder := &ArrayBuilder{nodes: []*Node{}}
+	fn(nestedArrayBuilder)
+	ab.nodes = append(ab.nodes, ArrayNode("", nestedArrayBuilder.nodes))
+	return ab
+}

--- a/vendored/gno.land/p/onbloc/json/builder_test.gno
+++ b/vendored/gno.land/p/onbloc/json/builder_test.gno
@@ -1,0 +1,103 @@
+package json
+
+import (
+	"testing"
+)
+
+func TestNodeBuilder(t *testing.T) {
+	tests := []struct {
+		name     string
+		build    func() *Node
+		expected string
+	}{
+		{
+			name: "plain object",
+			build: func() *Node {
+				return Builder().
+					WriteString("name", "Alice").
+					WriteNumber("age", 30).
+					WriteBool("is_student", false).
+					Node()
+			},
+			expected: `{"name":"Alice","age":30,"is_student":false}`,
+		},
+		{
+			name: "nested object",
+			build: func() *Node {
+				return Builder().
+					WriteString("name", "Alice").
+					WriteObject("address", func(b *NodeBuilder) {
+						b.WriteString("city", "New York").
+							WriteNumber("zipcode", 10001)
+					}).
+					Node()
+			},
+			expected: `{"name":"Alice","address":{"city":"New York","zipcode":10001}}`,
+		},
+		{
+			name: "null node",
+			build: func() *Node {
+				return Builder().WriteNull("foo").Node()
+			},
+			expected: `{"foo":null}`,
+		},
+		{
+			name: "array node",
+			build: func() *Node {
+				return Builder().
+					WriteArray("items", func(ab *ArrayBuilder) {
+						ab.WriteString("item1").
+							WriteString("item2").
+							WriteString("item3")
+					}).
+					Node()
+			},
+			expected: `{"items":["item1","item2","item3"]}`,
+		},
+		{
+			name: "array with objects",
+			build: func() *Node {
+				return Builder().
+					WriteArray("users", func(ab *ArrayBuilder) {
+						ab.WriteObject(func(b *NodeBuilder) {
+							b.WriteString("name", "Bob").
+								WriteNumber("age", 25)
+						}).
+							WriteObject(func(b *NodeBuilder) {
+								b.WriteString("name", "Carol").
+									WriteNumber("age", 27)
+							})
+					}).
+					Node()
+			},
+			expected: `{"users":[{"name":"Bob","age":25},{"name":"Carol","age":27}]}`,
+		},
+		{
+			name: "array with various types",
+			build: func() *Node {
+				return Builder().
+					WriteArray("values", func(ab *ArrayBuilder) {
+						ab.WriteString("item1").
+							WriteNumber(123).
+							WriteBool(true).
+							WriteNull()
+					}).
+					Node()
+			},
+			expected: `{"values":["item1",123,true,null]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := tt.build()
+			value, err := Marshal(node)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			}
+			if string(value) != tt.expected {
+				t.Errorf("expected %s, got %s", tt.expected, string(value))
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/decode.gno
+++ b/vendored/gno.land/p/onbloc/json/decode.gno
@@ -1,0 +1,370 @@
+// ref: https://github.com/spyzhov/ajson/blob/master/decode.go
+
+package json
+
+import (
+	"errors"
+	"io"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// This limits the max nesting depth to prevent stack overflow.
+// This is permitted by https://tools.ietf.org/html/rfc7159#section-9
+const maxNestingDepth = 10000
+
+// Unmarshal parses the JSON-encoded data and returns a Node.
+// The data must be a valid JSON-encoded value.
+//
+// Usage:
+//
+//	node, err := json.Unmarshal([]byte(`{"key": "value"}`))
+//	if err != nil {
+//		ufmt.Println(err)
+//	}
+//	println(node) // {"key": "value"}
+func Unmarshal(data []byte) (*Node, error) {
+	buf := newBuffer(data)
+
+	var (
+		state   States
+		key     *string
+		current *Node
+		nesting int
+		useKey  = func() **string {
+			tmp := cptrs(key)
+			key = nil
+			return &tmp
+		}
+		err error
+	)
+
+	if _, err = buf.first(); err != nil {
+		return nil, io.EOF
+	}
+
+	for {
+		state = buf.getState()
+		if state == __ {
+			return nil, unexpectedTokenError(buf.data, buf.index)
+		}
+
+		// region state machine
+		if state >= GO {
+			switch buf.state {
+			case ST: // string
+				if current != nil && current.IsObject() && key == nil {
+					// key detected
+					if key, err = getString(buf); err != nil {
+						return nil, err
+					}
+
+					buf.state = CO
+				} else {
+					current, nesting, err = createNestedNode(current, buf, String, nesting, useKey())
+					if err != nil {
+						return nil, err
+					}
+
+					err = buf.string(doubleQuote, false)
+					if err != nil {
+						return nil, err
+					}
+
+					current, nesting = updateNode(current, buf, nesting, true)
+					buf.state = OK
+				}
+
+			case MI, ZE, IN: // number
+				current, err = processNumericNode(current, buf, useKey())
+				if err != nil {
+					return nil, err
+				}
+
+			case T1, F1: // boolean
+				literal := falseLiteral
+				if buf.state == T1 {
+					literal = trueLiteral
+				}
+
+				current, nesting, err = processLiteralNode(current, buf, Boolean, literal, useKey(), nesting)
+				if err != nil {
+					return nil, err
+				}
+
+			case N1: // null
+				current, nesting, err = processLiteralNode(current, buf, Null, nullLiteral, useKey(), nesting)
+				if err != nil {
+					return nil, err
+				}
+			}
+		} else {
+			// region action
+			switch state {
+			case ec, cc: // <empty> }
+				if key != nil {
+					return nil, unexpectedTokenError(buf.data, buf.index)
+				}
+
+				current, nesting, err = updateNodeAndSetBufferState(current, buf, nesting, Object)
+				if err != nil {
+					return nil, err
+				}
+
+			case bc: // ]
+				current, nesting, err = updateNodeAndSetBufferState(current, buf, nesting, Array)
+				if err != nil {
+					return nil, err
+				}
+
+			case co, bo: // { [
+				valTyp, bState := Object, OB
+				if state == bo {
+					valTyp, bState = Array, AR
+				}
+
+				current, nesting, err = createNestedNode(current, buf, valTyp, nesting, useKey())
+				if err != nil {
+					return nil, err
+				}
+
+				buf.state = bState
+
+			case cm: // ,
+				if current == nil {
+					return nil, unexpectedTokenError(buf.data, buf.index)
+				}
+
+				if !current.isContainer() {
+					return nil, unexpectedTokenError(buf.data, buf.index)
+				}
+
+				if current.IsObject() {
+					buf.state = KE // key expected
+				} else {
+					buf.state = VA // value expected
+				}
+
+			case cl: // :
+				if current == nil || !current.IsObject() || key == nil {
+					return nil, unexpectedTokenError(buf.data, buf.index)
+				}
+
+				buf.state = VA
+
+			default:
+				return nil, unexpectedTokenError(buf.data, buf.index)
+			}
+		}
+
+		if buf.step() != nil {
+			break
+		}
+
+		if _, err = buf.first(); err != nil {
+			err = nil
+			break
+		}
+	}
+
+	if current == nil || buf.state != OK {
+		return nil, io.EOF
+	}
+
+	root := current.root()
+	if !root.ready() {
+		return nil, io.EOF
+	}
+
+	return root, err
+}
+
+// UnmarshalSafe parses the JSON-encoded data and returns a Node.
+func UnmarshalSafe(data []byte) (*Node, error) {
+	var safe []byte
+	safe = append(safe, data...)
+	return Unmarshal(safe)
+}
+
+// processNumericNode creates a new node, processes a numeric value,
+// sets the node's borders, and moves to the previous node.
+func processNumericNode(current *Node, buf *buffer, key **string) (*Node, error) {
+	var err error
+	current, err = createNode(current, buf, Number, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = buf.numeric(false); err != nil {
+		return nil, err
+	}
+
+	current.borders[1] = buf.index
+	if current.prev != nil {
+		current = current.prev
+	}
+
+	buf.index -= 1
+	buf.state = OK
+
+	return current, nil
+}
+
+// processLiteralNode creates a new node, processes a literal value,
+// sets the node's borders, and moves to the previous node.
+func processLiteralNode(
+	current *Node,
+	buf *buffer,
+	literalType ValueType,
+	literalValue []byte,
+	useKey **string,
+	nesting int,
+) (*Node, int, error) {
+	var err error
+	current, nesting, err = createLiteralNode(current, buf, literalType, literalValue, useKey, nesting)
+	if err != nil {
+		return nil, nesting, err
+	}
+	return current, nesting, nil
+}
+
+// isValidContainerType checks if the current node is a valid container (object or array).
+// The container must satisfy the following conditions:
+//  1. The current node must not be nil.
+//  2. The current node must be an object or array.
+//  3. The current node must not be ready.
+func isValidContainerType(current *Node, nodeType ValueType) bool {
+	switch nodeType {
+	case Object:
+		return current != nil && current.IsObject() && !current.ready()
+	case Array:
+		return current != nil && current.IsArray() && !current.ready()
+	default:
+		return false
+	}
+}
+
+// getString extracts a string from the buffer and advances the buffer index past the string.
+func getString(b *buffer) (*string, error) {
+	start := b.index
+	if err := b.string(doubleQuote, false); err != nil {
+		return nil, err
+	}
+
+	value, ok := Unquote(b.data[start:b.index+1], doubleQuote)
+	if !ok {
+		return nil, unexpectedTokenError(b.data, start)
+	}
+
+	return &value, nil
+}
+
+// createNode creates a new node and sets the key if it is not nil.
+func createNode(
+	current *Node,
+	buf *buffer,
+	nodeType ValueType,
+	key **string,
+) (*Node, error) {
+	var err error
+	current, err = NewNode(current, buf, nodeType, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return current, nil
+}
+
+// createNestedNode creates a new nested node (array or object) and sets the key if it is not nil.
+func createNestedNode(
+	current *Node,
+	buf *buffer,
+	nodeType ValueType,
+	nesting int,
+	key **string,
+) (*Node, int, error) {
+	var err error
+	if nesting, err = checkNestingDepth(nesting); err != nil {
+		return nil, nesting, err
+	}
+
+	if current, err = createNode(current, buf, nodeType, key); err != nil {
+		return nil, nesting, err
+	}
+
+	return current, nesting, nil
+}
+
+// createLiteralNode creates a new literal node and sets the key if it is not nil.
+// The literal is a byte slice that represents a boolean or null value.
+func createLiteralNode(
+	current *Node,
+	buf *buffer,
+	literalType ValueType,
+	literal []byte,
+	useKey **string,
+	nesting int,
+) (*Node, int, error) {
+	var err error
+	if current, err = createNode(current, buf, literalType, useKey); err != nil {
+		return nil, 0, err
+	}
+
+	if err = buf.word(literal); err != nil {
+		return nil, 0, err
+	}
+
+	current, nesting = updateNode(current, buf, nesting, false)
+	buf.state = OK
+
+	return current, nesting, nil
+}
+
+// updateNode updates the current node and returns the previous node.
+func updateNode(
+	current *Node, buf *buffer, nesting int, decreaseLevel bool,
+) (*Node, int) {
+	current.borders[1] = buf.index + 1
+
+	prev := current.prev
+	if prev == nil {
+		return current, nesting
+	}
+
+	current = prev
+	if decreaseLevel {
+		nesting--
+	}
+
+	return current, nesting
+}
+
+// updateNodeAndSetBufferState updates the current node and sets the buffer state to OK.
+func updateNodeAndSetBufferState(
+	current *Node,
+	buf *buffer,
+	nesting int,
+	typ ValueType,
+) (*Node, int, error) {
+	if !isValidContainerType(current, typ) {
+		return nil, nesting, unexpectedTokenError(buf.data, buf.index)
+	}
+
+	current, nesting = updateNode(current, buf, nesting, true)
+	buf.state = OK
+
+	return current, nesting, nil
+}
+
+// checkNestingDepth checks if the nesting depth is within the maximum allowed depth.
+func checkNestingDepth(nesting int) (int, error) {
+	if nesting >= maxNestingDepth {
+		return nesting, errors.New("maximum nesting depth exceeded")
+	}
+
+	return nesting + 1, nil
+}
+
+func unexpectedTokenError(data []byte, index int) error {
+	return ufmt.Errorf("unexpected token at index %d. data %b", index, data)
+}

--- a/vendored/gno.land/p/onbloc/json/decode_test.gno
+++ b/vendored/gno.land/p/onbloc/json/decode_test.gno
@@ -1,0 +1,554 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+type testNode struct {
+	name  string
+	input []byte
+	value []byte
+	_type ValueType
+}
+
+func simpleValid(test *testNode, t *testing.T) {
+	root, err := Unmarshal(test.input)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(%s): %s", test.input, err.Error())
+	} else if root == nil {
+		t.Errorf("Error on Unmarshal(%s): root is nil", test.name)
+	} else if root.nodeType != test._type {
+		t.Errorf("Error on Unmarshal(%s): wrong type", test.name)
+	} else if !bytes.Equal(root.source(), test.value) {
+		t.Errorf("Error on Unmarshal(%s): %s != %s", test.name, root.source(), test.value)
+	}
+}
+
+func simpleInvalid(test *testNode, t *testing.T) {
+	root, err := Unmarshal(test.input)
+	if err == nil {
+		t.Errorf("Error on Unmarshal(%s): error expected, got '%s'", test.name, root.source())
+	} else if root != nil {
+		t.Errorf("Error on Unmarshal(%s): root is not nil", test.name)
+	}
+}
+
+func simpleCorrupted(name string) *testNode {
+	return &testNode{name: name, input: []byte(name)}
+}
+
+func TestUnmarshal_StringSimpleSuccess(t *testing.T) {
+	tests := []*testNode{
+		{name: "blank", input: []byte("\"\""), _type: String, value: []byte("\"\"")},
+		{name: "char", input: []byte("\"c\""), _type: String, value: []byte("\"c\"")},
+		{name: "word", input: []byte("\"cat\""), _type: String, value: []byte("\"cat\"")},
+		{name: "spaces", input: []byte("  \"good cat or dog\"\r\n "), _type: String, value: []byte("\"good cat or dog\"")},
+		{name: "backslash", input: []byte("\"good \\\"cat\\\"\""), _type: String, value: []byte("\"good \\\"cat\\\"\"")},
+		{name: "backslash 2", input: []byte("\"good \\\\\\\"cat\\\"\""), _type: String, value: []byte("\"good \\\\\\\"cat\\\"\"")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleValid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_NumericSimpleSuccess(t *testing.T) {
+	tests := []*testNode{
+		{name: "1", input: []byte("1"), _type: Number, value: []byte("1")},
+		{name: "-1", input: []byte("-1"), _type: Number, value: []byte("-1")},
+
+		{name: "1234567890", input: []byte("1234567890"), _type: Number, value: []byte("1234567890")},
+		{name: "-123", input: []byte("-123"), _type: Number, value: []byte("-123")},
+
+		{name: "123.456", input: []byte("123.456"), _type: Number, value: []byte("123.456")},
+		{name: "-123.456", input: []byte("-123.456"), _type: Number, value: []byte("-123.456")},
+
+		{name: "1e3", input: []byte("1e3"), _type: Number, value: []byte("1e3")},
+		{name: "1e+3", input: []byte("1e+3"), _type: Number, value: []byte("1e+3")},
+		{name: "1e-3", input: []byte("1e-3"), _type: Number, value: []byte("1e-3")},
+		{name: "-1e3", input: []byte("-1e3"), _type: Number, value: []byte("-1e3")},
+		{name: "-1e-3", input: []byte("-1e-3"), _type: Number, value: []byte("-1e-3")},
+
+		{name: "1.123e3456", input: []byte("1.123e3456"), _type: Number, value: []byte("1.123e3456")},
+		{name: "1.123e-3456", input: []byte("1.123e-3456"), _type: Number, value: []byte("1.123e-3456")},
+		{name: "-1.123e3456", input: []byte("-1.123e3456"), _type: Number, value: []byte("-1.123e3456")},
+		{name: "-1.123e-3456", input: []byte("-1.123e-3456"), _type: Number, value: []byte("-1.123e-3456")},
+
+		{name: "1E3", input: []byte("1E3"), _type: Number, value: []byte("1E3")},
+		{name: "1E-3", input: []byte("1E-3"), _type: Number, value: []byte("1E-3")},
+		{name: "-1E3", input: []byte("-1E3"), _type: Number, value: []byte("-1E3")},
+		{name: "-1E-3", input: []byte("-1E-3"), _type: Number, value: []byte("-1E-3")},
+
+		{name: "1.123E3456", input: []byte("1.123E3456"), _type: Number, value: []byte("1.123E3456")},
+		{name: "1.123E-3456", input: []byte("1.123E-3456"), _type: Number, value: []byte("1.123E-3456")},
+		{name: "-1.123E3456", input: []byte("-1.123E3456"), _type: Number, value: []byte("-1.123E3456")},
+		{name: "-1.123E-3456", input: []byte("-1.123E-3456"), _type: Number, value: []byte("-1.123E-3456")},
+
+		{name: "-1.123E-3456 with spaces", input: []byte(" \r -1.123E-3456 \t\n"), _type: Number, value: []byte("-1.123E-3456")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			root, err := Unmarshal(test.input)
+			if err != nil {
+				t.Errorf("Error on Unmarshal(%s): %s", test.name, err.Error())
+			} else if root == nil {
+				t.Errorf("Error on Unmarshal(%s): root is nil", test.name)
+			} else if root.nodeType != test._type {
+				t.Errorf("Error on Unmarshal(%s): wrong type", test.name)
+			} else if !bytes.Equal(root.source(), test.value) {
+				t.Errorf("Error on Unmarshal(%s): %s != %s", test.name, root.source(), test.value)
+			}
+		})
+	}
+}
+
+func TestUnmarshal_StringSimpleCorrupted(t *testing.T) {
+	tests := []*testNode{
+		{name: "white NL", input: []byte("\"foo\nbar\"")},
+		{name: "white R", input: []byte("\"foo\rbar\"")},
+		{name: "white Tab", input: []byte("\"foo\tbar\"")},
+		{name: "wrong quotes", input: []byte("'cat'")},
+		{name: "double string", input: []byte("\"Hello\" \"World\"")},
+		{name: "quotes in quotes", input: []byte("\"good \"cat\"\"")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleInvalid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_ObjectSimpleSuccess(t *testing.T) {
+	tests := []*testNode{
+		{name: "{}", input: []byte("{}"), _type: Object, value: []byte("{}")},
+		{name: `{ \r\n }`, input: []byte("{ \r\n }"), _type: Object, value: []byte("{ \r\n }")},
+		{name: `{"key":1}`, input: []byte(`{"key":1}`), _type: Object, value: []byte(`{"key":1}`)},
+		{name: `{"key":true}`, input: []byte(`{"key":true}`), _type: Object, value: []byte(`{"key":true}`)},
+		{name: `{"key":"value"}`, input: []byte(`{"key":"value"}`), _type: Object, value: []byte(`{"key":"value"}`)},
+		{name: `{"foo":"bar","baz":"foo"}`, input: []byte(`{"foo":"bar", "baz":"foo"}`), _type: Object, value: []byte(`{"foo":"bar", "baz":"foo"}`)},
+		{name: "spaces", input: []byte(`  {  "foo"  :  "bar"  , "baz"   :   "foo"   }    `), _type: Object, value: []byte(`{  "foo"  :  "bar"  , "baz"   :   "foo"   }`)},
+		{name: "nested", input: []byte(`{"foo":{"bar":{"baz":{}}}}`), _type: Object, value: []byte(`{"foo":{"bar":{"baz":{}}}}`)},
+		{name: "array", input: []byte(`{"array":[{},{},{"foo":[{"bar":["baz"]}]}]}`), _type: Object, value: []byte(`{"array":[{},{},{"foo":[{"bar":["baz"]}]}]}`)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleValid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_ObjectSimpleCorrupted(t *testing.T) {
+	tests := []*testNode{
+		simpleCorrupted("{{{\"key\": \"foo\"{{{{"),
+		simpleCorrupted("}"),
+		simpleCorrupted("{ }}}}}}}"),
+		simpleCorrupted(" }"),
+		simpleCorrupted("{,}"),
+		simpleCorrupted("{:}"),
+		simpleCorrupted("{100000}"),
+		simpleCorrupted("{1:1}"),
+		simpleCorrupted("{'1:2,3:4'}"),
+		simpleCorrupted(`{"d"}`),
+		simpleCorrupted(`{"foo"}`),
+		simpleCorrupted(`{"foo":}`),
+		simpleCorrupted(`{:"foo"}`),
+		simpleCorrupted(`{"foo":bar}`),
+		simpleCorrupted(`{"foo":"bar",}`),
+		simpleCorrupted(`{}{}`),
+		simpleCorrupted(`{},{}`),
+		simpleCorrupted(`{[},{]}`),
+		simpleCorrupted(`{[,]}`),
+		simpleCorrupted(`{[]}`),
+		simpleCorrupted(`{}1`),
+		simpleCorrupted(`1{}`),
+		simpleCorrupted(`{"x"::1}`),
+		simpleCorrupted(`{null:null}`),
+		simpleCorrupted(`{"foo:"bar"}`),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleInvalid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_NullSimpleCorrupted(t *testing.T) {
+	tests := []*testNode{
+		{name: "nul", input: []byte("nul")},
+		{name: "nil", input: []byte("nil")},
+		{name: "nill", input: []byte("nill")},
+		{name: "NILL", input: []byte("NILL")},
+		{name: "Null", input: []byte("Null")},
+		{name: "NULL", input: []byte("NULL")},
+		{name: "spaces", input: []byte("Nu ll")},
+		{name: "null1", input: []byte("null1")},
+		{name: "double", input: []byte("null null")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleInvalid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_BoolSimpleSuccess(t *testing.T) {
+	tests := []*testNode{
+		{name: "lower true", input: []byte("true"), _type: Boolean, value: []byte("true")},
+		{name: "lower false", input: []byte("false"), _type: Boolean, value: []byte("false")},
+		{name: "spaces true", input: []byte("  true\r\n "), _type: Boolean, value: []byte("true")},
+		{name: "spaces false", input: []byte("  false\r\n "), _type: Boolean, value: []byte("false")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleValid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_BoolSimpleCorrupted(t *testing.T) {
+	tests := []*testNode{
+		simpleCorrupted("tru"),
+		simpleCorrupted("fals"),
+		simpleCorrupted("tre"),
+		simpleCorrupted("fal se"),
+		simpleCorrupted("true false"),
+		simpleCorrupted("True"),
+		simpleCorrupted("TRUE"),
+		simpleCorrupted("False"),
+		simpleCorrupted("FALSE"),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleInvalid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_ArraySimpleSuccess(t *testing.T) {
+	tests := []*testNode{
+		{name: "[]", input: []byte("[]"), _type: Array, value: []byte("[]")},
+		{name: "[1]", input: []byte("[1]"), _type: Array, value: []byte("[1]")},
+		{name: "[1,2,3]", input: []byte("[1,2,3]"), _type: Array, value: []byte("[1,2,3]")},
+		{name: "[1, 2, 3]", input: []byte("[1, 2, 3]"), _type: Array, value: []byte("[1, 2, 3]")},
+		{name: "[1,[2],3]", input: []byte("[1,[2],3]"), _type: Array, value: []byte("[1,[2],3]")},
+		{name: "[[],[],[]]", input: []byte("[[],[],[]]"), _type: Array, value: []byte("[[],[],[]]")},
+		{name: "[[[[[]]]]]", input: []byte("[[[[[]]]]]"), _type: Array, value: []byte("[[[[[]]]]]")},
+		{name: "[true,null,1,\"foo\",[]]", input: []byte("[true,null,1,\"foo\",[]]"), _type: Array, value: []byte("[true,null,1,\"foo\",[]]")},
+		{name: "spaces", input: []byte("\n\r [\n1\n ]\r\n"), _type: Array, value: []byte("[\n1\n ]")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleValid(test, t)
+		})
+	}
+}
+
+func TestUnmarshal_ArraySimpleCorrupted(t *testing.T) {
+	tests := []*testNode{
+		simpleCorrupted("[,]"),
+		simpleCorrupted("[]\\"),
+		simpleCorrupted("[1,]"),
+		simpleCorrupted("[[]"),
+		simpleCorrupted("[]]"),
+		simpleCorrupted("1[]"),
+		simpleCorrupted("[]1"),
+		simpleCorrupted("[[]1]"),
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			simpleInvalid(test, t)
+		})
+	}
+}
+
+// Examples from https://json.org/example.html
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name: "glossary",
+			value: `{
+				"glossary": {
+					"title": "example glossary",
+					"GlossDiv": {
+						"title": "S",
+						"GlossList": {
+							"GlossEntry": {
+								"ID": "SGML",
+								"SortAs": "SGML",
+								"GlossTerm": "Standard Generalized Markup Language",
+								"Acronym": "SGML",
+								"Abbrev": "ISO 8879:1986",
+								"GlossDef": {
+									"para": "A meta-markup language, used to create markup languages such as DocBook.",
+									"GlossSeeAlso": ["GML", "XML"]
+								},
+								"GlossSee": "markup"
+							}
+						}
+					}
+				}
+			}`,
+		},
+		{
+			name: "menu",
+			value: `{"menu": {
+				"id": "file",
+				"value": "File",
+				"popup": {
+				  "menuitem": [
+					{"value": "New", "onclick": "CreateNewDoc()"},
+					{"value": "Open", "onclick": "OpenDoc()"},
+					{"value": "Close", "onclick": "CloseDoc()"}
+				  ]
+				}
+			}}`,
+		},
+		{
+			name: "widget",
+			value: `{"widget": {
+				"debug": "on",
+				"window": {
+					"title": "Sample Konfabulator Widget",
+					"name": "main_window",
+					"width": 500,
+					"height": 500
+				},
+				"image": { 
+					"src": "Images/Sun.png",
+					"name": "sun1",
+					"hOffset": 250,
+					"vOffset": 250,
+					"alignment": "center"
+				},
+				"text": {
+					"data": "Click Here",
+					"size": 36,
+					"style": "bold",
+					"name": "text1",
+					"hOffset": 250,
+					"vOffset": 100,
+					"alignment": "center",
+					"onMouseUp": "sun1.opacity = (sun1.opacity / 100) * 90;"
+				}
+			}}    `,
+		},
+		{
+			name: "web-app",
+			value: `{"web-app": {
+				"servlet": [   
+				  {
+					"servlet-name": "cofaxCDS",
+					"servlet-class": "org.cofax.cds.CDSServlet",
+					"init-param": {
+					  "configGlossary:installationAt": "Philadelphia, PA",
+					  "configGlossary:adminEmail": "ksm@pobox.com",
+					  "configGlossary:poweredBy": "Cofax",
+					  "configGlossary:poweredByIcon": "/images/cofax.gif",
+					  "configGlossary:staticPath": "/content/static",
+					  "templateProcessorClass": "org.cofax.WysiwygTemplate",
+					  "templateLoaderClass": "org.cofax.FilesTemplateLoader",
+					  "templatePath": "templates",
+					  "templateOverridePath": "",
+					  "defaultListTemplate": "listTemplate.htm",
+					  "defaultFileTemplate": "articleTemplate.htm",
+					  "useJSP": false,
+					  "jspListTemplate": "listTemplate.jsp",
+					  "jspFileTemplate": "articleTemplate.jsp",
+					  "cachePackageTagsTrack": 200,
+					  "cachePackageTagsStore": 200,
+					  "cachePackageTagsRefresh": 60,
+					  "cacheTemplatesTrack": 100,
+					  "cacheTemplatesStore": 50,
+					  "cacheTemplatesRefresh": 15,
+					  "cachePagesTrack": 200,
+					  "cachePagesStore": 100,
+					  "cachePagesRefresh": 10,
+					  "cachePagesDirtyRead": 10,
+					  "searchEngineListTemplate": "forSearchEnginesList.htm",
+					  "searchEngineFileTemplate": "forSearchEngines.htm",
+					  "searchEngineRobotsDb": "WEB-INF/robots.db",
+					  "useDataStore": true,
+					  "dataStoreClass": "org.cofax.SqlDataStore",
+					  "redirectionClass": "org.cofax.SqlRedirection",
+					  "dataStoreName": "cofax",
+					  "dataStoreDriver": "com.microsoft.jdbc.sqlserver.SQLServerDriver",
+					  "dataStoreUrl": "jdbc:microsoft:sqlserver://LOCALHOST:1433;DatabaseName=goon",
+					  "dataStoreUser": "sa",
+					  "dataStorePassword": "dataStoreTestQuery",
+					  "dataStoreTestQuery": "SET NOCOUNT ON;select test='test';",
+					  "dataStoreLogFile": "/usr/local/tomcat/logs/datastore.log",
+					  "dataStoreInitConns": 10,
+					  "dataStoreMaxConns": 100,
+					  "dataStoreConnUsageLimit": 100,
+					  "dataStoreLogLevel": "debug",
+					  "maxUrlLength": 500}},
+				  {
+					"servlet-name": "cofaxEmail",
+					"servlet-class": "org.cofax.cds.EmailServlet",
+					"init-param": {
+					"mailHost": "mail1",
+					"mailHostOverride": "mail2"}},
+				  {
+					"servlet-name": "cofaxAdmin",
+					"servlet-class": "org.cofax.cds.AdminServlet"},
+			   
+				  {
+					"servlet-name": "fileServlet",
+					"servlet-class": "org.cofax.cds.FileServlet"},
+				  {
+					"servlet-name": "cofaxTools",
+					"servlet-class": "org.cofax.cms.CofaxToolsServlet",
+					"init-param": {
+					  "templatePath": "toolstemplates/",
+					  "log": 1,
+					  "logLocation": "/usr/local/tomcat/logs/CofaxTools.log",
+					  "logMaxSize": "",
+					  "dataLog": 1,
+					  "dataLogLocation": "/usr/local/tomcat/logs/dataLog.log",
+					  "dataLogMaxSize": "",
+					  "removePageCache": "/content/admin/remove?cache=pages&id=",
+					  "removeTemplateCache": "/content/admin/remove?cache=templates&id=",
+					  "fileTransferFolder": "/usr/local/tomcat/webapps/content/fileTransferFolder",
+					  "lookInContext": 1,
+					  "adminGroupID": 4,
+					  "betaServer": true}}],
+				"servlet-mapping": {
+				  "cofaxCDS": "/",
+				  "cofaxEmail": "/cofaxutil/aemail/*",
+				  "cofaxAdmin": "/admin/*",
+				  "fileServlet": "/static/*",
+				  "cofaxTools": "/tools/*"},
+			   
+				"taglib": {
+				  "taglib-uri": "cofax.tld",
+				  "taglib-location": "/WEB-INF/tlds/cofax.tld"}}}`,
+		},
+		{
+			name: "SVG Viewer",
+			value: `{"menu": {
+				"header": "SVG Viewer",
+				"items": [
+					{"id": "Open"},
+					{"id": "OpenNew", "label": "Open New"},
+					null,
+					{"id": "ZoomIn", "label": "Zoom In"},
+					{"id": "ZoomOut", "label": "Zoom Out"},
+					{"id": "OriginalView", "label": "Original View"},
+					null,
+					{"id": "Quality"},
+					{"id": "Pause"},
+					{"id": "Mute"},
+					null,
+					{"id": "Find", "label": "Find..."},
+					{"id": "FindAgain", "label": "Find Again"},
+					{"id": "Copy"},
+					{"id": "CopyAgain", "label": "Copy Again"},
+					{"id": "CopySVG", "label": "Copy SVG"},
+					{"id": "ViewSVG", "label": "View SVG"},
+					{"id": "ViewSource", "label": "View Source"},
+					{"id": "SaveAs", "label": "Save As"},
+					null,
+					{"id": "Help"},
+					{"id": "About", "label": "About Adobe CVG Viewer..."}
+				]
+			}}`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Unmarshal([]byte(test.value))
+			if err != nil {
+				t.Errorf("Error on Unmarshal: %s", err.Error())
+			}
+		})
+	}
+}
+
+func TestUnmarshalSafe(t *testing.T) {
+	json := []byte(`{ "store": {
+		"book": [ 
+		  { "category": "reference",
+			"author": "Nigel Rees",
+			"title": "Sayings of the Century",
+			"price": 8.95
+		  },
+		  { "category": "fiction",
+			"author": "Evelyn Waugh",
+			"title": "Sword of Honour",
+			"price": 12.99
+		  },
+		  { "category": "fiction",
+			"author": "Herman Melville",
+			"title": "Moby Dick",
+			"isbn": "0-553-21311-3",
+			"price": 8.99
+		  },
+		  { "category": "fiction",
+			"author": "J. R. R. Tolkien",
+			"title": "The Lord of the Rings",
+			"isbn": "0-395-19395-8",
+			"price": 22.99
+		  }
+		],
+		"bicycle": {
+		  "color": "red",
+		  "price": 19.95
+		}
+	  }
+	}`)
+	safe, err := UnmarshalSafe(json)
+	if err != nil {
+		t.Errorf("Error on Unmarshal: %s", err.Error())
+	} else if safe == nil {
+		t.Errorf("Error on Unmarshal: safe is nil")
+	} else {
+		root, err := Unmarshal(json)
+		if err != nil {
+			t.Errorf("Error on Unmarshal: %s", err.Error())
+		} else if root == nil {
+			t.Errorf("Error on Unmarshal: root is nil")
+		} else if !bytes.Equal(root.source(), safe.source()) {
+			t.Errorf("Error on UnmarshalSafe: values not same")
+		}
+	}
+}
+
+// BenchmarkGoStdUnmarshal-8   	   61698	     19350 ns/op	     288 B/op	       6 allocs/op
+// BenchmarkUnmarshal-8        	   45620	     26165 ns/op	   21889 B/op	     367 allocs/op
+//
+// type bench struct {
+// 	Name  string `json:"name"`
+// 	Value int    `json:"value"`
+// }
+
+// func BenchmarkGoStdUnmarshal(b *testing.B) {
+// 	data := []byte(webApp)
+// 	for i := 0; i < b.N; i++ {
+// 		err := json.Unmarshal(data, &bench{})
+// 		if err != nil {
+// 			b.Fatal(err)
+// 		}
+// 	}
+// }
+
+// func BenchmarkUnmarshal(b *testing.B) {
+// 	data := []byte(webApp)
+// 	for i := 0; i < b.N; i++ {
+// 		_, err := Unmarshal(data)
+// 		if err != nil {
+// 			b.Fatal(err)
+// 		}
+// 	}
+// }

--- a/vendored/gno.land/p/onbloc/json/encode.gno
+++ b/vendored/gno.land/p/onbloc/json/encode.gno
@@ -1,0 +1,117 @@
+package json
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// Marshal returns the JSON encoding of a Node.
+func Marshal(node *Node) ([]byte, error) {
+	var (
+		buf  bytes.Buffer
+		sVal string
+		bVal bool
+		nVal float64
+		oVal []byte
+		err  error
+	)
+
+	if node == nil {
+		return nil, errors.New("node is nil")
+	}
+
+	if !node.modified && !node.ready() {
+		return nil, errors.New("node is not ready")
+	}
+
+	if !node.modified && node.ready() {
+		buf.Write(node.source())
+	}
+
+	if node.modified {
+		switch node.nodeType {
+		case Null:
+			buf.Write(nullLiteral)
+
+		case Number:
+			nVal, err = node.GetNumeric()
+			if err != nil {
+				return nil, err
+			}
+
+			num := strconv.FormatFloat(nVal, 'f', -1, 64)
+			buf.WriteString(num)
+
+		case String:
+			sVal, err = node.GetString()
+			if err != nil {
+				return nil, err
+			}
+
+			quoted := ufmt.Sprintf("%s", strconv.Quote(sVal))
+			buf.WriteString(quoted)
+
+		case Boolean:
+			bVal, err = node.GetBool()
+			if err != nil {
+				return nil, err
+			}
+
+			bStr := ufmt.Sprintf("%t", bVal)
+			buf.WriteString(bStr)
+
+		case Array:
+			buf.WriteByte(bracketOpen)
+
+			for i := 0; i < len(node.next); i++ {
+				if i != 0 {
+					buf.WriteByte(comma)
+				}
+
+				elem, ok := node.next[strconv.Itoa(i)]
+				if !ok {
+					return nil, ufmt.Errorf("array element %d is not found", i)
+				}
+
+				oVal, err = Marshal(elem)
+				if err != nil {
+					return nil, err
+				}
+
+				buf.Write(oVal)
+			}
+
+			buf.WriteByte(bracketClose)
+
+		case Object:
+			buf.WriteByte(curlyOpen)
+
+			bVal = false
+			for k, v := range node.next {
+				if bVal {
+					buf.WriteByte(comma)
+				} else {
+					bVal = true
+				}
+
+				key := ufmt.Sprintf("%s", strconv.Quote(k))
+				buf.WriteString(key)
+				buf.WriteByte(colon)
+
+				oVal, err = Marshal(v)
+				if err != nil {
+					return nil, err
+				}
+
+				buf.Write(oVal)
+			}
+
+			buf.WriteByte(curlyClose)
+		}
+	}
+
+	return buf.Bytes(), nil
+}

--- a/vendored/gno.land/p/onbloc/json/encode_test.gno
+++ b/vendored/gno.land/p/onbloc/json/encode_test.gno
@@ -1,0 +1,254 @@
+package json
+
+import "testing"
+
+func TestMarshal_Primitive(t *testing.T) {
+	tests := []struct {
+		name string
+		node *Node
+	}{
+		{
+			name: "null",
+			node: NullNode(""),
+		},
+		{
+			name: "true",
+			node: BoolNode("", true),
+		},
+		{
+			name: "false",
+			node: BoolNode("", false),
+		},
+		{
+			name: `"string"`,
+			node: StringNode("", "string"),
+		},
+		{
+			name: `"one \"encoded\" string"`,
+			node: StringNode("", `one "encoded" string`),
+		},
+		{
+			name: `{"foo":"bar"}`,
+			node: ObjectNode("", map[string]*Node{
+				"foo": StringNode("foo", "bar"),
+			}),
+		},
+		{
+			name: "42",
+			node: NumberNode("", 42),
+		},
+		{
+			name: "3.14",
+			node: NumberNode("", 3.14),
+		},
+		{
+			name: `[1,2,3]`,
+			node: ArrayNode("", []*Node{
+				NumberNode("0", 1),
+				NumberNode("2", 2),
+				NumberNode("3", 3),
+			}),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, err := Marshal(test.node)
+			if err != nil {
+				t.Errorf("unexpected error: %s", err)
+			} else if string(value) != test.name {
+				t.Errorf("wrong result: '%s', expected '%s'", value, test.name)
+			}
+		})
+	}
+}
+
+func TestMarshal_Object(t *testing.T) {
+	node := ObjectNode("", map[string]*Node{
+		"foo": StringNode("foo", "bar"),
+		"baz": NumberNode("baz", 100500),
+		"qux": NullNode("qux"),
+	})
+
+	mustKey := []string{"foo", "baz", "qux"}
+
+	value, err := Marshal(node)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	// the order of keys in the map is not guaranteed
+	// so we need to unmarshal the result and check the keys
+	decoded, err := Unmarshal(value)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+
+	for _, key := range mustKey {
+		if node, err := decoded.GetKey(key); err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if node == nil {
+				t.Errorf("node is nil")
+			} else if node.key == nil {
+				t.Errorf("key is nil")
+			} else if *node.key != key {
+				t.Errorf("wrong key: '%s', expected '%s'", *node.key, key)
+			}
+		}
+	}
+}
+
+func valueNode(prev *Node, key string, typ ValueType, val any) *Node {
+	curr := &Node{
+		prev:     prev,
+		data:     nil,
+		key:      &key,
+		borders:  [2]int{0, 0},
+		value:    val,
+		modified: true,
+	}
+
+	if val != nil {
+		curr.nodeType = typ
+	}
+
+	return curr
+}
+
+func TestMarshal_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		node func() (node *Node)
+	}{
+		{
+			name: "nil",
+			node: func() (node *Node) {
+				return
+			},
+		},
+		{
+			name: "broken",
+			node: func() (node *Node) {
+				node = Must(Unmarshal([]byte(`{}`)))
+				node.borders[1] = 0
+				return
+			},
+		},
+		{
+			name: "Numeric",
+			node: func() (node *Node) {
+				return valueNode(nil, "", Number, false)
+			},
+		},
+		{
+			name: "String",
+			node: func() (node *Node) {
+				return valueNode(nil, "", String, false)
+			},
+		},
+		{
+			name: "Bool",
+			node: func() (node *Node) {
+				return valueNode(nil, "", Boolean, 1)
+			},
+		},
+		{
+			name: "Array_1",
+			node: func() (node *Node) {
+				node = ArrayNode("", nil)
+				node.next["1"] = NullNode("1")
+				return
+			},
+		},
+		{
+			name: "Array_2",
+			node: func() (node *Node) {
+				return ArrayNode("", []*Node{valueNode(nil, "", Boolean, 1)})
+			},
+		},
+		{
+			name: "Object",
+			node: func() (node *Node) {
+				return ObjectNode("", map[string]*Node{"key": valueNode(nil, "key", Boolean, 1)})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			value, err := Marshal(test.node())
+			if err == nil {
+				t.Errorf("expected error")
+			} else if len(value) != 0 {
+				t.Errorf("wrong result")
+			}
+		})
+	}
+}
+
+func TestMarshal_Nil(t *testing.T) {
+	_, err := Marshal(nil)
+	if err == nil {
+		t.Error("Expected error for nil node, but got nil")
+	}
+}
+
+func TestMarshal_NotModified(t *testing.T) {
+	node := &Node{}
+	_, err := Marshal(node)
+	if err == nil {
+		t.Error("Expected error for not modified node, but got nil")
+	}
+}
+
+func TestMarshalCycleReference(t *testing.T) {
+	node1 := &Node{
+		key:      stringPtr("node1"),
+		nodeType: String,
+		next: map[string]*Node{
+			"next": nil,
+		},
+	}
+
+	node2 := &Node{
+		key:      stringPtr("node2"),
+		nodeType: String,
+		prev:     node1,
+	}
+
+	node1.next["next"] = node2
+
+	_, err := Marshal(node1)
+	if err == nil {
+		t.Error("Expected error for cycle reference, but got nil")
+	}
+}
+
+func TestMarshalNoCycleReference(t *testing.T) {
+	node1 := &Node{
+		key:      stringPtr("node1"),
+		nodeType: String,
+		value:    "value1",
+		modified: true,
+	}
+
+	node2 := &Node{
+		key:      stringPtr("node2"),
+		nodeType: String,
+		value:    "value2",
+		modified: true,
+	}
+
+	_, err := Marshal(node1)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	_, err = Marshal(node2)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/vendored/gno.land/p/onbloc/json/errors.gno
+++ b/vendored/gno.land/p/onbloc/json/errors.gno
@@ -1,0 +1,34 @@
+package json
+
+import "errors"
+
+var (
+	errNilNode               = errors.New("node is nil")
+	errNotArrayNode          = errors.New("node is not array")
+	errNotBoolNode           = errors.New("node is not boolean")
+	errNotNullNode           = errors.New("node is not null")
+	errNotNumberNode         = errors.New("node is not number")
+	errNotObjectNode         = errors.New("node is not object")
+	errNotStringNode         = errors.New("node is not string")
+	errInvalidToken          = errors.New("invalid token")
+	errIndexNotFound         = errors.New("index not found")
+	errInvalidAppend         = errors.New("can't append value to non-appendable node")
+	errInvalidAppendCycle    = errors.New("appending value to itself or its children or parents will cause a cycle")
+	errInvalidEscapeSequence = errors.New("invalid escape sequence")
+	errInvalidStringValue    = errors.New("invalid string value")
+	errEmptyBooleanNode      = errors.New("boolean node is empty")
+	errEmptyStringNode       = errors.New("string node is empty")
+	errKeyRequired           = errors.New("key is required for object")
+	errUnmatchedParenthesis  = errors.New("mismatched bracket or parenthesis")
+	errUnmatchedQuotePath    = errors.New("unmatched quote in path")
+)
+
+var (
+	errInvalidStringInput    = errors.New("invalid string input")
+	errMalformedBooleanValue = errors.New("malformed boolean value")
+	errEmptyByteSlice        = errors.New("empty byte slice")
+	errInvalidExponentValue  = errors.New("invalid exponent value")
+	errNonDigitCharacters    = errors.New("non-digit characters found")
+	errNumericRangeExceeded  = errors.New("numeric value exceeds the range limit")
+	errMultipleDecimalPoints = errors.New("multiple decimal points found")
+)

--- a/vendored/gno.land/p/onbloc/json/escape.gno
+++ b/vendored/gno.land/p/onbloc/json/escape.gno
@@ -1,0 +1,298 @@
+package json
+
+import (
+	"unicode/utf8"
+)
+
+const (
+	supplementalPlanesOffset     = 0x10000
+	highSurrogateOffset          = 0xD800
+	lowSurrogateOffset           = 0xDC00
+	surrogateEnd                 = 0xDFFF
+	basicMultilingualPlaneOffset = 0xFFFF
+	badHex                       = -1
+
+	singleUnicodeEscapeLen = 6
+	surrogatePairLen       = 12
+)
+
+var hexLookupTable = [256]int{
+	'0': 0x0, '1': 0x1, '2': 0x2, '3': 0x3, '4': 0x4,
+	'5': 0x5, '6': 0x6, '7': 0x7, '8': 0x8, '9': 0x9,
+	'A': 0xA, 'B': 0xB, 'C': 0xC, 'D': 0xD, 'E': 0xE, 'F': 0xF,
+	'a': 0xA, 'b': 0xB, 'c': 0xC, 'd': 0xD, 'e': 0xE, 'f': 0xF,
+	// Fill unspecified index-value pairs with key and value of -1
+	'G': -1, 'H': -1, 'I': -1, 'J': -1,
+	'K': -1, 'L': -1, 'M': -1, 'N': -1,
+	'O': -1, 'P': -1, 'Q': -1, 'R': -1,
+	'S': -1, 'T': -1, 'U': -1, 'V': -1,
+	'W': -1, 'X': -1, 'Y': -1, 'Z': -1,
+	'g': -1, 'h': -1, 'i': -1, 'j': -1,
+	'k': -1, 'l': -1, 'm': -1, 'n': -1,
+	'o': -1, 'p': -1, 'q': -1, 'r': -1,
+	's': -1, 't': -1, 'u': -1, 'v': -1,
+	'w': -1, 'x': -1, 'y': -1, 'z': -1,
+}
+
+func h2i(c byte) int {
+	return hexLookupTable[c]
+}
+
+// Unescape takes an input byte slice, processes it to Unescape certain characters,
+// and writes the result into an output byte slice.
+//
+// it returns the processed slice and any error encountered during the Unescape operation.
+func Unescape(input, output []byte) ([]byte, error) {
+	// ensure the output slice has enough capacity to hold the input slice.
+	inputLen := len(input)
+	if cap(output) < inputLen {
+		output = make([]byte, inputLen)
+	}
+
+	inPos, outPos := 0, 0
+
+	for inPos < len(input) {
+		c := input[inPos]
+		if c != backSlash {
+			output[outPos] = c
+			inPos++
+			outPos++
+		} else {
+			// process escape sequence
+			inLen, outLen, err := processEscapedUTF8(input[inPos:], output[outPos:])
+			if err != nil {
+				return nil, err
+			}
+			inPos += inLen
+			outPos += outLen
+		}
+	}
+
+	return output[:outPos], nil
+}
+
+// isSurrogatePair returns true if the rune is a surrogate pair.
+//
+// A surrogate pairs are used in UTF-16 encoding to encode characters
+// outside the Basic Multilingual Plane (BMP).
+func isSurrogatePair(r rune) bool {
+	return highSurrogateOffset <= r && r <= surrogateEnd
+}
+
+// isHighSurrogate checks if the rune is a high surrogate (U+D800 to U+DBFF).
+func isHighSurrogate(r rune) bool {
+	return r >= highSurrogateOffset && r <= 0xDBFF
+}
+
+// isLowSurrogate checks if the rune is a low surrogate (U+DC00 to U+DFFF).
+func isLowSurrogate(r rune) bool {
+	return r >= lowSurrogateOffset && r <= surrogateEnd
+}
+
+// combineSurrogates reconstruct the original unicode code points in the
+// supplemental plane by combinin the high and low surrogate.
+//
+// The hight surrogate in the range from U+D800 to U+DBFF,
+// and the low surrogate in the range from U+DC00 to U+DFFF.
+//
+// The formula to combine the surrogates is:
+// (high - 0xD800) * 0x400 + (low - 0xDC00) + 0x10000
+func combineSurrogates(high, low rune) rune {
+	return ((high - highSurrogateOffset) << 10) + (low - lowSurrogateOffset) + supplementalPlanesOffset
+}
+
+// deocdeSingleUnicodeEscape decodes a unicode escape sequence (e.g., \uXXXX) into a rune.
+func decodeSingleUnicodeEscape(b []byte) (rune, bool) {
+	if len(b) < 6 {
+		return utf8.RuneError, false
+	}
+
+	// convert hex to decimal
+	h1, h2, h3, h4 := h2i(b[2]), h2i(b[3]), h2i(b[4]), h2i(b[5])
+	if h1 == badHex || h2 == badHex || h3 == badHex || h4 == badHex {
+		return utf8.RuneError, false
+	}
+
+	return rune(h1<<12 + h2<<8 + h3<<4 + h4), true
+}
+
+// decodeUnicodeEscape decodes a Unicode escape sequence from a byte slice.
+// It handles both single Unicode escape sequences and surrogate pairs.
+func decodeUnicodeEscape(b []byte) (rune, int) {
+	// decode the first Unicode escape sequence.
+	r, ok := decodeSingleUnicodeEscape(b)
+	if !ok {
+		return utf8.RuneError, -1
+	}
+
+	// if the rune is within the BMP and not a surrogate, return it
+	if r <= basicMultilingualPlaneOffset && !isSurrogatePair(r) {
+		return r, 6
+	}
+
+	if !isHighSurrogate(r) {
+		// invalid surrogate pair.
+		return utf8.RuneError, -1
+	}
+
+	// if the rune is a high surrogate, need to decode the next escape sequence.
+
+	// ensure there are enough bytes for the next escape sequence.
+	if len(b) < surrogatePairLen {
+		return utf8.RuneError, -1
+	}
+	// decode the second Unicode escape sequence.
+	r2, ok := decodeSingleUnicodeEscape(b[singleUnicodeEscapeLen:])
+	if !ok {
+		return utf8.RuneError, -1
+	}
+	// check if the second rune is a low surrogate.
+	if isLowSurrogate(r2) {
+		combined := combineSurrogates(r, r2)
+		return combined, surrogatePairLen
+	}
+	return utf8.RuneError, -1
+}
+
+var escapeByteSet = [256]byte{
+	'"':  doubleQuote,
+	'\\': backSlash,
+	'/':  slash,
+	'b':  backSpace,
+	'f':  formFeed,
+	'n':  newLine,
+	'r':  carriageReturn,
+	't':  tab,
+}
+
+// Unquote takes a byte slice and unquotes it by removing
+// the surrounding quotes and unescaping the contents.
+func Unquote(s []byte, border byte) (string, bool) {
+	s, ok := unquoteBytes(s, border)
+	return string(s), ok
+}
+
+// unquoteBytes takes a byte slice and unquotes it by removing
+func unquoteBytes(s []byte, border byte) ([]byte, bool) {
+	if len(s) < 2 || s[0] != border || s[len(s)-1] != border {
+		return nil, false
+	}
+
+	s = s[1 : len(s)-1]
+
+	r := 0
+	for r < len(s) {
+		c := s[r]
+
+		if c == backSlash || c == border || c < 0x20 {
+			break
+		}
+
+		if c < utf8.RuneSelf {
+			r++
+			continue
+		}
+
+		rr, size := utf8.DecodeRune(s[r:])
+		if rr == utf8.RuneError && size == 1 {
+			break
+		}
+
+		r += size
+	}
+
+	if r == len(s) {
+		return s, true
+	}
+
+	utfDoubleMax := utf8.UTFMax * 2
+	b := make([]byte, len(s)+utfDoubleMax)
+	w := copy(b, s[0:r])
+
+	for r < len(s) {
+		if w >= len(b)-utf8.UTFMax {
+			nb := make([]byte, utfDoubleMax+(2*len(b)))
+			copy(nb, b)
+			b = nb
+		}
+
+		c := s[r]
+		if c == backSlash {
+			r++
+			if r >= len(s) {
+				return nil, false
+			}
+
+			if s[r] == 'u' {
+				rr, res := decodeUnicodeEscape(s[r-1:])
+				if res < 0 {
+					return nil, false
+				}
+
+				w += utf8.EncodeRune(b[w:], rr)
+				r += 5
+			} else {
+				decode := escapeByteSet[s[r]]
+				if decode == 0 {
+					return nil, false
+				}
+
+				if decode == doubleQuote || decode == backSlash || decode == slash {
+					decode = s[r]
+				}
+
+				b[w] = decode
+				r++
+				w++
+			}
+		} else if c == border || c < 0x20 {
+			return nil, false
+		} else if c < utf8.RuneSelf {
+			b[w] = c
+			r++
+			w++
+		} else {
+			rr, size := utf8.DecodeRune(s[r:])
+
+			if rr == utf8.RuneError && size == 1 {
+				return nil, false
+			}
+
+			r += size
+			w += utf8.EncodeRune(b[w:], rr)
+		}
+	}
+
+	return b[:w], true
+}
+
+// processEscapedUTF8 converts escape sequences to UTF-8 characters.
+// It decodes Unicode escape sequences (\uXXXX) to UTF-8 and
+// converts standard escape sequences (e.g., \n) to their corresponding special characters.
+func processEscapedUTF8(in, out []byte) (int, int, error) {
+	if len(in) < 2 || in[0] != backSlash {
+		return -1, -1, errInvalidEscapeSequence
+	}
+
+	escapeSeqLen := 2
+	escapeChar := in[1]
+
+	if escapeChar != 'u' {
+		val := escapeByteSet[escapeChar]
+		if val == 0 {
+			return -1, -1, errInvalidEscapeSequence
+		}
+
+		out[0] = val
+		return escapeSeqLen, 1, nil
+	}
+
+	r, size := decodeUnicodeEscape(in)
+	if size == -1 {
+		return -1, -1, errInvalidEscapeSequence
+	}
+
+	outLen := utf8.EncodeRune(out, r)
+
+	return size, outLen, nil
+}

--- a/vendored/gno.land/p/onbloc/json/escape_test.gno
+++ b/vendored/gno.land/p/onbloc/json/escape_test.gno
@@ -1,0 +1,233 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestHexToInt(t *testing.T) {
+	tests := []struct {
+		name string
+		c    byte
+		want int
+	}{
+		{"Digit 0", '0', 0},
+		{"Digit 9", '9', 9},
+		{"Uppercase A", 'A', 10},
+		{"Uppercase F", 'F', 15},
+		{"Lowercase a", 'a', 10},
+		{"Lowercase f", 'f', 15},
+		{"Invalid character1", 'g', badHex},
+		{"Invalid character2", 'G', badHex},
+		{"Invalid character3", 'z', badHex},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := h2i(tt.c); got != tt.want {
+				t.Errorf("h2i() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSurrogatePair(t *testing.T) {
+	testCases := []struct {
+		name     string
+		r        rune
+		expected bool
+	}{
+		{"high surrogate start", 0xD800, true},
+		{"high surrogate end", 0xDBFF, true},
+		{"low surrogate start", 0xDC00, true},
+		{"low surrogate end", 0xDFFF, true},
+		{"Non-surrogate", 0x0000, false},
+		{"Non-surrogate 2", 0xE000, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSurrogatePair(tc.r); got != tc.expected {
+				t.Errorf("isSurrogate() = %v, want %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestCombineSurrogates(t *testing.T) {
+	testCases := []struct {
+		high, low rune
+		expected  rune
+	}{
+		{0xD83D, 0xDC36, 0x1F436}, // 🐶 U+1F436 DOG FACE
+		{0xD83D, 0xDE00, 0x1F600}, // 😀 U+1F600 GRINNING FACE
+		{0xD83C, 0xDF03, 0x1F303}, // 🌃 U+1F303 NIGHT WITH STARS
+	}
+
+	for _, tc := range testCases {
+		result := combineSurrogates(tc.high, tc.low)
+		if result != tc.expected {
+			t.Errorf("combineSurrogates(%U, %U) = %U; want %U", tc.high, tc.low, result, tc.expected)
+		}
+	}
+}
+
+func TestDecodeSingleUnicodeEscape(t *testing.T) {
+	testCases := []struct {
+		input    []byte
+		expected rune
+		isValid  bool
+	}{
+		// valid unicode escape sequences
+		{[]byte(`\u0041`), 'A', true},
+		{[]byte(`\u03B1`), 'α', true},
+		{[]byte(`\u00E9`), 'é', true}, // valid non-English character
+		{[]byte(`\u0021`), '!', true}, // valid special character
+		{[]byte(`\uFF11`), '１', true},
+		{[]byte(`\uD83D`), 0xD83D, true},
+		{[]byte(`\uDE03`), 0xDE03, true},
+
+		// invalid unicode escape sequences
+		{[]byte(`\u004`), utf8.RuneError, false},  // too short
+		{[]byte(`\uXYZW`), utf8.RuneError, false}, // invalid hex
+		{[]byte(`\u00G1`), utf8.RuneError, false}, // non-hex character
+	}
+
+	for _, tc := range testCases {
+		result, isValid := decodeSingleUnicodeEscape(tc.input)
+		if result != tc.expected || isValid != tc.isValid {
+			t.Errorf("decodeSingleUnicodeEscape(%s) = (%U, %v); want (%U, %v)", tc.input, result, isValid, tc.expected, tc.isValid)
+		}
+	}
+}
+
+func TestDecodeUnicodeEscape(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		expected rune
+		size     int
+	}{
+		{[]byte(`\u0041`), 'A', 6},
+		{[]byte(`\uD83D\uDE00`), 0x1F600, 12}, // 😀
+		{[]byte(`\uD834\uDD1E`), 0x1D11E, 12}, // 𝄞
+		{[]byte(`\uFFFF`), '\uFFFF', 6},
+		{[]byte(`\uXYZW`), utf8.RuneError, -1},
+		{[]byte(`\uD800`), utf8.RuneError, -1},       // single high surrogate
+		{[]byte(`\uDC00`), utf8.RuneError, -1},       // single low surrogate
+		{[]byte(`\uD800\uDC00`), 0x10000, 12},        // First code point above U+FFFF
+		{[]byte(`\uDBFF\uDFFF`), 0x10FFFF, 12},       // Maximum code point
+		{[]byte(`\uD83D\u0041`), utf8.RuneError, -1}, // invalid surrogate pair
+	}
+
+	for _, tc := range tests {
+		r, size := decodeUnicodeEscape(tc.input)
+		if r != tc.expected || size != tc.size {
+			t.Errorf("decodeUnicodeEscape(%q) = (%U, %d); want (%U, %d)", tc.input, r, size, tc.expected, tc.size)
+		}
+	}
+}
+
+func TestUnescapeToUTF8(t *testing.T) {
+	tests := []struct {
+		input       []byte
+		expectedIn  int
+		expectedOut int
+		isError     bool
+	}{
+		// valid escape sequences
+		{[]byte(`\n`), 2, 1, false},
+		{[]byte(`\t`), 2, 1, false},
+		{[]byte(`\u0041`), 6, 1, false},
+		{[]byte(`\u03B1`), 6, 2, false},
+		{[]byte(`\uD830\uDE03`), 12, 4, false},
+
+		// invalid escape sequences
+		{[]byte(`\`), -1, -1, true},            // incomplete escape sequence
+		{[]byte(`\x`), -1, -1, true},           // invalid escape character
+		{[]byte(`\u`), -1, -1, true},           // incomplete unicode escape sequence
+		{[]byte(`\u004`), -1, -1, true},        // invalid unicode escape sequence
+		{[]byte(`\uXYZW`), -1, -1, true},       // invalid unicode escape sequence
+		{[]byte(`\uD83D\u0041`), -1, -1, true}, // invalid unicode escape sequence
+	}
+
+	for _, tc := range tests {
+		input := make([]byte, len(tc.input))
+		copy(input, tc.input)
+		output := make([]byte, utf8.UTFMax)
+		inLen, outLen, err := processEscapedUTF8(input, output)
+		if (err != nil) != tc.isError {
+			t.Errorf("processEscapedUTF8(%q) = %v; want %v", tc.input, err, tc.isError)
+		}
+
+		if inLen != tc.expectedIn || outLen != tc.expectedOut {
+			t.Errorf("processEscapedUTF8(%q) = (%d, %d); want (%d, %d)", tc.input, inLen, outLen, tc.expectedIn, tc.expectedOut)
+		}
+	}
+}
+
+func TestUnescape(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+		isError  bool
+	}{
+		{"NoEscape", []byte("hello world"), []byte("hello world"), false},
+		{"SingleEscape", []byte("hello\\nworld"), []byte("hello\nworld"), false},
+		{"MultipleEscapes", []byte("line1\\nline2\\r\\nline3"), []byte("line1\nline2\r\nline3"), false},
+		{"UnicodeEscape", []byte("snowman:\\u2603"), []byte("snowman:\u2603"), false},
+		{"SurrogatePair", []byte("emoji:\\uD83D\\uDE00"), []byte("emoji:😀"), false},
+		{"InvalidEscape", []byte("hello\\xworld"), nil, true},
+		{"IncompleteUnicode", []byte("incomplete:\\u123"), nil, true},
+		{"InvalidSurrogatePair", []byte("invalid:\\uD83D\\u0041"), nil, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			output := make([]byte, len(tc.input)*2) // Allocate extra space for possible expansion
+			result, err := Unescape(tc.input, output)
+			if (err != nil) != tc.isError {
+				t.Errorf("Unescape(%q) error = %v; want error = %v", tc.input, err, tc.isError)
+			}
+
+			if !tc.isError && !bytes.Equal(result, tc.expected) {
+				t.Errorf("Unescape(%q) = %q; want %q", tc.input, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestUnquoteBytes(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		border   byte
+		expected []byte
+		ok       bool
+	}{
+		{[]byte("\"hello\""), '"', []byte("hello"), true},
+		{[]byte("'hello'"), '\'', []byte("hello"), true},
+		{[]byte("\"hello"), '"', nil, false},
+		{[]byte("hello\""), '"', nil, false},
+		{[]byte("\"he\\\"llo\""), '"', []byte("he\"llo"), true},
+		{[]byte("\"he\\nllo\""), '"', []byte("he\nllo"), true},
+		{[]byte("\"\""), '"', []byte(""), true},
+		{[]byte("''"), '\'', []byte(""), true},
+		{[]byte("\"\\u0041\""), '"', []byte("A"), true},
+		{[]byte(`"Hello, 世界"`), '"', []byte("Hello, 世界"), true},
+		{[]byte(`"Hello, \x80"`), '"', nil, false},
+		{[]byte(`"invalid surrogate: \uD83D\u0041"`), '"', nil, false},
+	}
+
+	for _, tc := range tests {
+		result, pass := unquoteBytes(tc.input, tc.border)
+
+		if pass != tc.ok {
+			t.Errorf("unquoteBytes(%q) = %v; want %v", tc.input, pass, tc.ok)
+		}
+
+		if !bytes.Equal(result, tc.expected) {
+			t.Errorf("unquoteBytes(%q) = %q; want %q", tc.input, result, tc.expected)
+		}
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/gnomod.toml
+++ b/vendored/gno.land/p/onbloc/json/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/onbloc/json"
+gno = "0.9"

--- a/vendored/gno.land/p/onbloc/json/indent.gno
+++ b/vendored/gno.land/p/onbloc/json/indent.gno
@@ -1,0 +1,130 @@
+package json
+
+import (
+	"bytes"
+	"strings"
+)
+
+// indentGrowthFactor specifies the growth factor of indenting JSON input.
+// A factor no higher than 2 ensures that wasted space never exceeds 50%.
+const indentGrowthFactor = 2
+
+// IndentJSON formats the JSON data with the specified indentation.
+func Indent(data []byte, indent string) ([]byte, error) {
+	var (
+		out        bytes.Buffer
+		level      int
+		inArray    bool
+		arrayDepth int
+	)
+
+	for i := 0; i < len(data); i++ {
+		c := data[i] // current character
+
+		switch c {
+		case bracketOpen:
+			arrayDepth++
+			if arrayDepth > 1 {
+				level++ // increase the level if it's nested array
+				inArray = true
+
+				if err := out.WriteByte(c); err != nil {
+					return nil, err
+				}
+
+				if err := writeNewlineAndIndent(&out, level, indent); err != nil {
+					return nil, err
+				}
+			} else {
+				// case of the top-level array
+				inArray = true
+				if err := out.WriteByte(c); err != nil {
+					return nil, err
+				}
+			}
+
+		case bracketClose:
+			if inArray && arrayDepth > 1 { // nested array
+				level--
+				if err := writeNewlineAndIndent(&out, level, indent); err != nil {
+					return nil, err
+				}
+			}
+
+			arrayDepth--
+			if arrayDepth == 0 {
+				inArray = false
+			}
+
+			if err := out.WriteByte(c); err != nil {
+				return nil, err
+			}
+
+		case curlyOpen:
+			// check if the empty object or array
+			// we don't need to apply the indent when it's empty containers.
+			if i+1 < len(data) && data[i+1] == curlyClose {
+				if err := out.WriteByte(c); err != nil {
+					return nil, err
+				}
+
+				i++ // skip next character
+				if err := out.WriteByte(data[i]); err != nil {
+					return nil, err
+				}
+			} else {
+				if err := out.WriteByte(c); err != nil {
+					return nil, err
+				}
+
+				level++
+				if err := writeNewlineAndIndent(&out, level, indent); err != nil {
+					return nil, err
+				}
+			}
+
+		case curlyClose:
+			level--
+			if err := writeNewlineAndIndent(&out, level, indent); err != nil {
+				return nil, err
+			}
+			if err := out.WriteByte(c); err != nil {
+				return nil, err
+			}
+
+		case comma, colon:
+			if err := out.WriteByte(c); err != nil {
+				return nil, err
+			}
+			if inArray && arrayDepth > 1 { // nested array
+				if err := writeNewlineAndIndent(&out, level, indent); err != nil {
+					return nil, err
+				}
+			} else if c == colon {
+				if err := out.WriteByte(' '); err != nil {
+					return nil, err
+				}
+			}
+
+		default:
+			if err := out.WriteByte(c); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return out.Bytes(), nil
+}
+
+func writeNewlineAndIndent(out *bytes.Buffer, level int, indent string) error {
+	if err := out.WriteByte('\n'); err != nil {
+		return err
+	}
+
+	idt := strings.Repeat(indent, level*indentGrowthFactor)
+	if _, err := out.WriteString(idt); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendored/gno.land/p/onbloc/json/indent_test.gno
+++ b/vendored/gno.land/p/onbloc/json/indent_test.gno
@@ -1,0 +1,84 @@
+package json
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestIndentJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		indent   string
+		expected []byte
+	}{
+		{
+			name:     "empty object",
+			input:    []byte(`{}`),
+			indent:   "  ",
+			expected: []byte(`{}`),
+		},
+		{
+			name:     "empty array",
+			input:    []byte(`[]`),
+			indent:   "  ",
+			expected: []byte(`[]`),
+		},
+		{
+			name:     "nested object",
+			input:    []byte(`{{}}`),
+			indent:   "\t",
+			expected: []byte("{\n\t\t{}\n}"),
+		},
+		{
+			name:     "nested array",
+			input:    []byte(`[[[]]]`),
+			indent:   "\t",
+			expected: []byte("[[\n\t\t[\n\t\t\t\t\n\t\t]\n]]"),
+		},
+		{
+			name:     "top-level array",
+			input:    []byte(`["apple","banana","cherry"]`),
+			indent:   "\t",
+			expected: []byte(`["apple","banana","cherry"]`),
+		},
+		{
+			name:     "array of arrays",
+			input:    []byte(`["apple",["banana","cherry"],"date"]`),
+			indent:   "  ",
+			expected: []byte("[\"apple\",[\n    \"banana\",\n    \"cherry\"\n],\"date\"]"),
+		},
+
+		{
+			name:     "nested array in object",
+			input:    []byte(`{"fruits":["apple",["banana","cherry"],"date"]}`),
+			indent:   "  ",
+			expected: []byte("{\n    \"fruits\": [\"apple\",[\n        \"banana\",\n        \"cherry\"\n    ],\"date\"]\n}"),
+		},
+		{
+			name:     "complex nested structure",
+			input:    []byte(`{"data":{"array":[1,2,3],"bool":true,"nestedArray":[["a","b"],"c"]}}`),
+			indent:   "  ",
+			expected: []byte("{\n    \"data\": {\n        \"array\": [1,2,3],\"bool\": true,\"nestedArray\": [[\n            \"a\",\n            \"b\"\n        ],\"c\"]\n    }\n}"),
+		},
+		{
+			name:     "custom ident character",
+			input:    []byte(`{"fruits":["apple",["banana","cherry"],"date"]}`),
+			indent:   "*",
+			expected: []byte("{\n**\"fruits\": [\"apple\",[\n****\"banana\",\n****\"cherry\"\n**],\"date\"]\n}"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := Indent(tt.input, tt.indent)
+			if err != nil {
+				t.Errorf("IndentJSON() error = %v", err)
+				return
+			}
+			if !bytes.Equal(actual, tt.expected) {
+				t.Errorf("IndentJSON() = %q, want %q", actual, tt.expected)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/internal.gno
+++ b/vendored/gno.land/p/onbloc/json/internal.gno
@@ -1,0 +1,198 @@
+package json
+
+// Reference: https://github.com/freddierice/php_source/blob/467ed5d6edff72219afd3e644516f131118ef48e/ext/json/JSON_parser.c
+// Copyright (c) 2005 JSON.org
+
+// Go implementation is taken from: https://github.com/spyzhov/ajson/blob/master/internal/state.go
+
+type (
+	States  int8 // possible states of the parser
+	Classes int8 // JSON string character types
+)
+
+const __ = -1
+
+// enum classes
+const (
+	C_SPACE Classes = iota /* space */
+	C_WHITE                /* other whitespace */
+	C_LCURB                /* {  */
+	C_RCURB                /* } */
+	C_LSQRB                /* [ */
+	C_RSQRB                /* ] */
+	C_COLON                /* : */
+	C_COMMA                /* , */
+	C_QUOTE                /* " */
+	C_BACKS                /* \ */
+	C_SLASH                /* / */
+	C_PLUS                 /* + */
+	C_MINUS                /* - */
+	C_POINT                /* . */
+	C_ZERO                 /* 0 */
+	C_DIGIT                /* 123456789 */
+	C_LOW_A                /* a */
+	C_LOW_B                /* b */
+	C_LOW_C                /* c */
+	C_LOW_D                /* d */
+	C_LOW_E                /* e */
+	C_LOW_F                /* f */
+	C_LOW_L                /* l */
+	C_LOW_N                /* n */
+	C_LOW_R                /* r */
+	C_LOW_S                /* s */
+	C_LOW_T                /* t */
+	C_LOW_U                /* u */
+	C_ABCDF                /* ABCDF */
+	C_E                    /* E */
+	C_ETC                  /* everything else */
+)
+
+// AsciiClasses array maps the 128 ASCII characters into character classes.
+var AsciiClasses = [128]Classes{
+	/*
+	   This array maps the 128 ASCII characters into character classes.
+	   The remaining Unicode characters should be mapped to C_ETC.
+	   Non-whitespace control characters are errors.
+	*/
+	__, __, __, __, __, __, __, __,
+	__, C_WHITE, C_WHITE, __, __, C_WHITE, __, __,
+	__, __, __, __, __, __, __, __,
+	__, __, __, __, __, __, __, __,
+
+	C_SPACE, C_ETC, C_QUOTE, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_PLUS, C_COMMA, C_MINUS, C_POINT, C_SLASH,
+	C_ZERO, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT,
+	C_DIGIT, C_DIGIT, C_COLON, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+
+	C_ETC, C_ABCDF, C_ABCDF, C_ABCDF, C_ABCDF, C_E, C_ABCDF, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_LSQRB, C_BACKS, C_RSQRB, C_ETC, C_ETC,
+
+	C_ETC, C_LOW_A, C_LOW_B, C_LOW_C, C_LOW_D, C_LOW_E, C_LOW_F, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_LOW_L, C_ETC, C_LOW_N, C_ETC,
+	C_ETC, C_ETC, C_LOW_R, C_LOW_S, C_LOW_T, C_LOW_U, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_LCURB, C_ETC, C_RCURB, C_ETC, C_ETC,
+}
+
+// QuoteAsciiClasses is a HACK for single quote from AsciiClasses
+var QuoteAsciiClasses = [128]Classes{
+	/*
+	   This array maps the 128 ASCII characters into character classes.
+	   The remaining Unicode characters should be mapped to C_ETC.
+	   Non-whitespace control characters are errors.
+	*/
+	__, __, __, __, __, __, __, __,
+	__, C_WHITE, C_WHITE, __, __, C_WHITE, __, __,
+	__, __, __, __, __, __, __, __,
+	__, __, __, __, __, __, __, __,
+
+	C_SPACE, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_QUOTE,
+	C_ETC, C_ETC, C_ETC, C_PLUS, C_COMMA, C_MINUS, C_POINT, C_SLASH,
+	C_ZERO, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT, C_DIGIT,
+	C_DIGIT, C_DIGIT, C_COLON, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+
+	C_ETC, C_ABCDF, C_ABCDF, C_ABCDF, C_ABCDF, C_E, C_ABCDF, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_LSQRB, C_BACKS, C_RSQRB, C_ETC, C_ETC,
+
+	C_ETC, C_LOW_A, C_LOW_B, C_LOW_C, C_LOW_D, C_LOW_E, C_LOW_F, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_ETC, C_LOW_L, C_ETC, C_LOW_N, C_ETC,
+	C_ETC, C_ETC, C_LOW_R, C_LOW_S, C_LOW_T, C_LOW_U, C_ETC, C_ETC,
+	C_ETC, C_ETC, C_ETC, C_LCURB, C_ETC, C_RCURB, C_ETC, C_ETC,
+}
+
+/*
+The state codes.
+*/
+const (
+	GO States = iota /* start    */
+	OK               /* ok       */
+	OB               /* object   */
+	KE               /* key      */
+	CO               /* colon    */
+	VA               /* value    */
+	AR               /* array    */
+	ST               /* string   */
+	ES               /* escape   */
+	U1               /* u1       */
+	U2               /* u2       */
+	U3               /* u3       */
+	U4               /* u4       */
+	MI               /* minus    */
+	ZE               /* zero     */
+	IN               /* integer  */
+	DT               /* dot      */
+	FR               /* fraction */
+	E1               /* e        */
+	E2               /* ex       */
+	E3               /* exp      */
+	T1               /* tr       */
+	T2               /* tru      */
+	T3               /* true     */
+	F1               /* fa       */
+	F2               /* fal      */
+	F3               /* fals     */
+	F4               /* false    */
+	N1               /* nu       */
+	N2               /* nul      */
+	N3               /* null     */
+)
+
+// List of action codes.
+// these constants are defining an action that should be performed under certain conditions.
+const (
+	cl States = -2 /* colon           */
+	cm States = -3 /* comma           */
+	qt States = -4 /* quote           */
+	bo States = -5 /* bracket open    */
+	co States = -6 /* curly bracket open  */
+	bc States = -7 /* bracket close   */
+	cc States = -8 /* curly bracket close */
+	ec States = -9 /* curly bracket empty */
+)
+
+// StateTransitionTable is the state transition table takes the current state and the current symbol, and returns either
+// a new state or an action. An action is represented as a negative number. A JSON text is accepted if at the end of the
+// text the state is OK and if the mode is DONE.
+var StateTransitionTable = [31][31]States{
+	/*
+	   The state transition table takes the current state and the current symbol,
+	   and returns either a new state or an action. An action is represented as a
+	   negative number. A JSON text is accepted if at the end of the text the
+	   state is OK and if the mode is DONE.
+	                  white                                                    1-9                                                ABCDF   etc
+	            space   |   {   }   [   ]   :   ,   "   \   /   +   -   .   0   |   a   b   c   d   e   f   l   n   r   s   t   u   |   E   |*/
+	/*start  GO*/ {GO, GO, co, __, bo, __, __, __, ST, __, __, __, MI, __, ZE, IN, __, __, __, __, __, F1, __, N1, __, __, T1, __, __, __, __},
+	/*ok     OK*/ {OK, OK, __, cc, __, bc, __, cm, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*object OB*/ {OB, OB, __, ec, __, __, __, __, ST, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*key    KE*/ {KE, KE, __, __, __, __, __, __, ST, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*colon  CO*/ {CO, CO, __, __, __, __, cl, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*value  VA*/ {VA, VA, co, __, bo, __, __, __, ST, __, __, __, MI, __, ZE, IN, __, __, __, __, __, F1, __, N1, __, __, T1, __, __, __, __},
+	/*array  AR*/ {AR, AR, co, __, bo, bc, __, __, ST, __, __, __, MI, __, ZE, IN, __, __, __, __, __, F1, __, N1, __, __, T1, __, __, __, __},
+	/*string ST*/ {ST, __, ST, ST, ST, ST, ST, ST, qt, ES, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST, ST},
+	/*escape ES*/ {__, __, __, __, __, __, __, __, ST, ST, ST, __, __, __, __, __, __, ST, __, __, __, ST, __, ST, ST, __, ST, U1, __, __, __},
+	/*u1     U1*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, U2, U2, U2, U2, U2, U2, U2, U2, __, __, __, __, __, __, U2, U2, __},
+	/*u2     U2*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, U3, U3, U3, U3, U3, U3, U3, U3, __, __, __, __, __, __, U3, U3, __},
+	/*u3     U3*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, U4, U4, U4, U4, U4, U4, U4, U4, __, __, __, __, __, __, U4, U4, __},
+	/*u4     U4*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, ST, ST, ST, ST, ST, ST, ST, ST, __, __, __, __, __, __, ST, ST, __},
+	/*minus  MI*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, ZE, IN, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*zero   ZE*/ {OK, OK, __, cc, __, bc, __, cm, __, __, __, __, __, DT, __, __, __, __, __, __, E1, __, __, __, __, __, __, __, __, E1, __},
+	/*int    IN*/ {OK, OK, __, cc, __, bc, __, cm, __, __, __, __, __, DT, IN, IN, __, __, __, __, E1, __, __, __, __, __, __, __, __, E1, __},
+	/*dot    DT*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, FR, FR, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*frac   FR*/ {OK, OK, __, cc, __, bc, __, cm, __, __, __, __, __, __, FR, FR, __, __, __, __, E1, __, __, __, __, __, __, __, __, E1, __},
+	/*e      E1*/ {__, __, __, __, __, __, __, __, __, __, __, E2, E2, __, E3, E3, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*ex     E2*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, E3, E3, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*exp    E3*/ {OK, OK, __, cc, __, bc, __, cm, __, __, __, __, __, __, E3, E3, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*tr     T1*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, T2, __, __, __, __, __, __},
+	/*tru    T2*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, T3, __, __, __},
+	/*true   T3*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, OK, __, __, __, __, __, __, __, __, __, __},
+	/*fa     F1*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, F2, __, __, __, __, __, __, __, __, __, __, __, __, __, __},
+	/*fal    F2*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, F3, __, __, __, __, __, __, __, __},
+	/*fals   F3*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, F4, __, __, __, __, __},
+	/*false  F4*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, OK, __, __, __, __, __, __, __, __, __, __},
+	/*nu     N1*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, N2, __, __, __},
+	/*nul    N2*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, N3, __, __, __, __, __, __, __, __},
+	/*null   N3*/ {__, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, OK, __, __, __, __, __, __, __, __},
+}

--- a/vendored/gno.land/p/onbloc/json/node.gno
+++ b/vendored/gno.land/p/onbloc/json/node.gno
@@ -1,0 +1,1083 @@
+package json
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// Node represents a JSON node.
+type Node struct {
+	prev     *Node            // prev is the parent node of the current node.
+	next     map[string]*Node // next is the child nodes of the current node.
+	key      *string          // key holds the key of the current node in the parent node.
+	data     []byte           // byte slice of JSON data
+	value    any              // value holds the value of the current node.
+	nodeType ValueType        // NodeType holds the type of the current node. (Object, Array, String, Number, Boolean, Null)
+	index    *int             // index holds the index of the current node in the parent array node.
+	borders  [2]int           // borders stores the start and end index of the current node in the data.
+	modified bool             // modified indicates the current node is changed or not.
+}
+
+// NewNode creates a new node instance with the given parent node, buffer, type, and key.
+func NewNode(prev *Node, b *buffer, typ ValueType, key **string) (*Node, error) {
+	curr := &Node{
+		prev:     prev,
+		data:     b.data,
+		borders:  [2]int{b.index, 0},
+		key:      *key,
+		nodeType: typ,
+		modified: false,
+	}
+
+	if typ == Object || typ == Array {
+		curr.next = make(map[string]*Node)
+	}
+
+	if prev != nil {
+		if prev.IsArray() {
+			size := len(prev.next)
+			curr.index = &size
+
+			prev.next[strconv.Itoa(size)] = curr
+		} else if prev.IsObject() {
+			if key == nil {
+				return nil, errKeyRequired
+			}
+
+			prev.next[**key] = curr
+		} else {
+			return nil, errors.New("invalid parent type")
+		}
+	}
+
+	return curr, nil
+}
+
+// load retrieves the value of the current node.
+func (n *Node) load() any {
+	return n.value
+}
+
+// Changed checks the current node is changed or not.
+func (n *Node) Changed() bool {
+	return n.modified
+}
+
+// Key returns the key of the current node.
+func (n *Node) Key() string {
+	if n == nil || n.key == nil {
+		return ""
+	}
+
+	return *n.key
+}
+
+// HasKey checks the current node has the given key or not.
+func (n *Node) HasKey(key string) bool {
+	if n == nil {
+		return false
+	}
+
+	_, ok := n.next[key]
+	return ok
+}
+
+// GetKey returns the value of the given key from the current object node.
+func (n *Node) GetKey(key string) (*Node, error) {
+	if n == nil {
+		return nil, errNilNode
+	}
+
+	if n.Type() != Object {
+		return nil, ufmt.Errorf("target node is not object type. got: %s", n.Type().String())
+	}
+
+	value, ok := n.next[key]
+	if !ok {
+		return nil, ufmt.Errorf("key not found: %s", key)
+	}
+
+	return value, nil
+}
+
+// MustKey returns the value of the given key from the current object node.
+func (n *Node) MustKey(key string) *Node {
+	val, err := n.GetKey(key)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// UniqueKeyLists traverses the current JSON nodes and collects all the unique keys.
+func (n *Node) UniqueKeyLists() []string {
+	var collectKeys func(*Node) []string
+	collectKeys = func(node *Node) []string {
+		if node == nil || !node.IsObject() {
+			return nil
+		}
+
+		result := make(map[string]bool)
+		for key, childNode := range node.next {
+			result[key] = true
+			childKeys := collectKeys(childNode)
+			for _, childKey := range childKeys {
+				result[childKey] = true
+			}
+		}
+
+		keys := make([]string, 0, len(result))
+		for key := range result {
+			keys = append(keys, key)
+		}
+		return keys
+	}
+
+	return collectKeys(n)
+}
+
+// Empty returns true if the current node is empty.
+func (n *Node) Empty() bool {
+	if n == nil {
+		return false
+	}
+
+	return len(n.next) == 0
+}
+
+// Type returns the type (ValueType) of the current node.
+func (n *Node) Type() ValueType {
+	return n.nodeType
+}
+
+// Value returns the value of the current node.
+//
+// Usage:
+//
+//	root := Unmarshal([]byte(`{"key": "value"}`))
+//	val, err := root.MustKey("key").Value()
+//	if err != nil {
+//		t.Errorf("Value returns error: %v", err)
+//	}
+//
+//	result: "value"
+func (n *Node) Value() (value any, err error) {
+	value = n.load()
+
+	if value == nil {
+		switch n.nodeType {
+		case Null:
+			return nil, nil
+
+		case Number:
+			value, err = strconv.ParseFloat(string(n.source()), 64)
+			if err != nil {
+				return nil, err
+			}
+
+			n.value = value
+
+		case String:
+			var ok bool
+			value, ok = Unquote(n.source(), doubleQuote)
+			if !ok {
+				return "", errInvalidStringValue
+			}
+
+			n.value = value
+
+		case Boolean:
+			if len(n.source()) == 0 {
+				return nil, errEmptyBooleanNode
+			}
+
+			b := n.source()[0]
+			value = b == 't' || b == 'T'
+			n.value = value
+
+		case Array:
+			elems := make([]*Node, len(n.next))
+
+			for _, e := range n.next {
+				elems[*e.index] = e
+			}
+
+			value = elems
+			n.value = value
+
+		case Object:
+			obj := make(map[string]*Node, len(n.next))
+
+			for k, v := range n.next {
+				obj[k] = v
+			}
+
+			value = obj
+			n.value = value
+		}
+	}
+
+	return value, nil
+}
+
+// Delete removes the current node from the parent node.
+//
+// Usage:
+//
+//	root := Unmarshal([]byte(`{"key": "value"}`))
+//	if err := root.MustKey("key").Delete(); err != nil {
+//		t.Errorf("Delete returns error: %v", err)
+//	}
+//
+//	result: {} (empty object)
+func (n *Node) Delete() error {
+	if n == nil {
+		return errors.New("can't delete nil node")
+	}
+
+	if n.prev == nil {
+		return nil
+	}
+
+	return n.prev.remove(n)
+}
+
+// Size returns the size (length) of the current array node.
+//
+// Usage:
+//
+//	root := ArrayNode("", []*Node{StringNode("", "foo"), NumberNode("", 1)})
+//	if root == nil {
+//		t.Errorf("ArrayNode returns nil")
+//	}
+//
+//	if root.Size() != 2 {
+//		t.Errorf("ArrayNode returns wrong size: %d", root.Size())
+//	}
+func (n *Node) Size() int {
+	if n == nil {
+		return 0
+	}
+
+	return len(n.next)
+}
+
+// Index returns the index of the current node in the parent array node.
+//
+// Usage:
+//
+//	root := ArrayNode("", []*Node{StringNode("", "foo"), NumberNode("", 1)})
+//	if root == nil {
+//		t.Errorf("ArrayNode returns nil")
+//	}
+//
+//	if root.MustIndex(1).Index() != 1 {
+//		t.Errorf("Index returns wrong index: %d", root.MustIndex(1).Index())
+//	}
+//
+// We can also use the index to the byte slice of the JSON data directly.
+//
+// Example:
+//
+//	root := Unmarshal([]byte(`["foo", 1]`))
+//	if root == nil {
+//		t.Errorf("Unmarshal returns nil")
+//	}
+//
+//	if string(root.MustIndex(1).source()) != "1" {
+//		t.Errorf("source returns wrong result: %s", root.MustIndex(1).source())
+//	}
+func (n *Node) Index() int {
+	if n == nil || n.index == nil {
+		return -1
+	}
+
+	return *n.index
+}
+
+// MustIndex returns the array element at the given index.
+//
+// If the index is negative, it returns the index is from the end of the array.
+// Also, it panics if the index is not found.
+//
+// check the Index method for detailed usage.
+func (n *Node) MustIndex(expectIdx int) *Node {
+	val, err := n.GetIndex(expectIdx)
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}
+
+// GetIndex returns the array element at the given index.
+//
+// if the index is negative, it returns the index is from the end of the array.
+func (n *Node) GetIndex(idx int) (*Node, error) {
+	if n == nil {
+		return nil, errNilNode
+	}
+
+	if !n.IsArray() {
+		return nil, errNotArrayNode
+	}
+
+	if idx > n.Size() {
+		return nil, errors.New("input index exceeds the array size")
+	}
+
+	if idx < 0 {
+		idx += len(n.next)
+	}
+
+	child, ok := n.next[strconv.Itoa(idx)]
+	if !ok {
+		return nil, errIndexNotFound
+	}
+
+	return child, nil
+}
+
+// DeleteIndex removes the array element at the given index.
+func (n *Node) DeleteIndex(idx int) error {
+	node, err := n.GetIndex(idx)
+	if err != nil {
+		return err
+	}
+
+	return n.remove(node)
+}
+
+// NullNode creates a new null type node.
+//
+// Usage:
+//
+//	_ := NullNode("")
+func NullNode(key string) *Node {
+	return &Node{
+		key:      &key,
+		value:    nil,
+		nodeType: Null,
+		modified: true,
+	}
+}
+
+// NumberNode creates a new number type node.
+//
+// Usage:
+//
+//	root := NumberNode("", 1)
+//	if root == nil {
+//		t.Errorf("NumberNode returns nil")
+//	}
+func NumberNode(key string, value float64) *Node {
+	return &Node{
+		key:      &key,
+		value:    value,
+		nodeType: Number,
+		modified: true,
+	}
+}
+
+// StringNode creates a new string type node.
+//
+// Usage:
+//
+//	root := StringNode("", "foo")
+//	if root == nil {
+//		t.Errorf("StringNode returns nil")
+//	}
+func StringNode(key string, value string) *Node {
+	return &Node{
+		key:      &key,
+		value:    value,
+		nodeType: String,
+		modified: true,
+	}
+}
+
+// BoolNode creates a new given boolean value node.
+//
+// Usage:
+//
+//	root := BoolNode("", true)
+//	if root == nil {
+//		t.Errorf("BoolNode returns nil")
+//	}
+func BoolNode(key string, value bool) *Node {
+	return &Node{
+		key:      &key,
+		value:    value,
+		nodeType: Boolean,
+		modified: true,
+	}
+}
+
+// ArrayNode creates a new array type node.
+//
+// If the given value is nil, it creates an empty array node.
+//
+// Usage:
+//
+//	root := ArrayNode("", []*Node{StringNode("", "foo"), NumberNode("", 1)})
+//	if root == nil {
+//		t.Errorf("ArrayNode returns nil")
+//	}
+func ArrayNode(key string, value []*Node) *Node {
+	curr := &Node{
+		key:      &key,
+		nodeType: Array,
+		modified: true,
+	}
+
+	curr.next = make(map[string]*Node, len(value))
+	if value != nil {
+		curr.value = value
+
+		for i, v := range value {
+			idx := i
+			curr.next[strconv.Itoa(i)] = v
+
+			v.prev = curr
+			v.index = &idx
+		}
+	}
+
+	return curr
+}
+
+// ObjectNode creates a new object type node.
+//
+// If the given value is nil, it creates an empty object node.
+//
+// next is a map of key and value pairs of the object.
+func ObjectNode(key string, value map[string]*Node) *Node {
+	curr := &Node{
+		nodeType: Object,
+		key:      &key,
+		next:     value,
+		modified: true,
+	}
+
+	if value != nil {
+		curr.value = value
+
+		for key, val := range value {
+			vkey := key
+			val.prev = curr
+			val.key = &vkey
+		}
+	} else {
+		curr.next = make(map[string]*Node)
+	}
+
+	return curr
+}
+
+// IsArray returns true if the current node is array type.
+func (n *Node) IsArray() bool {
+	return n.nodeType == Array
+}
+
+// IsObject returns true if the current node is object type.
+func (n *Node) IsObject() bool {
+	return n.nodeType == Object
+}
+
+// IsNull returns true if the current node is null type.
+func (n *Node) IsNull() bool {
+	return n.nodeType == Null
+}
+
+// IsBool returns true if the current node is boolean type.
+func (n *Node) IsBool() bool {
+	return n.nodeType == Boolean
+}
+
+// IsString returns true if the current node is string type.
+func (n *Node) IsString() bool {
+	return n.nodeType == String
+}
+
+// IsNumber returns true if the current node is number type.
+func (n *Node) IsNumber() bool {
+	return n.nodeType == Number
+}
+
+// ready checks the current node is ready or not.
+//
+// the meaning of ready is the current node is parsed and has a valid value.
+func (n *Node) ready() bool {
+	return n.borders[1] != 0
+}
+
+// source returns the source of the current node.
+func (n *Node) source() []byte {
+	if n == nil {
+		return nil
+	}
+
+	if n.ready() && !n.modified && n.data != nil {
+		return (n.data)[n.borders[0]:n.borders[1]]
+	}
+
+	return nil
+}
+
+// root returns the root node of the current node.
+func (n *Node) root() *Node {
+	if n == nil {
+		return nil
+	}
+
+	curr := n
+	for curr.prev != nil {
+		curr = curr.prev
+	}
+
+	return curr
+}
+
+// GetNull returns the null value if current node is null type.
+//
+// Usage:
+//
+//	root := Unmarshal([]byte("null"))
+//	val, err := root.GetNull()
+//	if err != nil {
+//		t.Errorf("GetNull returns error: %v", err)
+//	}
+//	if val != nil {
+//		t.Errorf("GetNull returns wrong result: %v", val)
+//	}
+func (n *Node) GetNull() (any, error) {
+	if n == nil {
+		return nil, errNilNode
+	}
+
+	if !n.IsNull() {
+		return nil, errNotNullNode
+	}
+
+	return nil, nil
+}
+
+// MustNull returns the null value if current node is null type.
+//
+// It panics if the current node is not null type.
+func (n *Node) MustNull() any {
+	v, err := n.GetNull()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// GetNumeric returns the numeric (int/float) value if current node is number type.
+//
+// Usage:
+//
+//	root := Unmarshal([]byte("10.5"))
+//	val, err := root.GetNumeric()
+//	if err != nil {
+//		t.Errorf("GetNumeric returns error: %v", err)
+//	}
+//	println(val) // 10.5
+func (n *Node) GetNumeric() (float64, error) {
+	if n == nil {
+		return 0, errNilNode
+	}
+
+	if n.nodeType != Number {
+		return 0, errNotNumberNode
+	}
+
+	val, err := n.Value()
+	if err != nil {
+		return 0, err
+	}
+
+	v, ok := val.(float64)
+	if !ok {
+		return 0, errNotNumberNode
+	}
+
+	return v, nil
+}
+
+// MustNumeric returns the numeric (int/float) value if current node is number type.
+//
+// It panics if the current node is not number type.
+func (n *Node) MustNumeric() float64 {
+	v, err := n.GetNumeric()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// GetString returns the string value if current node is string type.
+//
+// Usage:
+//
+//	root, err := Unmarshal([]byte("foo"))
+//	if err != nil {
+//		t.Errorf("Error on Unmarshal(): %s", err)
+//	}
+//
+//	str, err := root.GetString()
+//	if err != nil {
+//		t.Errorf("should retrieve string value: %s", err)
+//	}
+//
+//	println(str) // "foo"
+func (n *Node) GetString() (string, error) {
+	if n == nil {
+		return "", errEmptyStringNode
+	}
+
+	if !n.IsString() {
+		return "", errNotStringNode
+	}
+
+	val, err := n.Value()
+	if err != nil {
+		return "", err
+	}
+
+	v, ok := val.(string)
+	if !ok {
+		return "", errNotStringNode
+	}
+
+	return v, nil
+}
+
+// MustString returns the string value if current node is string type.
+//
+// It panics if the current node is not string type.
+func (n *Node) MustString() string {
+	v, err := n.GetString()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// GetBool returns the boolean value if current node is boolean type.
+//
+// Usage:
+//
+//	root := Unmarshal([]byte("true"))
+//	val, err := root.GetBool()
+//	if err != nil {
+//		t.Errorf("GetBool returns error: %v", err)
+//	}
+//	println(val) // true
+func (n *Node) GetBool() (bool, error) {
+	if n == nil {
+		return false, errNilNode
+	}
+
+	if n.nodeType != Boolean {
+		return false, errNotBoolNode
+	}
+
+	val, err := n.Value()
+	if err != nil {
+		return false, err
+	}
+
+	v, ok := val.(bool)
+	if !ok {
+		return false, errNotBoolNode
+	}
+
+	return v, nil
+}
+
+// MustBool returns the boolean value if current node is boolean type.
+//
+// It panics if the current node is not boolean type.
+func (n *Node) MustBool() bool {
+	v, err := n.GetBool()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// GetArray returns the array value if current node is array type.
+//
+// Usage:
+//
+//		root := Must(Unmarshal([]byte(`["foo", 1]`)))
+//		arr, err := root.GetArray()
+//		if err != nil {
+//			t.Errorf("GetArray returns error: %v", err)
+//		}
+//
+//		for _, val := range arr {
+//			println(val)
+//		}
+//
+//	 result: "foo", 1
+func (n *Node) GetArray() ([]*Node, error) {
+	if n == nil {
+		return nil, errNilNode
+	}
+
+	if n.nodeType != Array {
+		return nil, errNotArrayNode
+	}
+
+	val, err := n.Value()
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := val.([]*Node)
+	if !ok {
+		return nil, errNotArrayNode
+	}
+
+	return v, nil
+}
+
+// MustArray returns the array value if current node is array type.
+//
+// It panics if the current node is not array type.
+func (n *Node) MustArray() []*Node {
+	v, err := n.GetArray()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// AppendArray appends the given values to the current array node.
+//
+// If the current node is not array type, it returns an error.
+//
+// Example 1:
+//
+//	root := Must(Unmarshal([]byte(`[{"foo":"bar"}]`)))
+//	if err := root.AppendArray(NullNode("")); err != nil {
+//		t.Errorf("should not return error: %s", err)
+//	}
+//
+//	result: [{"foo":"bar"}, null]
+//
+// Example 2:
+//
+//	root := Must(Unmarshal([]byte(`["bar", "baz"]`)))
+//	err := root.AppendArray(NumberNode("", 1), StringNode("", "foo"))
+//	if err != nil {
+//		t.Errorf("AppendArray returns error: %v", err)
+//	 }
+//
+//	result: ["bar", "baz", 1, "foo"]
+func (n *Node) AppendArray(value ...*Node) error {
+	if !n.IsArray() {
+		return errInvalidAppend
+	}
+
+	for _, val := range value {
+		if err := n.append(nil, val); err != nil {
+			return err
+		}
+	}
+
+	n.mark()
+	return nil
+}
+
+// ArrayEach executes the callback for each element in the JSON array.
+//
+// Usage:
+//
+//	jsonArrayNode.ArrayEach(func(i int, valueNode *Node) {
+//	    ufmt.Println(i, valueNode)
+//	})
+func (n *Node) ArrayEach(callback func(i int, target *Node)) {
+	if n == nil || !n.IsArray() {
+		return
+	}
+
+	for idx := 0; idx < len(n.next); idx++ {
+		element, err := n.GetIndex(idx)
+		if err != nil {
+			continue
+		}
+
+		callback(idx, element)
+	}
+}
+
+// GetObject returns the object value if current node is object type.
+//
+// Usage:
+//
+//	root := Must(Unmarshal([]byte(`{"key": "value"}`)))
+//	obj, err := root.GetObject()
+//	if err != nil {
+//		t.Errorf("GetObject returns error: %v", err)
+//	}
+//
+//	result: map[string]*Node{"key": StringNode("key", "value")}
+func (n *Node) GetObject() (map[string]*Node, error) {
+	if n == nil {
+		return nil, errNilNode
+	}
+
+	if !n.IsObject() {
+		return nil, errNotObjectNode
+	}
+
+	val, err := n.Value()
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := val.(map[string]*Node)
+	if !ok {
+		return nil, errNotObjectNode
+	}
+
+	return v, nil
+}
+
+// MustObject returns the object value if current node is object type.
+//
+// It panics if the current node is not object type.
+func (n *Node) MustObject() map[string]*Node {
+	v, err := n.GetObject()
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// AppendObject appends the given key and value to the current object node.
+//
+// If the current node is not object type, it returns an error.
+func (n *Node) AppendObject(key string, value *Node) error {
+	if !n.IsObject() {
+		return errInvalidAppend
+	}
+
+	if err := n.append(&key, value); err != nil {
+		return err
+	}
+
+	n.mark()
+	return nil
+}
+
+// ObjectEach executes the callback for each key-value pair in the JSON object.
+//
+// Usage:
+//
+//	jsonObjectNode.ObjectEach(func(key string, valueNode *Node) {
+//	    ufmt.Println(key, valueNode)
+//	})
+func (n *Node) ObjectEach(callback func(key string, value *Node)) {
+	if n == nil || !n.IsObject() {
+		return
+	}
+
+	for key, child := range n.next {
+		callback(key, child)
+	}
+}
+
+// String converts the node to a string representation.
+func (n *Node) String() string {
+	if n == nil {
+		return ""
+	}
+
+	if n.ready() && !n.modified {
+		return string(n.source())
+	}
+
+	val, err := Marshal(n)
+	if err != nil {
+		return "error: " + err.Error()
+	}
+
+	return string(val)
+}
+
+// Path builds the path of the current node.
+//
+// For example:
+//
+//	{ "key": { "sub": [ "val1", "val2" ] }}
+//
+// The path of "val2" is: $.key.sub[1]
+func (n *Node) Path() string {
+	if n == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+
+	if n.prev == nil {
+		sb.WriteString("$")
+	} else {
+		sb.WriteString(n.prev.Path())
+
+		if n.key != nil {
+			sb.WriteString("['" + n.Key() + "']")
+		} else {
+			sb.WriteString("[" + strconv.Itoa(n.Index()) + "]")
+		}
+	}
+
+	return sb.String()
+}
+
+// mark marks the current node as modified.
+func (n *Node) mark() {
+	node := n
+	for node != nil && !node.modified {
+		node.modified = true
+		node = node.prev
+	}
+}
+
+// isContainer checks the current node type is array or object.
+func (n *Node) isContainer() bool {
+	return n.IsArray() || n.IsObject()
+}
+
+// remove removes the value from the current container type node.
+func (n *Node) remove(v *Node) error {
+	if !n.isContainer() {
+		return ufmt.Errorf(
+			"can't remove value from non-array or non-object node. got=%s",
+			n.Type().String(),
+		)
+	}
+
+	if v.prev != n {
+		return errors.New("invalid parent node")
+	}
+
+	n.mark()
+	if n.IsArray() {
+		delete(n.next, strconv.Itoa(*v.index))
+		n.dropIndex(*v.index)
+	} else {
+		delete(n.next, *v.key)
+	}
+
+	v.prev = nil
+	return nil
+}
+
+// dropIndex rebase the index of current array node values.
+func (n *Node) dropIndex(idx int) {
+	for i := idx + 1; i <= len(n.next); i++ {
+		prv := i - 1
+		if curr, ok := n.next[strconv.Itoa(i)]; ok {
+			curr.index = &prv
+			n.next[strconv.Itoa(prv)] = curr
+		}
+
+		delete(n.next, strconv.Itoa(i))
+	}
+}
+
+// append is a helper function to append the given value to the current container type node.
+func (n *Node) append(key *string, val *Node) error {
+	if n.isSameOrParentNode(val) {
+		return errInvalidAppendCycle
+	}
+
+	if val.prev != nil {
+		if err := val.prev.remove(val); err != nil {
+			return err
+		}
+	}
+
+	val.prev = n
+	val.key = key
+
+	if key == nil {
+		size := len(n.next)
+		val.index = &size
+		n.next[strconv.Itoa(size)] = val
+	} else {
+		if old, ok := n.next[*key]; ok {
+			if err := n.remove(old); err != nil {
+				return err
+			}
+		}
+		n.next[*key] = val
+	}
+
+	return nil
+}
+
+func (n *Node) isSameOrParentNode(nd *Node) bool {
+	return n == nd || n.isParentNode(nd)
+}
+
+func (n *Node) isParentNode(nd *Node) bool {
+	if n == nil {
+		return false
+	}
+
+	for curr := nd.prev; curr != nil; curr = curr.prev {
+		if curr == n {
+			return true
+		}
+	}
+
+	return false
+}
+
+// cptrs returns the pointer of the given string value.
+func cptrs(cpy *string) *string {
+	if cpy == nil {
+		return nil
+	}
+
+	val := *cpy
+
+	return &val
+}
+
+// cptri returns the pointer of the given integer value.
+func cptri(i *int) *int {
+	if i == nil {
+		return nil
+	}
+
+	val := *i
+	return &val
+}
+
+// Must panics if the given node is not fulfilled the expectation.
+// Usage:
+//
+//	node := Must(Unmarshal([]byte(`{"key": "value"}`))
+func Must(root *Node, expect error) *Node {
+	if expect != nil {
+		panic(expect)
+	}
+
+	return root
+}

--- a/vendored/gno.land/p/onbloc/json/node_test.gno
+++ b/vendored/gno.land/p/onbloc/json/node_test.gno
@@ -1,0 +1,1392 @@
+package json
+
+import (
+	"bytes"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+var (
+	nilKey   *string
+	dummyKey = "key"
+)
+
+type _args struct {
+	prev *Node
+	buf  *buffer
+	typ  ValueType
+	key  **string
+}
+
+type simpleNode struct {
+	name string
+	node *Node
+}
+
+func TestNode_CreateNewNode(t *testing.T) {
+	rel := &dummyKey
+
+	tests := []struct {
+		name        string
+		args        _args
+		expectCurr  *Node
+		expectErr   bool
+		expectPanic bool
+	}{
+		{
+			name: "child for non container type",
+			args: _args{
+				prev: BoolNode("", true),
+				buf:  newBuffer(make([]byte, 10)),
+				typ:  Boolean,
+				key:  &rel,
+			},
+			expectCurr: nil,
+			expectErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					if tt.expectPanic {
+						return
+					}
+					t.Errorf("%s panic occurred when not expected: %v", tt.name, r)
+				} else if tt.expectPanic {
+					t.Errorf("%s expected panic but didn't occur", tt.name)
+				}
+			}()
+
+			got, err := NewNode(tt.args.prev, tt.args.buf, tt.args.typ, tt.args.key)
+			if (err != nil) != tt.expectErr {
+				t.Errorf("%s error = %v, expect error %v", tt.name, err, tt.expectErr)
+				return
+			}
+
+			if tt.expectErr {
+				return
+			}
+
+			if !compareNodes(got, tt.expectCurr) {
+				t.Errorf("%s got = %v, want %v", tt.name, got, tt.expectCurr)
+			}
+		})
+	}
+}
+
+func TestNode_Value(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        []byte
+		_type       ValueType
+		expected    any
+		errExpected bool
+	}{
+		{name: "null", data: []byte("null"), _type: Null, expected: nil},
+		{name: "1", data: []byte("1"), _type: Number, expected: float64(1)},
+		{name: ".1", data: []byte(".1"), _type: Number, expected: float64(.1)},
+		{name: "-.1e1", data: []byte("-.1e1"), _type: Number, expected: float64(-1)},
+		{name: "string", data: []byte("\"foo\""), _type: String, expected: "foo"},
+		{name: "space", data: []byte("\"foo bar\""), _type: String, expected: "foo bar"},
+		{name: "true", data: []byte("true"), _type: Boolean, expected: true},
+		{name: "invalid true", data: []byte("tru"), _type: Unknown, errExpected: true},
+		{name: "invalid false", data: []byte("fals"), _type: Unknown, errExpected: true},
+		{name: "false", data: []byte("false"), _type: Boolean, expected: false},
+		{name: "e1", data: []byte("e1"), _type: Unknown, errExpected: true},
+		{name: "1a", data: []byte("1a"), _type: Unknown, errExpected: true},
+		{name: "string error", data: []byte("\"foo\nbar\""), _type: String, errExpected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			curr := &Node{
+				data:     tt.data,
+				nodeType: tt._type,
+				borders:  [2]int{0, len(tt.data)},
+			}
+
+			got, err := curr.Value()
+			if err != nil {
+				if !tt.errExpected {
+					t.Errorf("%s error = %v, expect error %v", tt.name, err, tt.errExpected)
+				}
+				return
+			}
+
+			if got != tt.expected {
+				t.Errorf("%s got = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNode_Delete(t *testing.T) {
+	root := Must(Unmarshal([]byte(`{"foo":"bar"}`)))
+	if err := root.Delete(); err != nil {
+		t.Errorf("Delete returns error: %v", err)
+	}
+
+	if value, err := Marshal(root); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if string(value) != `{"foo":"bar"}` {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+
+	foo := root.MustKey("foo")
+	if err := foo.Delete(); err != nil {
+		t.Errorf("Delete returns error while handling foo: %v", err)
+	}
+
+	if value, err := Marshal(root); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if string(value) != `{}` {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+
+	if value, err := Marshal(foo); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if string(value) != `"bar"` {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+
+	if foo.prev != nil {
+		t.Errorf("foo.prev should be nil")
+	}
+}
+
+func TestNode_ObjectNode(t *testing.T) {
+	objs := map[string]*Node{
+		"key1": NullNode("null"),
+		"key2": NumberNode("answer", 42),
+		"key3": StringNode("string", "foobar"),
+		"key4": BoolNode("bool", true),
+	}
+
+	node := ObjectNode("test", objs)
+
+	if len(node.next) != len(objs) {
+		t.Errorf("ObjectNode: want %v got %v", len(objs), len(node.next))
+	}
+
+	for k, v := range objs {
+		if node.next[k] == nil {
+			t.Errorf("ObjectNode: want %v got %v", v, node.next[k])
+		}
+	}
+}
+
+func TestNode_AppendObject(t *testing.T) {
+	if err := Must(Unmarshal([]byte(`{"foo":"bar","baz":null}`))).AppendObject("biz", NullNode("")); err != nil {
+		t.Errorf("AppendArray should return error")
+	}
+
+	root := Must(Unmarshal([]byte(`{"foo":"bar"}`)))
+	if err := root.AppendObject("baz", NullNode("")); err != nil {
+		t.Errorf("AppendObject should not return error: %s", err)
+	}
+
+	if value, err := Marshal(root); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if isSameObject(string(value), `"{"foo":"bar","baz":null}"`) {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+
+	// FIXME: this may fail if execute test in more than 3 times in a row.
+	if err := root.AppendObject("biz", NumberNode("", 42)); err != nil {
+		t.Errorf("AppendObject returns error: %v", err)
+	}
+
+	val, err := Marshal(root)
+	if err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	}
+
+	// FIXME: this may fail if execute test in more than 3 times in a row.
+	if isSameObject(string(val), `"{"foo":"bar","baz":null,"biz":42}"`) {
+		t.Errorf("Marshal returns wrong value: %s", string(val))
+	}
+}
+
+func TestNode_ArrayNode(t *testing.T) {
+	arr := []*Node{
+		NullNode("nil"),
+		NumberNode("num", 42),
+		StringNode("str", "foobar"),
+		BoolNode("bool", true),
+	}
+
+	node := ArrayNode("test", arr)
+
+	if len(node.next) != len(arr) {
+		t.Errorf("ArrayNode: want %v got %v", len(arr), len(node.next))
+	}
+
+	for i, v := range arr {
+		if node.next[strconv.Itoa(i)] == nil {
+			t.Errorf("ArrayNode: want %v got %v", v, node.next[strconv.Itoa(i)])
+		}
+	}
+}
+
+func TestNode_AppendArray(t *testing.T) {
+	if err := Must(Unmarshal([]byte(`[{"foo":"bar"}]`))).AppendArray(NullNode("")); err != nil {
+		t.Errorf("should return error")
+	}
+
+	root := Must(Unmarshal([]byte(`[{"foo":"bar"}]`)))
+	if err := root.AppendArray(NullNode("")); err != nil {
+		t.Errorf("should not return error: %s", err)
+	}
+
+	if value, err := Marshal(root); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if string(value) != `[{"foo":"bar"},null]` {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+
+	if err := root.AppendArray(
+		NumberNode("", 1),
+		StringNode("", "foo"),
+		Must(Unmarshal([]byte(`[0,1,null,true,"example"]`))),
+		Must(Unmarshal([]byte(`{"foo": true, "bar": null, "baz": 123}`))),
+	); err != nil {
+		t.Errorf("AppendArray returns error: %v", err)
+	}
+
+	if value, err := Marshal(root); err != nil {
+		t.Errorf("Marshal returns error: %v", err)
+	} else if string(value) != `[{"foo":"bar"},null,1,"foo",[0,1,null,true,"example"],{"foo": true, "bar": null, "baz": 123}]` {
+		t.Errorf("Marshal returns wrong value: %s", string(value))
+	}
+}
+
+/******** value getter ********/
+
+func TestNode_GetBool(t *testing.T) {
+	root, err := Unmarshal([]byte(`true`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+		return
+	}
+
+	value, err := root.GetBool()
+	if err != nil {
+		t.Errorf("Error on root.GetBool(): %s", err.Error())
+	}
+
+	if !value {
+		t.Errorf("root.GetBool() is corrupted")
+	}
+}
+
+func TestNode_GetBool_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"literally null node", NullNode("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetBool(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_IsBool(t *testing.T) {
+	tests := []simpleNode{
+		{"true", BoolNode("", true)},
+		{"false", BoolNode("", false)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.node.IsBool() {
+				t.Errorf("%s should be a bool", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_IsBool_With_Unmarshal(t *testing.T) {
+	tests := []struct {
+		name string
+		json []byte
+		want bool
+	}{
+		{"true", []byte("true"), true},
+		{"false", []byte("false"), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := Unmarshal(tt.json)
+			if err != nil {
+				t.Errorf("Error on Unmarshal(): %s", err.Error())
+			}
+
+			if root.IsBool() != tt.want {
+				t.Errorf("%s should be a bool", tt.name)
+			}
+		})
+	}
+}
+
+var nullJson = []byte(`null`)
+
+func TestNode_GetNull(t *testing.T) {
+	root, err := Unmarshal(nullJson)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+	}
+
+	value, err := root.GetNull()
+	if err != nil {
+		t.Errorf("error occurred while getting null, %s", err)
+	}
+
+	if value != nil {
+		t.Errorf("value is not matched. expected: nil, got: %v", value)
+	}
+}
+
+func TestNode_GetNull_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"number node is null", NumberNode("", 42)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetNull(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_MustNull(t *testing.T) {
+	root, err := Unmarshal(nullJson)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+	}
+
+	value := root.MustNull()
+	if value != nil {
+		t.Errorf("value is not matched. expected: nil, got: %v", value)
+	}
+}
+
+func TestNode_GetNumeric_Float(t *testing.T) {
+	root, err := Unmarshal([]byte(`123.456`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+		return
+	}
+
+	value, err := root.GetNumeric()
+	if err != nil {
+		t.Errorf("Error on root.GetNumeric(): %s", err)
+	}
+
+	if value != float64(123.456) {
+		t.Errorf(ufmt.Sprintf("value is not matched. expected: 123.456, got: %v", value))
+	}
+}
+
+func TestNode_GetNumeric_Scientific_Notation(t *testing.T) {
+	root, err := Unmarshal([]byte(`1e3`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+		return
+	}
+
+	value, err := root.GetNumeric()
+	if err != nil {
+		t.Errorf("Error on root.GetNumeric(): %s", err)
+	}
+
+	if value != float64(1000) {
+		t.Errorf(ufmt.Sprintf("value is not matched. expected: 1000, got: %v", value))
+	}
+}
+
+func TestNode_GetNumeric_With_Unmarshal(t *testing.T) {
+	root, err := Unmarshal([]byte(`123`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+		return
+	}
+
+	value, err := root.GetNumeric()
+	if err != nil {
+		t.Errorf("Error on root.GetNumeric(): %s", err)
+	}
+
+	if value != float64(123) {
+		t.Errorf(ufmt.Sprintf("value is not matched. expected: 123, got: %v", value))
+	}
+}
+
+func TestNode_GetNumeric_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"null node", NullNode("")},
+		{"string node", StringNode("", "123")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetNumeric(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_GetString(t *testing.T) {
+	root, err := Unmarshal([]byte(`"123foobar 3456"`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+	}
+
+	value, err := root.GetString()
+	if err != nil {
+		t.Errorf("Error on root.GetString(): %s", err)
+	}
+
+	if value != "123foobar 3456" {
+		t.Errorf(ufmt.Sprintf("value is not matched. expected: 123, got: %s", value))
+	}
+}
+
+func TestNode_GetString_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"null node", NullNode("")},
+		{"number node", NumberNode("", 123)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetString(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_MustString(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"foo", []byte(`"foo"`)},
+		{"foo bar", []byte(`"foo bar"`)},
+		{"", []byte(`""`)},
+		{"안녕하세요", []byte(`"안녕하세요"`)},
+		{"こんにちは", []byte(`"こんにちは"`)},
+		{"你好", []byte(`"你好"`)},
+		{"one \"encoded\" string", []byte(`"one \"encoded\" string"`)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := Unmarshal(tt.data)
+			if err != nil {
+				t.Errorf("Error on Unmarshal(): %s", err)
+			}
+
+			value := root.MustString()
+			if value != tt.name {
+				t.Errorf("value is not matched. expected: %s, got: %s", tt.name, value)
+			}
+		})
+	}
+}
+
+func TestUnmarshal_Array(t *testing.T) {
+	root, err := Unmarshal([]byte(" [1,[\"1\",[1,[1,2,3]]]]\r\n"))
+	if err != nil {
+		t.Errorf("Error on Unmarshal: %s", err.Error())
+	}
+
+	if root == nil {
+		t.Errorf("Error on Unmarshal: root is nil")
+	}
+
+	if root.Type() != Array {
+		t.Errorf("Error on Unmarshal: wrong type")
+	}
+
+	array, err := root.GetArray()
+	if err != nil {
+		t.Errorf("error occurred while getting array, %s", err)
+	} else if len(array) != 2 {
+		t.Errorf("expected 2 elements, got %d", len(array))
+	} else if val, err := array[0].GetNumeric(); err != nil {
+		t.Errorf("value of array[0] is not numeric. got: %v", array[0].value)
+	} else if val != 1 {
+		t.Errorf("Error on array[0].GetNumeric(): expected to be '1', got: %v", val)
+	} else if val, err := array[1].GetArray(); err != nil {
+		t.Errorf("error occurred while getting array, %s", err.Error())
+	} else if len(val) != 2 {
+		t.Errorf("Error on array[1].GetArray(): expected 2 elements, got %d", len(val))
+	} else if el, err := val[0].GetString(); err != nil {
+		t.Errorf("error occurred while getting string, %s", err.Error())
+	} else if el != "1" {
+		t.Errorf("Error on val[0].GetString(): expected to be '1', got: %s", el)
+	}
+}
+
+var sampleArr = []byte(`[-1, 2, 3, 4, 5, 6]`)
+
+func TestNode_GetArray(t *testing.T) {
+	root, err := Unmarshal(sampleArr)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+		return
+	}
+
+	array, err := root.GetArray()
+	if err != nil {
+		t.Errorf("Error on root.GetArray(): %s", err)
+	}
+
+	if len(array) != 6 {
+		t.Errorf(ufmt.Sprintf("length is not matched. expected: 3, got: %d", len(array)))
+	}
+
+	for i, node := range array {
+		for j, val := range []int{-1, 2, 3, 4, 5, 6} {
+			if i == j {
+				if v, err := node.GetNumeric(); err != nil {
+					t.Errorf(ufmt.Sprintf("Error on node.GetNumeric(): %s", err))
+				} else if v != float64(val) {
+					t.Errorf(ufmt.Sprintf("value is not matched. expected: %d, got: %v", val, v))
+				}
+			}
+		}
+	}
+}
+
+func TestNode_GetArray_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"null node", NullNode("")},
+		{"number node", NumberNode("", 123)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetArray(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_IsArray(t *testing.T) {
+	root, err := Unmarshal(sampleArr)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err)
+		return
+	}
+
+	if root.Type() != Array {
+		t.Errorf(ufmt.Sprintf("Must be an array. got: %s", root.Type().String()))
+	}
+}
+
+func TestNode_ArrayEach(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected []int
+	}{
+		{
+			name:     "empty array",
+			json:     `[]`,
+			expected: []int{},
+		},
+		{
+			name:     "single element",
+			json:     `[42]`,
+			expected: []int{42},
+		},
+		{
+			name:     "multiple elements",
+			json:     `[1, 2, 3, 4, 5]`,
+			expected: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "multiple elements but all values are same",
+			json:     `[1, 1, 1, 1, 1]`,
+			expected: []int{1, 1, 1, 1, 1},
+		},
+		{
+			name:     "multiple elements with non-numeric values",
+			json:     `["a", "b", "c", "d", "e"]`,
+			expected: []int{},
+		},
+		{
+			name:     "non-array node",
+			json:     `{"not": "an array"}`,
+			expected: []int{},
+		},
+		{
+			name:     "array containing numeric and non-numeric elements",
+			json:     `["1", 2, 3, "4", 5, "6"]`,
+			expected: []int{2, 3, 5},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := Unmarshal([]byte(tc.json))
+			if err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+
+			var result []int // callback result
+			root.ArrayEach(func(index int, element *Node) {
+				if val, err := strconv.Atoi(element.String()); err == nil {
+					result = append(result, val)
+				}
+			})
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("%s: expected %d elements, got %d", tc.name, len(tc.expected), len(result))
+				return
+			}
+
+			for i, val := range result {
+				if val != tc.expected[i] {
+					t.Errorf("%s: expected value at index %d to be %d, got %d", tc.name, i, tc.expected[i], val)
+				}
+			}
+		})
+	}
+}
+
+func TestNode_Key(t *testing.T) {
+	root, err := Unmarshal([]byte(`{"foo": true, "bar": null, "baz": 123, "biz": [1,2,3]}`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+	}
+
+	obj := root.MustObject()
+	for key, node := range obj {
+		if key != node.Key() {
+			t.Errorf("Key() = %v, want %v", node.Key(), key)
+		}
+	}
+
+	keys := []string{"foo", "bar", "baz", "biz"}
+	for _, key := range keys {
+		if obj[key].Key() != key {
+			t.Errorf("Key() = %v, want %v", obj[key].Key(), key)
+		}
+	}
+
+	// TODO: resolve stack overflow
+	// if root.MustKey("foo").Clone().Key() != "" {
+	// 	t.Errorf("wrong key found for cloned key")
+	// }
+
+	if (*Node)(nil).Key() != "" {
+		t.Errorf("wrong key found for nil node")
+	}
+}
+
+func TestNode_Size(t *testing.T) {
+	root, err := Unmarshal(sampleArr)
+	if err != nil {
+		t.Errorf("error occurred while unmarshal")
+	}
+
+	size := root.Size()
+	if size != 6 {
+		t.Errorf(ufmt.Sprintf("Size() must be 6. got: %v", size))
+	}
+
+	if (*Node)(nil).Size() != 0 {
+		t.Errorf(ufmt.Sprintf("Size() must be 0. got: %v", (*Node)(nil).Size()))
+	}
+}
+
+func TestNode_Index(t *testing.T) {
+	root, err := Unmarshal([]byte(`[1, 2, 3, 4, 5, 6]`))
+	if err != nil {
+		t.Error("error occurred while unmarshal")
+	}
+
+	arr := root.MustArray()
+	for i, node := range arr {
+		if i != node.Index() {
+			t.Errorf(ufmt.Sprintf("Index() must be nil. got: %v", i))
+		}
+	}
+}
+
+func TestNode_Index_NotSucceed(t *testing.T) {
+	tests := []struct {
+		name string
+		node *Node
+		want int
+	}{
+		{"nil node", (*Node)(nil), -1},
+		{"null node", NullNode(""), -1},
+		{"object node", ObjectNode("", nil), -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.Index(); got != tt.want {
+				t.Errorf("Index() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNode_GetIndex(t *testing.T) {
+	root := Must(Unmarshal([]byte(`[1, 2, 3, 4, 5, 6]`)))
+	expected := []int{1, 2, 3, 4, 5, 6}
+
+	if len(expected) != root.Size() {
+		t.Errorf("length is not matched. expected: %d, got: %d", len(expected), root.Size())
+	}
+
+	// TODO: if length exceeds, stack overflow occurs. need to fix
+	for i, v := range expected {
+		val, err := root.GetIndex(i)
+		if err != nil {
+			t.Errorf("error occurred while getting index %d, %s", i, err)
+		}
+
+		if val.MustNumeric() != float64(v) {
+			t.Errorf("value is not matched. expected: %d, got: %v", v, val.MustNumeric())
+		}
+	}
+}
+
+func TestNode_GetIndex_InputIndex_Exceed_Original_Node_Index(t *testing.T) {
+	root, err := Unmarshal([]byte(`[1, 2, 3, 4, 5, 6]`))
+	if err != nil {
+		t.Errorf("error occurred while unmarshal")
+	}
+
+	_, err = root.GetIndex(10)
+	if err == nil {
+		t.Errorf("GetIndex should return error")
+	}
+}
+
+func TestNode_DeleteIndex(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		index    int
+		ok       bool
+	}{
+		{`null`, ``, 0, false},
+		{`1`, ``, 0, false},
+		{`{}`, ``, 0, false},
+		{`{"foo":"bar"}`, ``, 0, false},
+		{`true`, ``, 0, false},
+		{`[]`, ``, 0, false},
+		{`[]`, ``, -1, false},
+		{`[1]`, `[]`, 0, true},
+		{`[{}]`, `[]`, 0, true},
+		{`[{}, [], 42]`, `[{}, []]`, -1, true},
+		{`[{}, [], 42]`, `[[], 42]`, 0, true},
+		{`[{}, [], 42]`, `[{}, 42]`, 1, true},
+		{`[{}, [], 42]`, `[{}, []]`, 2, true},
+		{`[{}, [], 42]`, ``, 10, false},
+		{`[{}, [], 42]`, ``, -10, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := Must(Unmarshal([]byte(tt.name)))
+			err := root.DeleteIndex(tt.index)
+			if err != nil && tt.ok {
+				t.Errorf("DeleteIndex returns error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNode_GetKey(t *testing.T) {
+	root, err := Unmarshal([]byte(`{"foo": true, "bar": null}`))
+	if err != nil {
+		t.Error("error occurred while unmarshal")
+	}
+
+	value, err := root.GetKey("foo")
+	if err != nil {
+		t.Errorf("error occurred while getting key, %s", err)
+	}
+
+	if value.MustBool() != true {
+		t.Errorf("value is not matched. expected: true, got: %v", value.MustBool())
+	}
+
+	value, err = root.GetKey("bar")
+	if err != nil {
+		t.Errorf("error occurred while getting key, %s", err)
+	}
+
+	_, err = root.GetKey("baz")
+	if err == nil {
+		t.Errorf("key baz is not exist. must be failed")
+	}
+
+	if value.MustNull() != nil {
+		t.Errorf("value is not matched. expected: nil, got: %v", value.MustNull())
+	}
+}
+
+func TestNode_GetKey_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"null node", NullNode("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetKey(""); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_GetUniqueKeyList(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected []string
+	}{
+		{
+			name:     "simple foo/bar",
+			json:     `{"foo": true, "bar": null}`,
+			expected: []string{"foo", "bar"},
+		},
+		{
+			name:     "empty object",
+			json:     `{}`,
+			expected: []string{},
+		},
+		{
+			name: "nested object",
+			json: `{
+				"outer": {
+					"inner": {
+						"key": "value"
+					},
+					"array": [1, 2, 3]
+				},
+				"another": "item"
+			}`,
+			expected: []string{"outer", "inner", "key", "array", "another"},
+		},
+		{
+			name: "complex object",
+			json: `{
+				"Image": {
+					"Width": 800,
+					"Height": 600,
+					"Title": "View from 15th Floor",
+					"Thumbnail": {
+						"Url": "http://www.example.com/image/481989943",
+						"Height": 125,
+						"Width": 100
+					},
+					"Animated": false,
+					"IDs": [116, 943, 234, 38793]
+				}
+			}`,
+			expected: []string{"Image", "Width", "Height", "Title", "Thumbnail", "Url", "Animated", "IDs"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root, err := Unmarshal([]byte(tt.json))
+			if err != nil {
+				t.Errorf("error occurred while unmarshal")
+			}
+
+			value := root.UniqueKeyLists()
+			if len(value) != len(tt.expected) {
+				t.Errorf("%s length must be %v. got: %v. retrieved keys: %s", tt.name, len(tt.expected), len(value), value)
+			}
+
+			for _, key := range value {
+				if !contains(tt.expected, key) {
+					t.Errorf("EachKey() must be in %v. got: %v", tt.expected, key)
+				}
+			}
+		})
+	}
+}
+
+// TODO: resolve stack overflow
+func TestNode_IsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		node     *Node
+		expected bool
+	}{
+		{"nil node", (*Node)(nil), false}, // nil node is not empty.
+		// {"null node", NullNode(""), true},
+		{"empty object", ObjectNode("", nil), true},
+		{"empty array", ArrayNode("", nil), true},
+		{"non-empty object", ObjectNode("", map[string]*Node{"foo": BoolNode("foo", true)}), false},
+		{"non-empty array", ArrayNode("", []*Node{BoolNode("0", true)}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.Empty(); got != tt.expected {
+				t.Errorf("%s = %v, want %v", tt.name, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNode_Index_EmptyList(t *testing.T) {
+	root, err := Unmarshal([]byte(`[]`))
+	if err != nil {
+		t.Errorf("error occurred while unmarshal")
+	}
+
+	array := root.MustArray()
+	for i, node := range array {
+		if i != node.Index() {
+			t.Errorf(ufmt.Sprintf("Index() must be nil. got: %v", i))
+		}
+	}
+}
+
+func TestNode_GetObject(t *testing.T) {
+	root, err := Unmarshal([]byte(`{"foo": true,"bar": null}`))
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+		return
+	}
+
+	value, err := root.GetObject()
+	if err != nil {
+		t.Errorf("Error on root.GetObject(): %s", err.Error())
+	}
+
+	if _, ok := value["foo"]; !ok {
+		t.Errorf("root.GetObject() is corrupted: foo")
+	}
+
+	if _, ok := value["bar"]; !ok {
+		t.Errorf("root.GetObject() is corrupted: bar")
+	}
+}
+
+func TestNode_GetObject_NotSucceed(t *testing.T) {
+	tests := []simpleNode{
+		{"nil node", (*Node)(nil)},
+		{"get object from null node", NullNode("")},
+		{"not object node", NumberNode("", 123)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := tt.node.GetObject(); err == nil {
+				t.Errorf("%s should be an error", tt.name)
+			}
+		})
+	}
+}
+
+func TestNode_ObjectEach(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected map[string]int
+	}{
+		{
+			name:     "empty object",
+			json:     `{}`,
+			expected: make(map[string]int),
+		},
+		{
+			name:     "single key-value pair",
+			json:     `{"key": 42}`,
+			expected: map[string]int{"key": 42},
+		},
+		{
+			name:     "multiple key-value pairs",
+			json:     `{"one": 1, "two": 2, "three": 3}`,
+			expected: map[string]int{"one": 1, "two": 2, "three": 3},
+		},
+		{
+			name:     "multiple key-value pairs with some non-numeric values",
+			json:     `{"one": 1, "two": "2", "three": 3, "four": "4"}`,
+			expected: map[string]int{"one": 1, "three": 3},
+		},
+		{
+			name:     "non-object node",
+			json:     `["not", "an", "object"]`,
+			expected: make(map[string]int),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root, err := Unmarshal([]byte(tc.json))
+			if err != nil {
+				t.Fatalf("Unmarshal failed: %v", err)
+			}
+
+			result := make(map[string]int)
+			root.ObjectEach(func(key string, value *Node) {
+				// extract integer values from the object
+				if val, err := strconv.Atoi(value.String()); err == nil {
+					result[key] = val
+				}
+			})
+
+			if len(result) != len(tc.expected) {
+				t.Errorf("%s: expected %d key-value pairs, got %d", tc.name, len(tc.expected), len(result))
+				return
+			}
+
+			for key, val := range tc.expected {
+				if result[key] != val {
+					t.Errorf("%s: expected value for key %s to be %d, got %d", tc.name, key, val, result[key])
+				}
+			}
+		})
+	}
+}
+
+func TestNode_ExampleMust(t *testing.T) {
+	data := []byte(`{
+        "Image": {
+            "Width":  800,
+            "Height": 600,
+            "Title":  "View from 15th Floor",
+            "Thumbnail": {
+                "Url":    "http://www.example.com/image/481989943",
+                "Height": 125,
+                "Width":  100
+            },
+            "Animated" : false,
+            "IDs": [116, 943, 234, 38793]
+        }
+    }`)
+
+	root := Must(Unmarshal(data))
+	if root.Size() != 1 {
+		t.Errorf("root.Size() must be 1. got: %v", root.Size())
+	}
+
+	ufmt.Sprintf("Object has %d inheritors inside", root.Size())
+	// Output:
+	// Object has 1 inheritors inside
+}
+
+// Calculate AVG price from different types of objects, JSON from: https://goessner.net/articles/JsonPath/index.html#e3
+func TestExampleUnmarshal(t *testing.T) {
+	data := []byte(`{ "store": {
+    "book": [ 
+      { "category": "reference",
+        "author": "Nigel Rees",
+        "title": "Sayings of the Century",
+        "price": 8.95
+      },
+      { "category": "fiction",
+        "author": "Evelyn Waugh",
+        "title": "Sword of Honour",
+        "price": 12.99
+      },
+      { "category": "fiction",
+        "author": "Herman Melville",
+        "title": "Moby Dick",
+        "isbn": "0-553-21311-3",
+        "price": 8.99
+      },
+      { "category": "fiction",
+        "author": "J. R. R. Tolkien",
+        "title": "The Lord of the Rings",
+        "isbn": "0-395-19395-8",
+        "price": 22.99
+      }
+    ],
+    "bicycle": { "color": "red",
+      "price": 19.95
+    },
+    "tools": null
+  }
+}`)
+
+	root, err := Unmarshal(data)
+	if err != nil {
+		t.Errorf("error occurred when unmarshal")
+	}
+
+	store := root.MustKey("store").MustObject()
+
+	var prices float64
+	size := 0
+	for _, objects := range store {
+		if objects.IsArray() && objects.Size() > 0 {
+			size += objects.Size()
+			for _, object := range objects.MustArray() {
+				prices += object.MustKey("price").MustNumeric()
+			}
+		} else if objects.IsObject() && objects.HasKey("price") {
+			size++
+			prices += objects.MustKey("price").MustNumeric()
+		}
+	}
+
+	result := int(prices / float64(size))
+	ufmt.Sprintf("AVG price: %d", result)
+}
+
+func TestNode_ExampleMust_panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code did not panic")
+		}
+	}()
+	data := []byte(`{]`)
+	root := Must(Unmarshal(data))
+	ufmt.Sprintf("Object has %d inheritors inside", root.Size())
+}
+
+func TestNode_Path(t *testing.T) {
+	data := []byte(`{
+        "Image": {
+            "Width":  800,
+            "Height": 600,
+            "Title":  "View from 15th Floor",
+            "Thumbnail": {
+                "Url":    "http://www.example.com/image/481989943",
+                "Height": 125,
+                "Width":  100
+            },
+            "Animated" : false,
+            "IDs": [116, 943, 234, 38793]
+          }
+      }`)
+
+	root, err := Unmarshal(data)
+	if err != nil {
+		t.Errorf("Error on Unmarshal(): %s", err.Error())
+		return
+	}
+
+	if root.Path() != "$" {
+		t.Errorf("Wrong root.Path()")
+	}
+
+	element := root.MustKey("Image").MustKey("Thumbnail").MustKey("Url")
+	if element.Path() != "$['Image']['Thumbnail']['Url']" {
+		t.Errorf("Wrong path found: %s", element.Path())
+	}
+
+	if (*Node)(nil).Path() != "" {
+		t.Errorf("Wrong (nil).Path()")
+	}
+}
+
+func TestNode_Path2(t *testing.T) {
+	tests := []struct {
+		name string
+		node *Node
+		want string
+	}{
+		{
+			name: "Node with key",
+			node: &Node{
+				prev: &Node{},
+				key:  func() *string { s := "key"; return &s }(),
+			},
+			want: "$['key']",
+		},
+		{
+			name: "Node with index",
+			node: &Node{
+				prev:  &Node{},
+				index: func() *int { i := 1; return &i }(),
+			},
+			want: "$[1]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.Path(); got != tt.want {
+				t.Errorf("Path() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNode_Root(t *testing.T) {
+	root := &Node{}
+	child := &Node{prev: root}
+	grandChild := &Node{prev: child}
+
+	tests := []struct {
+		name string
+		node *Node
+		want *Node
+	}{
+		{
+			name: "Root node",
+			node: root,
+			want: root,
+		},
+		{
+			name: "Child node",
+			node: child,
+			want: root,
+		},
+		{
+			name: "Grandchild node",
+			node: grandChild,
+			want: root,
+		},
+		{
+			name: "Node is nil",
+			node: nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.node.root(); got != tt.want {
+				t.Errorf("root() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func contains(slice []string, item string) bool {
+	for _, a := range slice {
+		if a == item {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ignore the sequence of keys by ordering them.
+// need to avoid import encoding/json and reflect package.
+// because gno does not support them for now.
+// TODO: use encoding/json to compare the result after if possible in gno.
+func isSameObject(a, b string) bool {
+	aPairs := strings.Split(strings.Trim(a, "{}"), ",")
+	bPairs := strings.Split(strings.Trim(b, "{}"), ",")
+
+	aMap := make(map[string]string)
+	bMap := make(map[string]string)
+	for _, pair := range aPairs {
+		kv := strings.Split(pair, ":")
+		key := strings.Trim(kv[0], `"`)
+		value := strings.Trim(kv[1], `"`)
+		aMap[key] = value
+	}
+	for _, pair := range bPairs {
+		kv := strings.Split(pair, ":")
+		key := strings.Trim(kv[0], `"`)
+		value := strings.Trim(kv[1], `"`)
+		bMap[key] = value
+	}
+
+	aKeys := make([]string, 0, len(aMap))
+	bKeys := make([]string, 0, len(bMap))
+	for k := range aMap {
+		aKeys = append(aKeys, k)
+	}
+
+	for k := range bMap {
+		bKeys = append(bKeys, k)
+	}
+
+	sort.Strings(aKeys)
+	sort.Strings(bKeys)
+
+	if len(aKeys) != len(bKeys) {
+		return false
+	}
+
+	for i := range aKeys {
+		if aKeys[i] != bKeys[i] {
+			return false
+		}
+
+		if aMap[aKeys[i]] != bMap[bKeys[i]] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareNodes(n1, n2 *Node) bool {
+	if n1 == nil || n2 == nil {
+		return n1 == n2
+	}
+
+	if n1.key != n2.key {
+		return false
+	}
+
+	if !bytes.Equal(n1.data, n2.data) {
+		return false
+	}
+
+	if n1.index != n2.index {
+		return false
+	}
+
+	if n1.borders != n2.borders {
+		return false
+	}
+
+	if n1.modified != n2.modified {
+		return false
+	}
+
+	if n1.nodeType != n2.nodeType {
+		return false
+	}
+
+	if !compareNodes(n1.prev, n2.prev) {
+		return false
+	}
+
+	if len(n1.next) != len(n2.next) {
+		return false
+	}
+
+	for k, v := range n1.next {
+		if !compareNodes(v, n2.next[k]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendored/gno.land/p/onbloc/json/parser.gno
+++ b/vendored/gno.land/p/onbloc/json/parser.gno
@@ -1,0 +1,36 @@
+package json
+
+import (
+	"bytes"
+)
+
+const (
+	unescapeStackBufSize = 64
+	absMinInt64          = 1 << 63
+	maxInt64             = absMinInt64 - 1
+	maxUint64            = 1<<64 - 1
+)
+
+// PaseStringLiteral parses a string from the given byte slice.
+func ParseStringLiteral(data []byte) (string, error) {
+	var buf [unescapeStackBufSize]byte
+
+	bf, err := Unescape(data, buf[:])
+	if err != nil {
+		return "", errInvalidStringInput
+	}
+
+	return string(bf), nil
+}
+
+// ParseBoolLiteral parses a boolean value from the given byte slice.
+func ParseBoolLiteral(data []byte) (bool, error) {
+	switch {
+	case bytes.Equal(data, trueLiteral):
+		return true, nil
+	case bytes.Equal(data, falseLiteral):
+		return false, nil
+	default:
+		return false, errMalformedBooleanValue
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/parser_test.gno
+++ b/vendored/gno.land/p/onbloc/json/parser_test.gno
@@ -1,0 +1,66 @@
+package json
+
+import "testing"
+
+func TestParseStringLiteral(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		isError  bool
+	}{
+		{`"Hello, World!"`, "\"Hello, World!\"", false},
+		{`\uFF11`, "\uFF11", false},
+		{`\uFFFF`, "\uFFFF", false},
+		{`true`, "true", false},
+		{`false`, "false", false},
+		{`\uDF00`, "", true},
+	}
+
+	for i, tt := range tests {
+		s, err := ParseStringLiteral([]byte(tt.input))
+
+		if !tt.isError && err != nil {
+			t.Errorf("%d. unexpected error: %s", i, err)
+		}
+
+		if tt.isError && err == nil {
+			t.Errorf("%d. expected error, but not error", i)
+		}
+
+		if s != tt.expected {
+			t.Errorf("%d. expected=%s, but actual=%s", i, tt.expected, s)
+		}
+	}
+}
+
+func TestParseBoolLiteral(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+		isError  bool
+	}{
+		{`true`, true, false},
+		{`false`, false, false},
+		{`TRUE`, false, true},
+		{`FALSE`, false, true},
+		{`foo`, false, true},
+		{`"true"`, false, true},
+		{`"false"`, false, true},
+	}
+
+	for i, tt := range tests {
+		b, err := ParseBoolLiteral([]byte(tt.input))
+
+		if !tt.isError && err != nil {
+			t.Errorf("%d. unexpected error: %s", i, err)
+		}
+
+		if tt.isError && err == nil {
+			t.Errorf("%d. expected error, but not error", i)
+		}
+
+		if b != tt.expected {
+			t.Errorf("%d. expected=%t, but actual=%t", i, tt.expected, b)
+		}
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/path.gno
+++ b/vendored/gno.land/p/onbloc/json/path.gno
@@ -1,0 +1,78 @@
+package json
+
+import (
+	"errors"
+)
+
+// ParsePath takes a JSONPath string and returns a slice of strings representing the path segments.
+func ParsePath(path string) ([]string, error) {
+	buf := newBuffer([]byte(path))
+	result := make([]string, 0)
+
+	for {
+		b, err := buf.current()
+		if err != nil {
+			break
+		}
+
+		switch {
+		case b == dollarSign || b == atSign:
+			result = append(result, string(b))
+			buf.step()
+
+		case b == dot:
+			buf.step()
+
+			if next, _ := buf.current(); next == dot {
+				buf.step()
+				result = append(result, "..")
+
+				extractNextSegment(buf, &result)
+			} else {
+				extractNextSegment(buf, &result)
+			}
+
+		case b == bracketOpen:
+			start := buf.index
+			buf.step()
+
+			for {
+				if buf.index >= buf.length || buf.data[buf.index] == bracketClose {
+					break
+				}
+
+				buf.step()
+			}
+
+			if buf.index >= buf.length {
+				return nil, errors.New("unexpected end of path")
+			}
+
+			segment := string(buf.sliceFromIndices(start+1, buf.index))
+			result = append(result, segment)
+
+			buf.step()
+
+		default:
+			buf.step()
+		}
+	}
+
+	return result, nil
+}
+
+// extractNextSegment extracts the segment from the current index
+// to the next significant character and adds it to the resulting slice.
+func extractNextSegment(buf *buffer, result *[]string) {
+	start := buf.index
+	buf.skipToNextSignificantToken()
+
+	if buf.index <= start {
+		return
+	}
+
+	segment := string(buf.sliceFromIndices(start, buf.index))
+	if segment != "" {
+		*result = append(*result, segment)
+	}
+}

--- a/vendored/gno.land/p/onbloc/json/path_test.gno
+++ b/vendored/gno.land/p/onbloc/json/path_test.gno
@@ -1,0 +1,62 @@
+package json
+
+import "testing"
+
+func TestParseJSONPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{name: "Empty string path", path: "", expected: []string{}},
+		{name: "Root only path", path: "$", expected: []string{"$"}},
+		{name: "Root with dot path", path: "$.", expected: []string{"$"}},
+		{name: "All objects in path", path: "$..", expected: []string{"$", ".."}},
+		{name: "Only children in path", path: "$.*", expected: []string{"$", "*"}},
+		{name: "All objects' children in path", path: "$..*", expected: []string{"$", "..", "*"}},
+		{name: "Simple dot notation path", path: "$.root.element", expected: []string{"$", "root", "element"}},
+		{name: "Complex dot notation path with wildcard", path: "$.root.*.element", expected: []string{"$", "root", "*", "element"}},
+		{name: "Path with array wildcard", path: "$.phoneNumbers[*].type", expected: []string{"$", "phoneNumbers", "*", "type"}},
+		{name: "Path with filter expression", path: "$.store.book[?(@.price < 10)].title", expected: []string{"$", "store", "book", "?(@.price < 10)", "title"}},
+		{name: "Path with formula", path: "$..phoneNumbers..('ty' + 'pe')", expected: []string{"$", "..", "phoneNumbers", "..", "('ty' + 'pe')"}},
+		{name: "Simple bracket notation path", path: "$['root']['element']", expected: []string{"$", "'root'", "'element'"}},
+		{name: "Complex bracket notation path with wildcard", path: "$['root'][*]['element']", expected: []string{"$", "'root'", "*", "'element'"}},
+		{name: "Bracket notation path with integer index", path: "$['store']['book'][0]['title']", expected: []string{"$", "'store'", "'book'", "0", "'title'"}},
+		{name: "Complex path with wildcard in bracket notation", path: "$['root'].*['element']", expected: []string{"$", "'root'", "*", "'element'"}},
+		{name: "Mixed notation path with dot after bracket", path: "$.['root'].*.['element']", expected: []string{"$", "'root'", "*", "'element'"}},
+		{name: "Mixed notation path with dot before bracket", path: "$['root'].*.['element']", expected: []string{"$", "'root'", "*", "'element'"}},
+		{name: "Single character path with root", path: "$.a", expected: []string{"$", "a"}},
+		{name: "Multiple characters path with root", path: "$.abc", expected: []string{"$", "abc"}},
+		{name: "Multiple segments path with root", path: "$.a.b.c", expected: []string{"$", "a", "b", "c"}},
+		{name: "Multiple segments path with wildcard and root", path: "$.a.*.c", expected: []string{"$", "a", "*", "c"}},
+		{name: "Multiple segments path with filter and root", path: "$.a[?(@.b == 'c')].d", expected: []string{"$", "a", "?(@.b == 'c')", "d"}},
+		{name: "Complex path with multiple filters", path: "$.a[?(@.b == 'c')].d[?(@.e == 'f')].g", expected: []string{"$", "a", "?(@.b == 'c')", "d", "?(@.e == 'f')", "g"}},
+		{name: "Complex path with multiple filters and wildcards", path: "$.a[?(@.b == 'c')].*.d[?(@.e == 'f')].g", expected: []string{"$", "a", "?(@.b == 'c')", "*", "d", "?(@.e == 'f')", "g"}},
+		{name: "Path with array index and root", path: "$.a[0].b", expected: []string{"$", "a", "0", "b"}},
+		{name: "Path with multiple array indices and root", path: "$.a[0].b[1].c", expected: []string{"$", "a", "0", "b", "1", "c"}},
+		{name: "Path with array index, wildcard and root", path: "$.a[0].*.c", expected: []string{"$", "a", "0", "*", "c"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reult, _ := ParsePath(tt.path)
+			if !isEqualSlice(reult, tt.expected) {
+				t.Errorf("ParsePath(%s) expected: %v, got: %v", tt.path, tt.expected, reult)
+			}
+		})
+	}
+}
+
+func isEqualSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/vendored/gno.land/p/onbloc/json/token.gno
+++ b/vendored/gno.land/p/onbloc/json/token.gno
@@ -1,0 +1,76 @@
+package json
+
+const (
+	bracketOpen    = '['
+	bracketClose   = ']'
+	parenOpen      = '('
+	parenClose     = ')'
+	curlyOpen      = '{'
+	curlyClose     = '}'
+	comma          = ','
+	dot            = '.'
+	colon          = ':'
+	backTick       = '`'
+	singleQuote    = '\''
+	doubleQuote    = '"'
+	emptyString    = ""
+	whiteSpace     = ' '
+	plus           = '+'
+	minus          = '-'
+	aesterisk      = '*'
+	bang           = '!'
+	question       = '?'
+	newLine        = '\n'
+	tab            = '\t'
+	carriageReturn = '\r'
+	formFeed       = '\f'
+	backSpace      = '\b'
+	slash          = '/'
+	backSlash      = '\\'
+	underScore     = '_'
+	dollarSign     = '$'
+	atSign         = '@'
+	andSign        = '&'
+	orSign         = '|'
+)
+
+var (
+	trueLiteral  = []byte("true")
+	falseLiteral = []byte("false")
+	nullLiteral  = []byte("null")
+)
+
+type ValueType int
+
+const (
+	NotExist ValueType = iota
+	String
+	Number
+	Float
+	Object
+	Array
+	Boolean
+	Null
+	Unknown
+)
+
+func (v ValueType) String() string {
+	switch v {
+	case NotExist:
+		return "not-exist"
+	case String:
+		return "string"
+	case Number:
+		return "number"
+	case Object:
+		return "object"
+	case Array:
+		return "array"
+	case Boolean:
+		return "boolean"
+	case Null:
+		return "null"
+	default:
+		return "unknown"
+	}
+}

--- a/vendored/gno.land/p/samcrew/avl/README.md
+++ b/vendored/gno.land/p/samcrew/avl/README.md
@@ -1,0 +1,87 @@
+> **v0 - Unaudited**
+> This is an initial version of this package that has not yet been formally audited.
+> A fully audited version will be published as a subsequent release.
+> Use in production at your own risk.
+
+
+# AVL Tree Package
+
+The `avl` package provides a gas-efficient AVL tree implementation for storing key-value data in Gno realms.
+
+## Basic Usage
+
+```go
+package myrealm
+
+import "gno.land/p/samcrew/avl"
+
+// This AVL tree will be persisted after transaction calls
+var tree *avl.Tree
+
+func Set(key string, value int) {
+	// tree.Set takes in a string key, and a value that can be of any type
+	tree.Set(key, value)
+}
+
+func Get(key string) int {
+	// tree.Get returns the value at given key in its raw form,
+	// and a bool to signify the existence of the key-value pair
+	rawValue, exists := tree.Get(key)
+	if !exists {
+		panic("value at given key does not exist")
+	}
+
+	// rawValue needs to be converted into the proper type before returning it
+	return rawValue.(int)
+}
+```
+
+## Storage Architecture: AVL Tree vs Map
+
+In Gno, the choice between `avl.Tree` and `map` is fundamentally about how data is persisted in storage.
+
+**Maps** are stored as a single, monolithic object. When you access *any* value in a map, Gno must load the *entire* map into memory. For a map with 1,000 entries, accessing one value means loading all 1,000 entries.
+
+**AVL trees** store each node as a separate object. When you access a value, Gno only loads the nodes along the search path (typically log2(n) nodes). For a tree with 1,000 entries, accessing one value loads ~10 nodes; but a tree with 1,000,000 entries only needs to load ~20 nodes.
+
+## Storage Comparison Example
+
+Consider a realm with 1,000 key-value pairs. Here's what happens when you access a single value:
+
+**Map storage:**
+
+```
+Object :4 = map{
+  ("0" string):("123" string),
+  ("1" string):("123" string),
+  ...
+  ("999" string):("123" string)
+}
+```
+- Accessing `map["100"]` loads object `:4` (contains **all 1,000 pairs**)
+- Gas cost is proportional to total map size (1,000 entries)
+- **1 object fetch, but massive data load**
+
+**AVL tree storage:**
+
+```
+Object :6 = Node{key="4", height=10, size=1000, left=:7, right=...}
+Object :9 = Node{key="2", height=9, size=334, left=:10, right=...}
+Object :11 = Node{key="14", height=8, size=112, left=:12, right=...}
+Object :13 = Node{key="12", height=6, size=46, left=:14, right=...}
+Object :15 = Node{key="11", height=5, size=24, left=:16, right=...}
+Object :17 = Node{key="102", height=4, size=13, left=:18, right=...}
+Object :19 = Node{key="100", height=3, size=5, left=:30, right=...}
+Object :31 = Node{key="101", height=1, size=2, left=:32, right=...}
+Object :33 = Node{key="100", value="123", height=0, size=1}
+```
+- Accessing `tree.Get("100")` loads ~10 objects (the search path)
+- Gas cost is proportional to log2(n) ≈ 10 nodes
+- **10 object fetches, each containing only a single node**
+
+## Further Reading
+
+- [Why should you use an AVL tree instead of a map?](https://howl.moe/posts/2024-09-19-gno-avl-over-maps/) - Howl detailed analysis
+- [Berty's AVL scalability report](https://github.com/gnolang/hackerspace/issues/67) - Real-world testing with up to 20M entries
+- [Wikipedia - AVL tree](https://en.wikipedia.org/wiki/AVL_tree) - Algorithm details and balancing
+- [Effective Gno](https://docs.gno.land/resources/effective-gno#prefer-avltree-over-map-for-scalable-storage) - High-level usage guidance

--- a/vendored/gno.land/p/samcrew/avl/doc.gno
+++ b/vendored/gno.land/p/samcrew/avl/doc.gno
@@ -1,0 +1,7 @@
+// v0 - Unaudited: This is an initial version that has not yet been formally audited.
+// A fully audited version will be published as a subsequent release.
+// Use in production at your own risk.
+//
+// Package avl provides a gas-efficient AVL tree implementation for storing
+// key-value data in Gno realms.
+package avl

--- a/vendored/gno.land/p/samcrew/avl/equivalence_test.gno
+++ b/vendored/gno.land/p/samcrew/avl/equivalence_test.gno
@@ -1,0 +1,213 @@
+package avl
+
+// Equivalence suite for the vendored avl (AVL_OPTION_A_VENDORING_SPEC §3.2).
+//
+// The vendored module is byte-identical to gno.land/p/nt/avl/v0 @ f3d5a5d13
+// except for the module/import paths, so "equivalence vs the stdlib avl" is
+// proven by pinning the OBSERVABLE CONTRACT here and running the IDENTICAL
+// suite at both the pre-avl pin (f3d5a5d13, CI) and the mainnet-candidate ref
+// (67a0bb333, local Topaz toolchain until the flag-day re-pin) — a behavior
+// drift introduced by either VM would fail one leg. A literal side-by-side
+// import of p/nt/avl/v0 cannot compile at both refs (its Get is two-value at
+// the pin and single-value after #5314), hence the reference-model form.
+//
+// Frozen contract under test (the whole point of Option A):
+//   Get(key)    -> (value any, exists bool)   hit: (val, true) · miss: (nil, false)
+//   Set(k, v)   -> updated bool
+//   Remove(key) -> (value any, removed bool)
+//   Iterate / ReverseIterate / Size / Has / GetByIndex unchanged.
+
+import (
+	"sort"
+	"strconv"
+	"testing"
+)
+
+// TestGetTwoValueContract pins the exact two-value Get semantics ~407 Memba
+// call sites rely on, including the nil-VALUE-vs-miss distinction (the
+// custody-oracle nil-vs-zero trap: a stored nil must read back (nil, true)).
+func TestGetTwoValueContract(t *testing.T) {
+	tree := NewTree()
+
+	// Miss on empty tree.
+	if v, ok := tree.Get("absent"); v != nil || ok {
+		t.Fatalf("empty-tree Get: want (nil,false), got (%v,%t)", v, ok)
+	}
+
+	// Hit returns (val, true).
+	tree.Set("k", 42)
+	if v, ok := tree.Get("k"); v != 42 || !ok {
+		t.Fatalf("hit Get: want (42,true), got (%v,%t)", v, ok)
+	}
+
+	// A stored nil VALUE is a hit: (nil, true) — distinct from a miss.
+	tree.Set("nilval", nil)
+	if v, ok := tree.Get("nilval"); v != nil || !ok {
+		t.Fatalf("nil-value Get: want (nil,true), got (%v,%t)", v, ok)
+	}
+
+	// Miss after Remove reverts to (nil, false).
+	tree.Remove("k")
+	if v, ok := tree.Get("k"); v != nil || ok {
+		t.Fatalf("post-Remove Get: want (nil,false), got (%v,%t)", v, ok)
+	}
+}
+
+// TestSetRemoveContract pins Set's updated flag and Remove's two-value form.
+func TestSetRemoveContract(t *testing.T) {
+	tree := NewTree()
+
+	if updated := tree.Set("a", 1); updated {
+		t.Fatal("Set on new key: want updated=false")
+	}
+	if updated := tree.Set("a", 2); !updated {
+		t.Fatal("Set on existing key: want updated=true")
+	}
+	if v, removed := tree.Remove("a"); v != 2 || !removed {
+		t.Fatalf("Remove hit: want (2,true), got (%v,%t)", v, removed)
+	}
+	if v, removed := tree.Remove("a"); v != nil || removed {
+		t.Fatalf("Remove miss: want (nil,false), got (%v,%t)", v, removed)
+	}
+	if s := tree.Size(); s != 0 {
+		t.Fatalf("Size after remove: want 0, got %d", s)
+	}
+}
+
+// lcg is a deterministic linear congruential generator (Numerical Recipes
+// constants) so the fuzz sequence is bit-identical on every run and ref.
+type lcg struct{ state uint64 }
+
+func (r *lcg) next() uint64 {
+	r.state = r.state*6364136223846793005 + 1442695040888963407
+	return r.state
+}
+
+// TestFuzzEquivalenceVsModel drives a deterministic randomized op sequence
+// against the tree and a map+sorted-keys reference model, checking every op
+// result and periodically the full in-order state.
+func TestFuzzEquivalenceVsModel(t *testing.T) {
+	const (
+		ops        = 4000
+		keySpace   = 157 // forces plenty of hit/miss/update/rebalance traffic
+		checkEvery = 500
+	)
+
+	tree := NewTree()
+	model := make(map[string]any)
+	rng := &lcg{state: 20260717}
+
+	fullCompare := func(step int) {
+		if got, want := tree.Size(), len(model); got != want {
+			t.Fatalf("step %d: Size=%d, model=%d", step, got, want)
+		}
+		keys := []string{}
+		for k := range model {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		// Per-key two-value Get equivalence.
+		for _, k := range keys {
+			v, ok := tree.Get(k)
+			if !ok || v != model[k] {
+				t.Fatalf("step %d: Get(%s): want (%v,true), got (%v,%t)", step, k, model[k], v, ok)
+			}
+		}
+
+		// Full in-order traversal: order and values must match the model.
+		i := 0
+		tree.Iterate("", "", func(k string, v any) bool {
+			if i >= len(keys) {
+				t.Fatalf("step %d: Iterate yielded more than %d entries", step, len(keys))
+			}
+			if k != keys[i] || v != model[keys[i]] {
+				t.Fatalf("step %d: Iterate[%d]: want (%s,%v), got (%s,%v)", step, i, keys[i], model[keys[i]], k, v)
+			}
+			i++
+			return false
+		})
+		if i != len(keys) {
+			t.Fatalf("step %d: Iterate yielded %d entries, want %d", step, i, len(keys))
+		}
+
+		// Reverse traversal mirrors the sorted order.
+		j := len(keys) - 1
+		tree.ReverseIterate("", "", func(k string, v any) bool {
+			if j < 0 {
+				t.Fatalf("step %d: ReverseIterate yielded too many entries", step)
+			}
+			if k != keys[j] {
+				t.Fatalf("step %d: ReverseIterate: want %s, got %s", step, keys[j], k)
+			}
+			j--
+			return false
+		})
+		if j != -1 {
+			t.Fatalf("step %d: ReverseIterate incomplete (j=%d)", step, j)
+		}
+
+		// GetByIndex agrees with the sorted model.
+		for idx, k := range keys {
+			gk, gv := tree.GetByIndex(idx)
+			if gk != k || gv != model[k] {
+				t.Fatalf("step %d: GetByIndex(%d): want (%s,%v), got (%s,%v)", step, idx, k, model[k], gk, gv)
+			}
+		}
+	}
+
+	for op := 1; op <= ops; op++ {
+		k := "k" + strconv.Itoa(int(rng.next()%keySpace))
+		switch rng.next() % 4 {
+		case 0, 1: // Set (50%)
+			val := int(rng.next() % 1000)
+			_, existed := model[k]
+			if updated := tree.Set(k, val); updated != existed {
+				t.Fatalf("op %d: Set(%s) updated=%t, model existed=%t", op, k, updated, existed)
+			}
+			model[k] = val
+		case 2: // Remove (25%)
+			want, existed := model[k]
+			v, removed := tree.Remove(k)
+			if removed != existed {
+				t.Fatalf("op %d: Remove(%s) removed=%t, model existed=%t", op, k, removed, existed)
+			}
+			if existed && v != want {
+				t.Fatalf("op %d: Remove(%s) value=%v, model=%v", op, k, v, want)
+			}
+			if !existed && v != nil {
+				t.Fatalf("op %d: Remove(%s) miss returned value %v, want nil", op, k, v)
+			}
+			delete(model, k)
+		default: // Get + Has (25%)
+			want, existed := model[k]
+			v, ok := tree.Get(k)
+			if ok != existed {
+				t.Fatalf("op %d: Get(%s) exists=%t, model=%t", op, k, ok, existed)
+			}
+			if existed && v != want {
+				t.Fatalf("op %d: Get(%s) value=%v, model=%v", op, k, v, want)
+			}
+			if !existed && v != nil {
+				t.Fatalf("op %d: Get(%s) miss returned value %v, want nil", op, k, v)
+			}
+			if tree.Has(k) != existed {
+				t.Fatalf("op %d: Has(%s) != model %t", op, k, existed)
+			}
+		}
+		if op%checkEvery == 0 {
+			fullCompare(op)
+		}
+	}
+	fullCompare(ops)
+
+	// Iterate early-stop contract: returning true halts the walk.
+	seen := 0
+	tree.Iterate("", "", func(k string, v any) bool {
+		seen++
+		return seen == 3
+	})
+	if tree.Size() >= 3 && seen != 3 {
+		t.Fatalf("Iterate early-stop: want 3 callbacks, got %d", seen)
+	}
+}

--- a/vendored/gno.land/p/samcrew/avl/gnomod.toml
+++ b/vendored/gno.land/p/samcrew/avl/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/samcrew/avl"
+gno = "0.9"

--- a/vendored/gno.land/p/samcrew/avl/node.gno
+++ b/vendored/gno.land/p/samcrew/avl/node.gno
@@ -1,0 +1,482 @@
+package avl
+
+//----------------------------------------
+// Node
+
+// Node represents a node in an AVL tree.
+type Node struct {
+	key       string // key is the unique identifier for the node.
+	value     any    // value is the data stored in the node.
+	height    int8   // height is the height of the node in the tree.
+	size      int    // size is the number of leaf nodes (key-value pairs) in the subtree rooted at this node.
+	leftNode  *Node  // leftNode is the left child of the node.
+	rightNode *Node  // rightNode is the right child of the node.
+}
+
+// NewNode creates a new node with the given key and value.
+func NewNode(key string, value any) *Node {
+	return &Node{
+		key:    key,
+		value:  value,
+		height: 0,
+		size:   1,
+	}
+}
+
+// Size returns the size of the subtree rooted at the node.
+func (node *Node) Size() int {
+	if node == nil {
+		return 0
+	}
+	return node.size
+}
+
+// IsLeaf checks if the node is a leaf node (has no children).
+func (node *Node) IsLeaf() bool {
+	return node.height == 0
+}
+
+// Key returns the key of the node.
+func (node *Node) Key() string {
+	return node.key
+}
+
+// Value returns the value of the node.
+func (node *Node) Value() any {
+	return node.value
+}
+
+func (node *Node) _copy() *Node {
+	if node.height == 0 {
+		panic("Why are you copying a value node?")
+	}
+	return &Node{
+		key:       node.key,
+		height:    node.height,
+		size:      node.size,
+		leftNode:  node.leftNode,
+		rightNode: node.rightNode,
+	}
+}
+
+// Has checks if a node with the given key exists in the subtree rooted at the node.
+func (node *Node) Has(key string) (has bool) {
+	if node == nil {
+		return false
+	}
+	if node.key == key {
+		return true
+	}
+	if node.height == 0 {
+		return false
+	} else {
+		if key < node.key {
+			return node.getLeftNode().Has(key)
+		} else {
+			return node.getRightNode().Has(key)
+		}
+	}
+}
+
+// Get searches for a node with the given key in the subtree rooted at the node
+// and returns its index, value, and whether it exists.
+func (node *Node) Get(key string) (index int, value any, exists bool) {
+	if node == nil {
+		return 0, nil, false
+	}
+
+	if node.height == 0 {
+		if node.key == key {
+			return 0, node.value, true
+		} else if node.key < key {
+			return 1, nil, false
+		} else {
+			return 0, nil, false
+		}
+	} else {
+		if key < node.key {
+			return node.getLeftNode().Get(key)
+		} else {
+			rightNode := node.getRightNode()
+			index, value, exists = rightNode.Get(key)
+			index += node.size - rightNode.size
+			return index, value, exists
+		}
+	}
+}
+
+// GetByIndex retrieves the key-value pair of the node at the given index
+// in the subtree rooted at the node.
+func (node *Node) GetByIndex(index int) (key string, value any) {
+	if node.height == 0 {
+		if index == 0 {
+			return node.key, node.value
+		} else {
+			panic("GetByIndex asked for invalid index")
+		}
+	} else {
+		// TODO: could improve this by storing the sizes
+		leftNode := node.getLeftNode()
+		if index < leftNode.size {
+			return leftNode.GetByIndex(index)
+		} else {
+			return node.getRightNode().GetByIndex(index - leftNode.size)
+		}
+	}
+}
+
+// Set inserts a new node with the given key-value pair into the subtree rooted at the node,
+// and returns the new root of the subtree and whether an existing node was updated.
+//
+// XXX consider a better way to do this... perhaps split Node from Node.
+func (node *Node) Set(key string, value any) (newSelf *Node, updated bool) {
+	if node == nil {
+		return NewNode(key, value), false
+	}
+	if node.height == 0 {
+		if key < node.key {
+			return &Node{
+				key:       node.key,
+				height:    1,
+				size:      2,
+				leftNode:  NewNode(key, value),
+				rightNode: node,
+			}, false
+		} else if key == node.key {
+			return NewNode(key, value), true
+		} else {
+			return &Node{
+				key:       key,
+				height:    1,
+				size:      2,
+				leftNode:  node,
+				rightNode: NewNode(key, value),
+			}, false
+		}
+	} else {
+		node = node._copy()
+		if key < node.key {
+			node.leftNode, updated = node.getLeftNode().Set(key, value)
+		} else {
+			node.rightNode, updated = node.getRightNode().Set(key, value)
+		}
+		if updated {
+			return node, updated
+		} else {
+			node.calcHeightAndSize()
+			return node.balance(), updated
+		}
+	}
+}
+
+// Remove deletes the node with the given key from the subtree rooted at the node.
+// returns the new root of the subtree, the new leftmost leaf key (if changed),
+// the removed value and the removal was successful.
+func (node *Node) Remove(key string) (
+	newNode *Node, newKey string, value any, removed bool,
+) {
+	if node == nil {
+		return nil, "", nil, false
+	}
+	if node.height == 0 {
+		if key == node.key {
+			return nil, "", node.value, true
+		} else {
+			return node, "", nil, false
+		}
+	} else {
+		if key < node.key {
+			var newLeftNode *Node
+			newLeftNode, newKey, value, removed = node.getLeftNode().Remove(key)
+			if !removed {
+				return node, "", value, false
+			} else if newLeftNode == nil { // left node held value, was removed
+				return node.rightNode, node.key, value, true
+			}
+			node = node._copy()
+			node.leftNode = newLeftNode
+			node.calcHeightAndSize()
+			node = node.balance()
+			return node, newKey, value, true
+		} else {
+			var newRightNode *Node
+			newRightNode, newKey, value, removed = node.getRightNode().Remove(key)
+			if !removed {
+				return node, "", value, false
+			} else if newRightNode == nil { // right node held value, was removed
+				return node.leftNode, "", value, true
+			}
+			node = node._copy()
+			node.rightNode = newRightNode
+			if newKey != "" {
+				node.key = newKey
+			}
+			node.calcHeightAndSize()
+			node = node.balance()
+			return node, "", value, true
+		}
+	}
+}
+
+func (node *Node) getLeftNode() *Node {
+	return node.leftNode
+}
+
+func (node *Node) getRightNode() *Node {
+	return node.rightNode
+}
+
+// rotateRight performs a right rotation on the node and returns the new root.
+// NOTE: overwrites node
+// TODO: optimize balance & rotate
+func (node *Node) rotateRight() *Node {
+	node = node._copy()
+	l := node.getLeftNode()
+	_l := l._copy()
+
+	_lrCached := _l.rightNode
+	_l.rightNode = node
+	node.leftNode = _lrCached
+
+	node.calcHeightAndSize()
+	_l.calcHeightAndSize()
+
+	return _l
+}
+
+// rotateLeft performs a left rotation on the node and returns the new root.
+// NOTE: overwrites node
+// TODO: optimize balance & rotate
+func (node *Node) rotateLeft() *Node {
+	node = node._copy()
+	r := node.getRightNode()
+	_r := r._copy()
+
+	_rlCached := _r.leftNode
+	_r.leftNode = node
+	node.rightNode = _rlCached
+
+	node.calcHeightAndSize()
+	_r.calcHeightAndSize()
+
+	return _r
+}
+
+// calcHeightAndSize updates the height and size of the node based on its children.
+// NOTE: mutates height and size
+func (node *Node) calcHeightAndSize() {
+	node.height = maxInt8(node.getLeftNode().height, node.getRightNode().height) + 1
+	node.size = node.getLeftNode().size + node.getRightNode().size
+}
+
+// calcBalance calculates the balance factor of the node.
+func (node *Node) calcBalance() int {
+	return int(node.getLeftNode().height) - int(node.getRightNode().height)
+}
+
+// balance balances the subtree rooted at the node and returns the new root.
+// NOTE: assumes that node can be modified
+// TODO: optimize balance & rotate
+func (node *Node) balance() (newSelf *Node) {
+	balance := node.calcBalance()
+	if balance > 1 {
+		if node.getLeftNode().calcBalance() >= 0 {
+			// Left Left Case
+			return node.rotateRight()
+		} else {
+			// Left Right Case
+			left := node.getLeftNode()
+			node.leftNode = left.rotateLeft()
+			return node.rotateRight()
+		}
+	}
+	if balance < -1 {
+		if node.getRightNode().calcBalance() <= 0 {
+			// Right Right Case
+			return node.rotateLeft()
+		} else {
+			// Right Left Case
+			right := node.getRightNode()
+			node.rightNode = right.rotateRight()
+			return node.rotateLeft()
+		}
+	}
+	// Nothing changed
+	return node
+}
+
+// Shortcut for TraverseInRange.
+func (node *Node) Iterate(start, end string, cb func(*Node) bool) bool {
+	return node.TraverseInRange(start, end, true, true, cb)
+}
+
+// Shortcut for TraverseInRange.
+func (node *Node) ReverseIterate(start, end string, cb func(*Node) bool) bool {
+	return node.TraverseInRange(start, end, false, true, cb)
+}
+
+// TraverseInRange traverses all nodes, including inner nodes.
+// Start is inclusive and end is exclusive when ascending,
+// Start and end are inclusive when descending.
+// Empty start and empty end denote no start and no end.
+// If leavesOnly is true, only visit leaf nodes.
+// NOTE: To simulate an exclusive reverse traversal,
+// just append 0x00 to start.
+func (node *Node) TraverseInRange(start, end string, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	if node == nil {
+		return false
+	}
+	afterStart := (start == "" || start < node.key)
+	startOrAfter := (start == "" || start <= node.key)
+	beforeEnd := false
+	if ascending {
+		beforeEnd = (end == "" || node.key < end)
+	} else {
+		beforeEnd = (end == "" || node.key <= end)
+	}
+
+	// Run callback per inner/leaf node.
+	stop := false
+	if (!node.IsLeaf() && !leavesOnly) ||
+		(node.IsLeaf() && startOrAfter && beforeEnd) {
+		stop = cb(node)
+		if stop {
+			return stop
+		}
+	}
+	if node.IsLeaf() {
+		return stop
+	}
+
+	if ascending {
+		// check lower nodes, then higher
+		if afterStart {
+			stop = node.getLeftNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+		if stop {
+			return stop
+		}
+		if beforeEnd {
+			stop = node.getRightNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+	} else {
+		// check the higher nodes first
+		if beforeEnd {
+			stop = node.getRightNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+		if stop {
+			return stop
+		}
+		if afterStart {
+			stop = node.getLeftNode().TraverseInRange(start, end, ascending, leavesOnly, cb)
+		}
+	}
+
+	return stop
+}
+
+// TraverseByOffset traverses all nodes, including inner nodes.
+// A limit of math.MaxInt means no limit.
+func (node *Node) TraverseByOffset(offset, limit int, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	if node == nil {
+		return false
+	}
+
+	// fast paths. these happen only if TraverseByOffset is called directly on a leaf.
+	if limit <= 0 || offset >= node.size {
+		return false
+	}
+	if node.IsLeaf() {
+		if offset > 0 {
+			return false
+		}
+		return cb(node)
+	}
+
+	// go to the actual recursive function.
+	return node.traverseByOffset(offset, limit, ascending, leavesOnly, cb)
+}
+
+// TraverseByOffset traverses the subtree rooted at the node by offset and limit,
+// in either ascending or descending order, and applies the callback function to each traversed node.
+// If leavesOnly is true, only leaf nodes are visited.
+func (node *Node) traverseByOffset(offset, limit int, ascending bool, leavesOnly bool, cb func(*Node) bool) bool {
+	// caller guarantees: offset < node.size; limit > 0.
+	if !leavesOnly {
+		if cb(node) {
+			return true // Stop traversal if callback returns true
+		}
+	}
+	first, second := node.getLeftNode(), node.getRightNode()
+	if !ascending {
+		first, second = second, first
+	}
+	if first.IsLeaf() {
+		// either run or skip, based on offset
+		if offset > 0 {
+			offset--
+		} else {
+			if cb(first) {
+				return true // Stop traversal if callback returns true
+			}
+			limit--
+			if limit <= 0 {
+				return true // Stop traversal when limit is reached
+			}
+		}
+	} else {
+		// possible cases:
+		// 1 the offset given skips the first node entirely
+		// 2 the offset skips none or part of the first node, but the limit requires some of the second node.
+		// 3 the offset skips none or part of the first node, and the limit stops our search on the first node.
+		if offset >= first.size {
+			offset -= first.size // 1
+		} else {
+			if first.traverseByOffset(offset, limit, ascending, leavesOnly, cb) {
+				return true
+			}
+			// number of leaves which could actually be called from inside
+			delta := first.size - offset
+			offset = 0
+			if delta >= limit {
+				return true // 3
+			}
+			limit -= delta // 2
+		}
+	}
+
+	// because of the caller guarantees and the way we handle the first node,
+	// at this point we know that limit > 0 and there must be some values in
+	// this second node that we include.
+
+	// => if the second node is a leaf, it has to be included.
+	if second.IsLeaf() {
+		return cb(second)
+	}
+	// => if it is not a leaf, it will still be enough to recursively call this
+	// function with the updated offset and limit
+	return second.traverseByOffset(offset, limit, ascending, leavesOnly, cb)
+}
+
+// Only used in testing...
+func (node *Node) lmd() *Node {
+	if node.height == 0 {
+		return node
+	}
+	return node.getLeftNode().lmd()
+}
+
+// Only used in testing...
+func (node *Node) rmd() *Node {
+	if node.height == 0 {
+		return node
+	}
+	return node.getRightNode().rmd()
+}
+
+func maxInt8(a, b int8) int8 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendored/gno.land/p/samcrew/avl/node_test.gno
+++ b/vendored/gno.land/p/samcrew/avl/node_test.gno
@@ -1,0 +1,741 @@
+package avl
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func TestTraverseByOffset(t *testing.T) {
+	const testStrings = `Alfa
+Alfred
+Alpha
+Alphabet
+Beta
+Beth
+Book
+Browser`
+	tt := []struct {
+		name string
+		asc  bool
+	}{
+		{"ascending", true},
+		{"descending", false},
+	}
+
+	for _, tt := range tt {
+		t.Run(tt.name, func(t *testing.T) {
+			// use sl to insert the values, and reversed to match the values
+			// we do this to ensure that the order of TraverseByOffset is independent
+			// from the insertion order
+			sl := strings.Split(testStrings, "\n")
+			sort.Strings(sl)
+			reversed := append([]string{}, sl...)
+			reverseSlice(reversed)
+
+			if !tt.asc {
+				sl, reversed = reversed, sl
+			}
+
+			r := NewNode(reversed[0], nil)
+			for _, v := range reversed[1:] {
+				r, _ = r.Set(v, nil)
+			}
+
+			var result []string
+			for i := 0; i < len(sl); i++ {
+				r.TraverseByOffset(i, 1, tt.asc, true, func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+			}
+
+			if !slicesEqual(sl, result) {
+				t.Errorf("want %v got %v", sl, result)
+			}
+
+			for l := 2; l <= len(sl); l++ {
+				// "slices"
+				for i := 0; i <= len(sl); i++ {
+					max := i + l
+					if max > len(sl) {
+						max = len(sl)
+					}
+					exp := sl[i:max]
+					actual := []string{}
+
+					r.TraverseByOffset(i, l, tt.asc, true, func(tr *Node) bool {
+						actual = append(actual, tr.Key())
+						return false
+					})
+					if !slicesEqual(exp, actual) {
+						t.Errorf("want %v got %v", exp, actual)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHas(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		hasKey   string
+		expected bool
+	}{
+		{
+			"has key in non-empty tree",
+			[]string{"C", "A", "B", "E", "D"},
+			"B",
+			true,
+		},
+		{
+			"does not have key in non-empty tree",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			false,
+		},
+		{
+			"has key in single-node tree",
+			[]string{"A"},
+			"A",
+			true,
+		},
+		{
+			"does not have key in single-node tree",
+			[]string{"A"},
+			"B",
+			false,
+		},
+		{
+			"does not have key in empty tree",
+			[]string{},
+			"A",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			result := tree.Has(tt.hasKey)
+
+			if result != tt.expected {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        []string
+		getKey       string
+		expectIdx    int
+		expectVal    any
+		expectExists bool
+	}{
+		{
+			"get existing key",
+			[]string{"C", "A", "B", "E", "D"},
+			"B",
+			1,
+			nil,
+			true,
+		},
+		{
+			"get non-existent key (smaller)",
+			[]string{"C", "A", "B", "E", "D"},
+			"@",
+			0,
+			nil,
+			false,
+		},
+		{
+			"get non-existent key (larger)",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			5,
+			nil,
+			false,
+		},
+		{
+			"get from empty tree",
+			[]string{},
+			"A",
+			0,
+			nil,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			idx, val, exists := tree.Get(tt.getKey)
+
+			if idx != tt.expectIdx {
+				t.Errorf("Expected index %d, got %d", tt.expectIdx, idx)
+			}
+
+			if val != tt.expectVal {
+				t.Errorf("Expected value %v, got %v", tt.expectVal, val)
+			}
+
+			if exists != tt.expectExists {
+				t.Errorf("Expected exists %t, got %t", tt.expectExists, exists)
+			}
+		})
+	}
+}
+
+func TestGetByIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       []string
+		idx         int
+		expectKey   string
+		expectVal   any
+		expectPanic bool
+	}{
+		{
+			"get by valid index",
+			[]string{"C", "A", "B", "E", "D"},
+			2,
+			"C",
+			nil,
+			false,
+		},
+		{
+			"get by valid index (smallest)",
+			[]string{"C", "A", "B", "E", "D"},
+			0,
+			"A",
+			nil,
+			false,
+		},
+		{
+			"get by valid index (largest)",
+			[]string{"C", "A", "B", "E", "D"},
+			4,
+			"E",
+			nil,
+			false,
+		},
+		{
+			"get by invalid index (negative)",
+			[]string{"C", "A", "B", "E", "D"},
+			-1,
+			"",
+			nil,
+			true,
+		},
+		{
+			"get by invalid index (out of range)",
+			[]string{"C", "A", "B", "E", "D"},
+			5,
+			"",
+			nil,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			if tt.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("Expected a panic but didn't get one")
+					}
+				}()
+			}
+
+			key, val := tree.GetByIndex(tt.idx)
+
+			if !tt.expectPanic {
+				if key != tt.expectKey {
+					t.Errorf("Expected key %s, got %s", tt.expectKey, key)
+				}
+
+				if val != tt.expectVal {
+					t.Errorf("Expected value %v, got %v", tt.expectVal, val)
+				}
+			}
+		})
+	}
+}
+
+func TestRemove(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     []string
+		removeKey string
+		expected  []string
+	}{
+		{
+			"remove leaf node",
+			[]string{"C", "A", "B", "D"},
+			"B",
+			[]string{"A", "C", "D"},
+		},
+		{
+			"remove node with one child",
+			[]string{"C", "A", "B", "D"},
+			"A",
+			[]string{"B", "C", "D"},
+		},
+		{
+			"remove node with two children",
+			[]string{"C", "A", "B", "E", "D"},
+			"C",
+			[]string{"A", "B", "D", "E"},
+		},
+		{
+			"remove root node",
+			[]string{"C", "A", "B", "E", "D"},
+			"C",
+			[]string{"A", "B", "D", "E"},
+		},
+		{
+			"remove non-existent key",
+			[]string{"C", "A", "B", "E", "D"},
+			"F",
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree, _, _, _ = tree.Remove(tt.removeKey)
+
+			result := make([]string, 0)
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestTraverse(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"empty tree",
+			[]string{},
+			[]string{},
+		},
+		{
+			"single node tree",
+			[]string{"A"},
+			[]string{"A"},
+		},
+		{
+			"small tree",
+			[]string{"C", "A", "B", "E", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"large tree",
+			[]string{"H", "D", "L", "B", "F", "J", "N", "A", "C", "E", "G", "I", "K", "M", "O"},
+			[]string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			t.Run("iterate", func(t *testing.T) {
+				var result []string
+				tree.Iterate("", "", func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				if !slicesEqual(tt.expected, result) {
+					t.Errorf("want %v got %v", tt.expected, result)
+				}
+			})
+
+			t.Run("ReverseIterate", func(t *testing.T) {
+				var result []string
+				tree.ReverseIterate("", "", func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				expected := make([]string, len(tt.expected))
+				copy(expected, tt.expected)
+				for i, j := 0, len(expected)-1; i < j; i, j = i+1, j-1 {
+					expected[i], expected[j] = expected[j], expected[i]
+				}
+				if !slicesEqual(expected, result) {
+					t.Errorf("want %v got %v", expected, result)
+				}
+			})
+
+			t.Run("TraverseInRange", func(t *testing.T) {
+				var result []string
+				start, end := "C", "M"
+				tree.TraverseInRange(start, end, true, true, func(n *Node) bool {
+					result = append(result, n.Key())
+					return false
+				})
+				expected := make([]string, 0)
+				for _, key := range tt.expected {
+					if key >= start && key < end {
+						expected = append(expected, key)
+					}
+				}
+				if !slicesEqual(expected, result) {
+					t.Errorf("want %v got %v", expected, result)
+				}
+			})
+
+			t.Run("early termination", func(t *testing.T) {
+				if len(tt.input) == 0 {
+					return // Skip for empty tree
+				}
+
+				var result []string
+				var count int
+				tree.Iterate("", "", func(n *Node) bool {
+					count++
+					result = append(result, n.Key())
+					return true // Stop after first item
+				})
+
+				if count != 1 {
+					t.Errorf("Expected callback to be called exactly once, got %d calls", count)
+				}
+				if len(result) != 1 {
+					t.Errorf("Expected exactly one result, got %d items", len(result))
+				}
+				if len(result) > 0 && result[0] != tt.expected[0] {
+					t.Errorf("Expected first item to be %v, got %v", tt.expected[0], result[0])
+				}
+			})
+		})
+	}
+}
+
+func TestRotateWhenHeightDiffers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"right rotation when left subtree is higher",
+			[]string{"E", "C", "A", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left rotation when right subtree is higher",
+			[]string{"A", "C", "E", "D", "F"},
+			[]string{"A", "C", "D", "E", "F"},
+		},
+		{
+			"left-right rotation",
+			[]string{"E", "A", "C", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"right-left rotation",
+			[]string{"A", "E", "C", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			// perform rotation or balance
+			tree = tree.balance()
+
+			// check tree structure
+			var result []string
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRotateAndBalance(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			"right rotation",
+			[]string{"A", "B", "C", "D", "E"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left rotation",
+			[]string{"E", "D", "C", "B", "A"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"left-right rotation",
+			[]string{"C", "A", "E", "B", "D"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+		{
+			"right-left rotation",
+			[]string{"C", "E", "A", "D", "B"},
+			[]string{"A", "B", "C", "D", "E"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.input {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree = tree.balance()
+
+			var result []string
+			tree.Iterate("", "", func(n *Node) bool {
+				result = append(result, n.Key())
+				return false
+			})
+
+			if !slicesEqual(tt.expected, result) {
+				t.Errorf("want %v got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestRemoveFromEmptyTree(t *testing.T) {
+	var tree *Node
+	newTree, _, val, removed := tree.Remove("NonExistent")
+	if newTree != nil {
+		t.Errorf("Removing from an empty tree should still be nil tree.")
+	}
+	if val != nil || removed {
+		t.Errorf("Expected no value and removed=false when removing from empty tree.")
+	}
+}
+
+func TestBalanceAfterRemoval(t *testing.T) {
+	tests := []struct {
+		name            string
+		insertKeys      []string
+		removeKey       string
+		expectedBalance int
+	}{
+		{
+			name:            "balance after removing right node",
+			insertKeys:      []string{"B", "A", "D", "C", "E"},
+			removeKey:       "E",
+			expectedBalance: 0,
+		},
+		{
+			name:            "balance after removing left node",
+			insertKeys:      []string{"D", "B", "E", "A", "C"},
+			removeKey:       "A",
+			expectedBalance: 0,
+		},
+		{
+			name:            "ensure no lean after removal",
+			insertKeys:      []string{"C", "B", "E", "A", "D", "F"},
+			removeKey:       "F",
+			expectedBalance: -1,
+		},
+		{
+			name:            "descending order insert, remove middle node",
+			insertKeys:      []string{"E", "D", "C", "B", "A"},
+			removeKey:       "C",
+			expectedBalance: 0,
+		},
+		{
+			name:            "ascending order insert, remove middle node",
+			insertKeys:      []string{"A", "B", "C", "D", "E"},
+			removeKey:       "C",
+			expectedBalance: 0,
+		},
+		{
+			name:            "duplicate key insert, remove the duplicated key",
+			insertKeys:      []string{"C", "B", "C", "A", "D"},
+			removeKey:       "C",
+			expectedBalance: 1,
+		},
+		{
+			name:            "complex rotation case",
+			insertKeys:      []string{"H", "B", "A", "C", "E", "D", "F", "G"},
+			removeKey:       "B",
+			expectedBalance: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tree *Node
+			for _, key := range tt.insertKeys {
+				tree, _ = tree.Set(key, nil)
+			}
+
+			tree, _, _, _ = tree.Remove(tt.removeKey)
+
+			balance := tree.calcBalance()
+			if balance != tt.expectedBalance {
+				t.Errorf("Expected balance factor %d, got %d", tt.expectedBalance, balance)
+			}
+
+			if balance < -1 || balance > 1 {
+				t.Errorf("Tree is unbalanced with factor %d", balance)
+			}
+
+			if errMsg := checkSubtreeBalance(t, tree); errMsg != "" {
+				t.Errorf("AVL property violation after removal: %s", errMsg)
+			}
+		})
+	}
+}
+
+func TestBSTProperty(t *testing.T) {
+	var tree *Node
+	keys := []string{"D", "B", "F", "A", "C", "E", "G"}
+	for _, key := range keys {
+		tree, _ = tree.Set(key, nil)
+	}
+
+	var result []string
+	inorderTraversal(t, tree, &result)
+
+	for i := 1; i < len(result); i++ {
+		if result[i] < result[i-1] {
+			t.Errorf("BST property violated: %s < %s (index %d)",
+				result[i], result[i-1], i)
+		}
+	}
+}
+
+// inorderTraversal performs an inorder traversal of the tree and returns the keys in a list.
+func inorderTraversal(t *testing.T, node *Node, result *[]string) {
+	t.Helper()
+
+	if node == nil {
+		return
+	}
+	// leaf
+	if node.height == 0 {
+		*result = append(*result, node.key)
+		return
+	}
+	inorderTraversal(t, node.leftNode, result)
+	inorderTraversal(t, node.rightNode, result)
+}
+
+// checkSubtreeBalance checks if all nodes under the given node satisfy the AVL tree conditions.
+// The balance factor of all nodes must be ∈ [-1, +1]
+func checkSubtreeBalance(t *testing.T, node *Node) string {
+	t.Helper()
+
+	if node == nil {
+		return ""
+	}
+
+	if node.IsLeaf() {
+		// leaf node must be height=0, size=1
+		if node.height != 0 {
+			return ufmt.Sprintf("Leaf node %s has height %d, expected 0", node.Key(), node.height)
+		}
+		if node.size != 1 {
+			return ufmt.Sprintf("Leaf node %s has size %d, expected 1", node.Key(), node.size)
+		}
+		return ""
+	}
+
+	// check balance factor for current node
+	balanceFactor := node.calcBalance()
+	if balanceFactor < -1 || balanceFactor > 1 {
+		return ufmt.Sprintf("Node %s is unbalanced: balanceFactor=%d", node.Key(), balanceFactor)
+	}
+
+	// check height / size relationship for children
+	left, right := node.getLeftNode(), node.getRightNode()
+	expectedHeight := maxInt8(left.height, right.height) + 1
+	if node.height != expectedHeight {
+		return ufmt.Sprintf("Node %s has incorrect height %d, expected %d", node.Key(), node.height, expectedHeight)
+	}
+	expectedSize := left.Size() + right.Size()
+	if node.size != expectedSize {
+		return ufmt.Sprintf("Node %s has incorrect size %d, expected %d", node.Key(), node.size, expectedSize)
+	}
+
+	// recursively check the left/right subtree
+	if errMsg := checkSubtreeBalance(t, left); errMsg != "" {
+		return errMsg
+	}
+	if errMsg := checkSubtreeBalance(t, right); errMsg != "" {
+		return errMsg
+	}
+
+	return ""
+}
+
+func slicesEqual(w1, w2 []string) bool {
+	if len(w1) != len(w2) {
+		return false
+	}
+	for i := 0; i < len(w1); i++ {
+		if w1[i] != w2[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func reverseSlice(ss []string) {
+	for i := 0; i < len(ss)/2; i++ {
+		j := len(ss) - 1 - i
+		ss[i], ss[j] = ss[j], ss[i]
+	}
+}

--- a/vendored/gno.land/p/samcrew/avl/pager/gnomod.toml
+++ b/vendored/gno.land/p/samcrew/avl/pager/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/samcrew/avl/pager"
+gno = "0.9"

--- a/vendored/gno.land/p/samcrew/avl/pager/pager.gno
+++ b/vendored/gno.land/p/samcrew/avl/pager/pager.gno
@@ -1,0 +1,228 @@
+package pager
+
+import (
+	"math"
+	"net/url"
+	"strconv"
+
+	"gno.land/p/samcrew/avl/rotree"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// Pager is a struct that holds the AVL tree and pagination parameters.
+type Pager struct {
+	Tree            rotree.IReadOnlyTree
+	PageQueryParam  string
+	SizeQueryParam  string
+	DefaultPageSize int
+	Reversed        bool
+}
+
+// Page represents a single page of results.
+type Page struct {
+	Items      []Item
+	PageNumber int
+	PageSize   int
+	TotalItems int
+	TotalPages int
+	HasPrev    bool
+	HasNext    bool
+	Pager      *Pager // Reference to the parent Pager
+}
+
+// Item represents a key-value pair in the AVL tree.
+type Item struct {
+	Key   string
+	Value any
+}
+
+// NewPager creates a new Pager with default values.
+func NewPager(tree rotree.IReadOnlyTree, defaultPageSize int, reversed bool) *Pager {
+	return &Pager{
+		Tree:            tree,
+		PageQueryParam:  "page",
+		SizeQueryParam:  "size",
+		DefaultPageSize: defaultPageSize,
+		Reversed:        reversed,
+	}
+}
+
+// GetPage retrieves a page of results from the AVL tree.
+func (p *Pager) GetPage(pageNumber int) *Page {
+	return p.GetPageWithSize(pageNumber, p.DefaultPageSize)
+}
+
+func (p *Pager) GetPageWithSize(pageNumber, pageSize int) *Page {
+	totalItems := p.Tree.Size()
+	totalPages := int(math.Ceil(float64(totalItems) / float64(pageSize)))
+
+	page := &Page{
+		TotalItems: totalItems,
+		TotalPages: totalPages,
+		PageSize:   pageSize,
+		Pager:      p,
+	}
+
+	// pages without content
+	if pageSize < 1 {
+		return page
+	}
+
+	// page number provided is not available
+	if pageNumber < 1 {
+		page.HasNext = totalPages > 0
+		return page
+	}
+
+	// page number provided is outside the range of total pages
+	if pageNumber > totalPages {
+		page.PageNumber = pageNumber
+		page.HasPrev = pageNumber > 0
+		return page
+	}
+
+	startIndex := (pageNumber - 1) * pageSize
+	endIndex := startIndex + pageSize
+	if endIndex > totalItems {
+		endIndex = totalItems
+	}
+
+	items := []Item{}
+
+	if p.Reversed {
+		p.Tree.ReverseIterateByOffset(startIndex, endIndex-startIndex, func(key string, value any) bool {
+			items = append(items, Item{Key: key, Value: value})
+			return false
+		})
+	} else {
+		p.Tree.IterateByOffset(startIndex, endIndex-startIndex, func(key string, value any) bool {
+			items = append(items, Item{Key: key, Value: value})
+			return false
+		})
+	}
+
+	page.Items = items
+	page.PageNumber = pageNumber
+	page.HasPrev = pageNumber > 1
+	page.HasNext = pageNumber < totalPages
+	return page
+}
+
+func (p *Pager) MustGetPageByPath(rawURL string) *Page {
+	page, err := p.GetPageByPath(rawURL)
+	if err != nil {
+		panic("invalid path")
+	}
+	return page
+}
+
+// GetPageByPath retrieves a page of results based on the query parameters in the URL path.
+func (p *Pager) GetPageByPath(rawURL string) (*Page, error) {
+	pageNumber, pageSize, err := p.ParseQuery(rawURL)
+	if err != nil {
+		return nil, err
+	}
+	return p.GetPageWithSize(pageNumber, pageSize), nil
+}
+
+// Picker generates the Markdown UI for the page Picker
+func (p *Page) Picker(path string) string {
+	pageNumber := p.PageNumber
+	pageNumber = max(pageNumber, 1)
+
+	if p.TotalPages <= 1 {
+		return ""
+	}
+
+	u, _ := url.Parse(path)
+	query := u.Query()
+
+	// Remove existing page query parameter
+	query.Del(p.Pager.PageQueryParam)
+
+	// Encode remaining query parameters
+	baseQuery := query.Encode()
+	if baseQuery != "" {
+		baseQuery = "&" + baseQuery
+	}
+	md := ""
+
+	if p.HasPrev {
+		md += ufmt.Sprintf("[%d](?%s=%d%s) | ", 1, p.Pager.PageQueryParam, 1, baseQuery)
+
+		if p.PageNumber > 4 {
+			md += "… | "
+		}
+
+		if p.PageNumber > 3 {
+			md += ufmt.Sprintf("[%d](?%s=%d%s) | ", p.PageNumber-2, p.Pager.PageQueryParam, p.PageNumber-2, baseQuery)
+		}
+
+		if p.PageNumber > 2 {
+			md += ufmt.Sprintf("[%d](?%s=%d%s) | ", p.PageNumber-1, p.Pager.PageQueryParam, p.PageNumber-1, baseQuery)
+		}
+	}
+
+	if p.PageNumber > 0 && p.PageNumber <= p.TotalPages {
+		md += ufmt.Sprintf("**%d**", p.PageNumber)
+	} else {
+		md += ufmt.Sprintf("_%d_", p.PageNumber)
+	}
+
+	if p.HasNext {
+		if p.PageNumber < p.TotalPages-1 {
+			md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.PageNumber+1, p.Pager.PageQueryParam, p.PageNumber+1, baseQuery)
+		}
+
+		if p.PageNumber < p.TotalPages-2 {
+			md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.PageNumber+2, p.Pager.PageQueryParam, p.PageNumber+2, baseQuery)
+		}
+
+		if p.PageNumber < p.TotalPages-3 {
+			md += " | …"
+		}
+
+		md += ufmt.Sprintf(" | [%d](?%s=%d%s)", p.TotalPages, p.Pager.PageQueryParam, p.TotalPages, baseQuery)
+	}
+
+	return md
+}
+
+// ParseQuery parses the URL to extract the page number and page size.
+func (p *Pager) ParseQuery(rawURL string) (int, int, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return 1, p.DefaultPageSize, err
+	}
+
+	query := u.Query()
+	pageNumber := 1
+	pageSize := p.DefaultPageSize
+
+	if p.PageQueryParam != "" {
+		if pageStr := query.Get(p.PageQueryParam); pageStr != "" {
+			pageNumber, err = strconv.Atoi(pageStr)
+			if err != nil || pageNumber < 1 {
+				pageNumber = 1
+			}
+		}
+	}
+
+	if p.SizeQueryParam != "" {
+		if sizeStr := query.Get(p.SizeQueryParam); sizeStr != "" {
+			pageSize, err = strconv.Atoi(sizeStr)
+			if err != nil || pageSize < 1 {
+				pageSize = p.DefaultPageSize
+			}
+		}
+	}
+
+	return pageNumber, pageSize, nil
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/vendored/gno.land/p/samcrew/avl/pager/pager_test.gno
+++ b/vendored/gno.land/p/samcrew/avl/pager/pager_test.gno
@@ -1,0 +1,281 @@
+package pager
+
+import (
+	"testing"
+
+	"gno.land/p/samcrew/avl"
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/nt/ufmt/v0"
+	"gno.land/p/nt/urequire/v0"
+)
+
+func TestPager_GetPage(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	t.Run("normal ordering", func(t *testing.T) {
+		// Create a new pager.
+		pager := NewPager(tree, 10, false)
+
+		// Define test cases.
+		tests := []struct {
+			pageNumber int
+			pageSize   int
+			expected   []Item
+		}{
+			{1, 2, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}}},
+			{2, 2, []Item{{Key: "c", Value: 3}, {Key: "d", Value: 4}}},
+			{3, 2, []Item{{Key: "e", Value: 5}}},
+			{1, 3, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}, {Key: "c", Value: 3}}},
+			{2, 3, []Item{{Key: "d", Value: 4}, {Key: "e", Value: 5}}},
+			{1, 5, []Item{{Key: "a", Value: 1}, {Key: "b", Value: 2}, {Key: "c", Value: 3}, {Key: "d", Value: 4}, {Key: "e", Value: 5}}},
+			{2, 5, []Item{}},
+		}
+
+		for _, tt := range tests {
+			page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+			uassert.Equal(t, len(tt.expected), len(page.Items))
+
+			for i, item := range page.Items {
+				uassert.Equal(t, tt.expected[i].Key, item.Key)
+				uassert.Equal(t, tt.expected[i].Value, item.Value)
+			}
+		}
+	})
+
+	t.Run("reversed ordering", func(t *testing.T) {
+		// Create a new pager.
+		pager := NewPager(tree, 10, true)
+
+		// Define test cases.
+		tests := []struct {
+			pageNumber int
+			pageSize   int
+			expected   []Item
+		}{
+			{1, 2, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}}},
+			{2, 2, []Item{{Key: "c", Value: 3}, {Key: "b", Value: 2}}},
+			{3, 2, []Item{{Key: "a", Value: 1}}},
+			{1, 3, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}, {Key: "c", Value: 3}}},
+			{2, 3, []Item{{Key: "b", Value: 2}, {Key: "a", Value: 1}}},
+			{1, 5, []Item{{Key: "e", Value: 5}, {Key: "d", Value: 4}, {Key: "c", Value: 3}, {Key: "b", Value: 2}, {Key: "a", Value: 1}}},
+			{2, 5, []Item{}},
+		}
+
+		for _, tt := range tests {
+			page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+			uassert.Equal(t, len(tt.expected), len(page.Items))
+
+			for i, item := range page.Items {
+				uassert.Equal(t, tt.expected[i].Key, item.Key)
+				uassert.Equal(t, tt.expected[i].Value, item.Value)
+			}
+		}
+	})
+}
+
+func TestPager_GetPageByPath(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	for i := 0; i < 50; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		rawURL       string
+		expectedPage int
+		expectedSize int
+	}{
+		{"/r/foo:bar/baz?size=10&page=1", 1, 10},
+		{"/r/foo:bar/baz?size=10&page=2", 2, 10},
+		{"/r/foo:bar/baz?page=3", 3, pager.DefaultPageSize},
+		{"/r/foo:bar/baz?size=20", 1, 20},
+		{"/r/foo:bar/baz", 1, pager.DefaultPageSize},
+	}
+
+	for _, tt := range tests {
+		page, err := pager.GetPageByPath(tt.rawURL)
+		urequire.NoError(t, err, ufmt.Sprintf("GetPageByPath(%s) returned error: %v", tt.rawURL, err))
+
+		uassert.Equal(t, tt.expectedPage, page.PageNumber)
+		uassert.Equal(t, tt.expectedSize, page.PageSize)
+	}
+}
+
+func TestPage_Picker(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		pageNumber int
+		pageSize   int
+		path       string
+		expected   string
+	}{
+		{1, 2, "/test", "**1** | [2](?page=2) | [3](?page=3)"},
+		{2, 2, "/test", "[1](?page=1) | **2** | [3](?page=3)"},
+		{3, 2, "/test", "[1](?page=1) | [2](?page=2) | **3**"},
+		{1, 2, "/test?foo=bar", "**1** | [2](?page=2&foo=bar) | [3](?page=3&foo=bar)"},
+	}
+
+	for _, tt := range tests {
+		page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+		ui := page.Picker(tt.path)
+		uassert.Equal(t, tt.expected, ui)
+	}
+}
+
+func TestPager_UI_WithManyPages(t *testing.T) {
+	// Create a new AVL tree and populate it with many key-value pairs.
+	tree := avl.NewTree()
+	for i := 0; i < 100; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases for a large number of pages.
+	tests := []struct {
+		pageNumber int
+		pageSize   int
+		path       string
+		expected   string
+	}{
+		{1, 10, "/test", "**1** | [2](?page=2) | [3](?page=3) | … | [10](?page=10)"},
+		{2, 10, "/test", "[1](?page=1) | **2** | [3](?page=3) | [4](?page=4) | … | [10](?page=10)"},
+		{3, 10, "/test", "[1](?page=1) | [2](?page=2) | **3** | [4](?page=4) | [5](?page=5) | … | [10](?page=10)"},
+		{4, 10, "/test", "[1](?page=1) | [2](?page=2) | [3](?page=3) | **4** | [5](?page=5) | [6](?page=6) | … | [10](?page=10)"},
+		{5, 10, "/test", "[1](?page=1) | … | [3](?page=3) | [4](?page=4) | **5** | [6](?page=6) | [7](?page=7) | … | [10](?page=10)"},
+		{6, 10, "/test", "[1](?page=1) | … | [4](?page=4) | [5](?page=5) | **6** | [7](?page=7) | [8](?page=8) | … | [10](?page=10)"},
+		{7, 10, "/test", "[1](?page=1) | … | [5](?page=5) | [6](?page=6) | **7** | [8](?page=8) | [9](?page=9) | [10](?page=10)"},
+		{8, 10, "/test", "[1](?page=1) | … | [6](?page=6) | [7](?page=7) | **8** | [9](?page=9) | [10](?page=10)"},
+		{9, 10, "/test", "[1](?page=1) | … | [7](?page=7) | [8](?page=8) | **9** | [10](?page=10)"},
+		{10, 10, "/test", "[1](?page=1) | … | [8](?page=8) | [9](?page=9) | **10**"},
+	}
+
+	for _, tt := range tests {
+		page := pager.GetPageWithSize(tt.pageNumber, tt.pageSize)
+
+		ui := page.Picker(tt.path)
+		uassert.Equal(t, tt.expected, ui)
+	}
+}
+
+func TestPager_ParseQuery(t *testing.T) {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	tree := avl.NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// Create a new pager.
+	pager := NewPager(tree, 10, false)
+
+	// Define test cases.
+	tests := []struct {
+		rawURL        string
+		expectedPage  int
+		expectedSize  int
+		expectedError bool
+	}{
+		{"/r/foo:bar/baz?size=2&page=1", 1, 2, false},
+		{"/r/foo:bar/baz?size=3&page=2", 2, 3, false},
+		{"/r/foo:bar/baz?size=5&page=3", 3, 5, false},
+		{"/r/foo:bar/baz?page=2", 2, pager.DefaultPageSize, false},
+		{"/r/foo:bar/baz?size=3", 1, 3, false},
+		{"/r/foo:bar/baz", 1, pager.DefaultPageSize, false},
+		{"/r/foo:bar/baz?size=0&page=0", 1, pager.DefaultPageSize, false},
+	}
+
+	for _, tt := range tests {
+		page, size, err := pager.ParseQuery(tt.rawURL)
+		if tt.expectedError {
+			uassert.Error(t, err, ufmt.Sprintf("ParseQuery(%s) expected error but got none", tt.rawURL))
+		} else {
+			urequire.NoError(t, err, ufmt.Sprintf("ParseQuery(%s) returned error: %v", tt.rawURL, err))
+			uassert.Equal(t, tt.expectedPage, page, ufmt.Sprintf("ParseQuery(%s) returned page %d, expected %d", tt.rawURL, page, tt.expectedPage))
+			uassert.Equal(t, tt.expectedSize, size, ufmt.Sprintf("ParseQuery(%s) returned size %d, expected %d", tt.rawURL, size, tt.expectedSize))
+		}
+	}
+}
+
+func TestPage_PickerQueryParamPreservation(t *testing.T) {
+	tree := avl.NewTree()
+	for i := 1; i <= 6; i++ {
+		tree.Set(ufmt.Sprintf("key%d", i), i)
+	}
+
+	pager := NewPager(tree, 2, false)
+
+	tests := []struct {
+		name       string
+		pageNumber int
+		path       string
+		expected   string
+	}{
+		{
+			name:       "single query param",
+			pageNumber: 1,
+			path:       "/test?foo=bar",
+			expected:   "**1** | [2](?page=2&foo=bar) | [3](?page=3&foo=bar)",
+		},
+		{
+			name:       "multiple query params",
+			pageNumber: 2,
+			path:       "/test?foo=bar&baz=qux",
+			expected:   "[1](?page=1&baz=qux&foo=bar) | **2** | [3](?page=3&baz=qux&foo=bar)",
+		},
+		{
+			name:       "overwrite existing page param",
+			pageNumber: 1,
+			path:       "/test?param1=value1&page=999&param2=value2",
+			expected:   "**1** | [2](?page=2&param1=value1&param2=value2) | [3](?page=3&param1=value1&param2=value2)",
+		},
+		{
+			name:       "empty query string",
+			pageNumber: 2,
+			path:       "/test",
+			expected:   "[1](?page=1) | **2** | [3](?page=3)",
+		},
+		{
+			name:       "query string with only page param",
+			pageNumber: 2,
+			path:       "/test?page=2",
+			expected:   "[1](?page=1) | **2** | [3](?page=3)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			page := pager.GetPageWithSize(tt.pageNumber, 2)
+			result := page.Picker(tt.path)
+			if result != tt.expected {
+				t.Errorf("\nwant: %s\ngot:  %s", tt.expected, result)
+			}
+		})
+	}
+}

--- a/vendored/gno.land/p/samcrew/avl/pager/z_filetest.gno
+++ b/vendored/gno.land/p/samcrew/avl/pager/z_filetest.gno
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"gno.land/p/samcrew/avl"
+	"gno.land/p/samcrew/avl/pager"
+	"gno.land/p/nt/seqid/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+func main() {
+	// Create a new AVL tree and populate it with some key-value pairs.
+	var id seqid.ID
+	tree := avl.NewTree()
+	for i := 0; i < 42; i++ {
+		tree.Set(id.Next().String(), i)
+	}
+
+	// Create a new pager.
+	pager := pager.NewPager(tree, 7, false)
+
+	for pn := -1; pn < 8; pn++ {
+		page := pager.GetPage(pn)
+
+		println(ufmt.Sprintf("## Page %d of %d", page.PageNumber, page.TotalPages))
+		for idx, item := range page.Items {
+			println(ufmt.Sprintf("- idx=%d key=%s value=%d", idx, item.Key, item.Value))
+		}
+		println(page.Picker("/"))
+		println()
+	}
+}
+
+// Output:
+// ## Page 0 of 6
+// _0_ | [1](?page=1) | [2](?page=2) | … | [6](?page=6)
+//
+// ## Page 0 of 6
+// _0_ | [1](?page=1) | [2](?page=2) | … | [6](?page=6)
+//
+// ## Page 1 of 6
+// - idx=0 key=0000001 value=0
+// - idx=1 key=0000002 value=1
+// - idx=2 key=0000003 value=2
+// - idx=3 key=0000004 value=3
+// - idx=4 key=0000005 value=4
+// - idx=5 key=0000006 value=5
+// - idx=6 key=0000007 value=6
+// **1** | [2](?page=2) | [3](?page=3) | … | [6](?page=6)
+//
+// ## Page 2 of 6
+// - idx=0 key=0000008 value=7
+// - idx=1 key=0000009 value=8
+// - idx=2 key=000000a value=9
+// - idx=3 key=000000b value=10
+// - idx=4 key=000000c value=11
+// - idx=5 key=000000d value=12
+// - idx=6 key=000000e value=13
+// [1](?page=1) | **2** | [3](?page=3) | [4](?page=4) | … | [6](?page=6)
+//
+// ## Page 3 of 6
+// - idx=0 key=000000f value=14
+// - idx=1 key=000000g value=15
+// - idx=2 key=000000h value=16
+// - idx=3 key=000000j value=17
+// - idx=4 key=000000k value=18
+// - idx=5 key=000000m value=19
+// - idx=6 key=000000n value=20
+// [1](?page=1) | [2](?page=2) | **3** | [4](?page=4) | [5](?page=5) | [6](?page=6)
+//
+// ## Page 4 of 6
+// - idx=0 key=000000p value=21
+// - idx=1 key=000000q value=22
+// - idx=2 key=000000r value=23
+// - idx=3 key=000000s value=24
+// - idx=4 key=000000t value=25
+// - idx=5 key=000000v value=26
+// - idx=6 key=000000w value=27
+// [1](?page=1) | [2](?page=2) | [3](?page=3) | **4** | [5](?page=5) | [6](?page=6)
+//
+// ## Page 5 of 6
+// - idx=0 key=000000x value=28
+// - idx=1 key=000000y value=29
+// - idx=2 key=000000z value=30
+// - idx=3 key=0000010 value=31
+// - idx=4 key=0000011 value=32
+// - idx=5 key=0000012 value=33
+// - idx=6 key=0000013 value=34
+// [1](?page=1) | … | [3](?page=3) | [4](?page=4) | **5** | [6](?page=6)
+//
+// ## Page 6 of 6
+// - idx=0 key=0000014 value=35
+// - idx=1 key=0000015 value=36
+// - idx=2 key=0000016 value=37
+// - idx=3 key=0000017 value=38
+// - idx=4 key=0000018 value=39
+// - idx=5 key=0000019 value=40
+// - idx=6 key=000001a value=41
+// [1](?page=1) | … | [4](?page=4) | [5](?page=5) | **6**
+//
+// ## Page 7 of 6
+// [1](?page=1) | … | [5](?page=5) | [6](?page=6) | _7_
+//

--- a/vendored/gno.land/p/samcrew/avl/rotree/gnomod.toml
+++ b/vendored/gno.land/p/samcrew/avl/rotree/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/samcrew/avl/rotree"
+gno = "0.9"

--- a/vendored/gno.land/p/samcrew/avl/rotree/rotree.gno
+++ b/vendored/gno.land/p/samcrew/avl/rotree/rotree.gno
@@ -1,0 +1,177 @@
+// Package rotree provides a read-only wrapper for avl.Tree with safe value transformation.
+//
+// It is useful when you want to expose a read-only view of a tree while ensuring that
+// the sensitive data cannot be modified.
+//
+// Example:
+//
+//	// Define a user structure with sensitive data
+//	type User struct {
+//		Name     string
+//		Balance  int
+//		Internal string // sensitive field
+//	}
+//
+//	// Create and populate the original tree
+//	privateTree := avl.NewTree()
+//	privateTree.Set("alice", &User{
+//		Name:     "Alice",
+//		Balance:  100,
+//		Internal: "sensitive",
+//	})
+//
+//	// Create a safe transformation function that copies the struct
+//	// while excluding sensitive data
+//	makeEntrySafeFn := func(v any) any {
+//		u := v.(*User)
+//		return &User{
+//			Name:     u.Name,
+//			Balance:  u.Balance,
+//			Internal: "", // omit sensitive data
+//		}
+//	}
+//
+//	// Create a read-only view of the tree
+//	PublicTree := rotree.Wrap(tree, makeEntrySafeFn)
+//
+//	// Safely access the data
+//	value, _ := roTree.Get("alice")
+//	user := value.(*User)
+//	// user.Name == "Alice"
+//	// user.Balance == 100
+//	// user.Internal == "" (sensitive data is filtered)
+package rotree
+
+import (
+	"gno.land/p/samcrew/avl"
+)
+
+// Wrap creates a new ReadOnlyTree from an existing avl.Tree and a safety transformation function.
+// If makeEntrySafeFn is nil, values will be returned as-is without transformation.
+//
+// makeEntrySafeFn is a function that transforms a tree entry into a safe version that can be exposed to external users.
+// This function should be implemented based on the specific safety requirements of your use case:
+//
+//  1. No-op transformation: For primitive types (int, string, etc.) or already safe objects,
+//     simply pass nil as the makeEntrySafeFn to return values as-is.
+//
+//  2. Defensive copying: For mutable types like slices or maps, you should create a deep copy
+//     to prevent modification of the original data.
+//     Example: func(v any) any { return append([]int{}, v.([]int)...) }
+//
+//  3. Read-only wrapper: Return a read-only version of the object that implements
+//     a limited interface.
+//     Example: func(v any) any { return NewReadOnlyObject(v) }
+//
+//  4. DAO transformation: Transform the object into a data access object that
+//     controls how the underlying data can be accessed.
+//     Example: func(v any) any { return NewDAO(v) }
+//
+// The function ensures that the returned object is safe to expose to untrusted code,
+// preventing unauthorized modifications to the original data structure.
+func Wrap(tree *avl.Tree, makeEntrySafeFn func(any) any) *ReadOnlyTree {
+	return &ReadOnlyTree{
+		tree:            tree,
+		makeEntrySafeFn: makeEntrySafeFn,
+	}
+}
+
+// ReadOnlyTree wraps an avl.Tree and provides read-only access.
+type ReadOnlyTree struct {
+	tree            *avl.Tree
+	makeEntrySafeFn func(any) any
+}
+
+// IReadOnlyTree defines the read-only operations available on a tree.
+type IReadOnlyTree interface {
+	Size() int
+	Has(key string) bool
+	Get(key string) (any, bool)
+	GetByIndex(index int) (string, any)
+	Iterate(start, end string, cb avl.IterCbFn) bool
+	ReverseIterate(start, end string, cb avl.IterCbFn) bool
+	IterateByOffset(offset int, count int, cb avl.IterCbFn) bool
+	ReverseIterateByOffset(offset int, count int, cb avl.IterCbFn) bool
+}
+
+// Verify that ReadOnlyTree implements both ITree and IReadOnlyTree
+var (
+	_ avl.ITree     = (*ReadOnlyTree)(nil)
+	_ IReadOnlyTree = (*ReadOnlyTree)(nil)
+)
+
+// getSafeValue applies the makeEntrySafeFn if it exists, otherwise returns the original value
+func (roTree *ReadOnlyTree) getSafeValue(value any) any {
+	if roTree.makeEntrySafeFn == nil {
+		return value
+	}
+	return roTree.makeEntrySafeFn(value)
+}
+
+// Size returns the number of key-value pairs in the tree.
+func (roTree *ReadOnlyTree) Size() int {
+	return roTree.tree.Size()
+}
+
+// Has checks whether a key exists in the tree.
+func (roTree *ReadOnlyTree) Has(key string) bool {
+	return roTree.tree.Has(key)
+}
+
+// Get retrieves the value associated with the given key, converted to a safe format.
+func (roTree *ReadOnlyTree) Get(key string) (any, bool) {
+	value, exists := roTree.tree.Get(key)
+	if !exists {
+		return nil, false
+	}
+	return roTree.getSafeValue(value), true
+}
+
+// GetByIndex retrieves the key-value pair at the specified index in the tree, with the value converted to a safe format.
+func (roTree *ReadOnlyTree) GetByIndex(index int) (string, any) {
+	key, value := roTree.tree.GetByIndex(index)
+	return key, roTree.getSafeValue(value)
+}
+
+// Iterate performs an in-order traversal of the tree within the specified key range.
+func (roTree *ReadOnlyTree) Iterate(start, end string, cb avl.IterCbFn) bool {
+	return roTree.tree.Iterate(start, end, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// ReverseIterate performs a reverse in-order traversal of the tree within the specified key range.
+func (roTree *ReadOnlyTree) ReverseIterate(start, end string, cb avl.IterCbFn) bool {
+	return roTree.tree.ReverseIterate(start, end, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// IterateByOffset performs an in-order traversal of the tree starting from the specified offset.
+func (roTree *ReadOnlyTree) IterateByOffset(offset int, count int, cb avl.IterCbFn) bool {
+	return roTree.tree.IterateByOffset(offset, count, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// ReverseIterateByOffset performs a reverse in-order traversal of the tree starting from the specified offset.
+func (roTree *ReadOnlyTree) ReverseIterateByOffset(offset int, count int, cb avl.IterCbFn) bool {
+	return roTree.tree.ReverseIterateByOffset(offset, count, func(key string, value any) bool {
+		return cb(key, roTree.getSafeValue(value))
+	})
+}
+
+// Set is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) Set(key string, value any) bool {
+	panic("Set operation not supported on ReadOnlyTree")
+}
+
+// Remove is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) Remove(key string) (value any, removed bool) {
+	panic("Remove operation not supported on ReadOnlyTree")
+}
+
+// RemoveByIndex is not supported on ReadOnlyTree and will panic.
+func (roTree *ReadOnlyTree) RemoveByIndex(index int) (key string, value any) {
+	panic("RemoveByIndex operation not supported on ReadOnlyTree")
+}

--- a/vendored/gno.land/p/samcrew/avl/rotree/rotree_test.gno
+++ b/vendored/gno.land/p/samcrew/avl/rotree/rotree_test.gno
@@ -1,0 +1,222 @@
+package rotree
+
+import (
+	"testing"
+
+	"gno.land/p/samcrew/avl"
+)
+
+func TestExample(t *testing.T) {
+	// User represents our internal data structure
+	type User struct {
+		ID       string
+		Name     string
+		Balance  int
+		Internal string // sensitive internal data
+	}
+
+	// Create and populate the original tree with user pointers
+	tree := avl.NewTree()
+	tree.Set("alice", &User{
+		ID:       "1",
+		Name:     "Alice",
+		Balance:  100,
+		Internal: "sensitive_data_1",
+	})
+	tree.Set("bob", &User{
+		ID:       "2",
+		Name:     "Bob",
+		Balance:  200,
+		Internal: "sensitive_data_2",
+	})
+
+	// Define a makeEntrySafeFn that:
+	// 1. Creates a defensive copy of the User struct
+	// 2. Omits sensitive internal data
+	makeEntrySafeFn := func(v any) any {
+		originalUser := v.(*User)
+		return &User{
+			ID:       originalUser.ID,
+			Name:     originalUser.Name,
+			Balance:  originalUser.Balance,
+			Internal: "", // Omit sensitive data
+		}
+	}
+
+	// Create a read-only view of the tree
+	roTree := Wrap(tree, makeEntrySafeFn)
+
+	// Test retrieving and verifying a user
+	t.Run("Get User", func(t *testing.T) {
+		// Get user from read-only tree
+		value, exists := roTree.Get("alice")
+		if !exists {
+			t.Fatal("User 'alice' not found")
+		}
+
+		user := value.(*User)
+
+		// Verify user data is correct
+		if user.Name != "Alice" || user.Balance != 100 {
+			t.Errorf("Unexpected user data: got name=%s balance=%d", user.Name, user.Balance)
+		}
+
+		// Verify sensitive data is not exposed
+		if user.Internal != "" {
+			t.Error("Sensitive data should not be exposed")
+		}
+
+		// Verify it's a different instance than the original
+		originalValue, _ := tree.Get("alice")
+		originalUser := originalValue.(*User)
+		if user == originalUser {
+			t.Error("Read-only tree should return a copy, not the original pointer")
+		}
+	})
+
+	// Test iterating over users
+	t.Run("Iterate Users", func(t *testing.T) {
+		count := 0
+		roTree.Iterate("", "", func(key string, value any) bool {
+			user := value.(*User)
+			// Verify each user has empty Internal field
+			if user.Internal != "" {
+				t.Error("Sensitive data exposed during iteration")
+			}
+			count++
+			return false
+		})
+
+		if count != 2 {
+			t.Errorf("Expected 2 users, got %d", count)
+		}
+	})
+
+	// Verify that modifications to the returned user don't affect the original
+	t.Run("Modification Safety", func(t *testing.T) {
+		value, _ := roTree.Get("alice")
+		user := value.(*User)
+
+		// Try to modify the returned user
+		user.Balance = 999
+		user.Internal = "hacked"
+
+		// Verify original is unchanged
+		originalValue, _ := tree.Get("alice")
+		originalUser := originalValue.(*User)
+		if originalUser.Balance != 100 || originalUser.Internal != "sensitive_data_1" {
+			t.Error("Original user data was modified")
+		}
+	})
+}
+
+func TestReadOnlyTree(t *testing.T) {
+	// Example of a makeEntrySafeFn that appends "_readonly" to demonstrate transformation
+	makeEntrySafeFn := func(value any) any {
+		return value.(string) + "_readonly"
+	}
+
+	tree := avl.NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	roTree := Wrap(tree, makeEntrySafeFn)
+
+	tests := []struct {
+		name     string
+		key      string
+		expected any
+		exists   bool
+	}{
+		{"ExistingKey1", "key1", "value1_readonly", true},
+		{"ExistingKey2", "key2", "value2_readonly", true},
+		{"NonExistingKey", "key4", nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, exists := roTree.Get(tt.key)
+			if exists != tt.exists || value != tt.expected {
+				t.Errorf("For key %s, expected %v (exists: %v), got %v (exists: %v)", tt.key, tt.expected, tt.exists, value, exists)
+			}
+		})
+	}
+}
+
+// Add example tests showing different makeEntrySafeFn implementations
+func TestMakeEntrySafeFnVariants(t *testing.T) {
+	tree := avl.NewTree()
+	tree.Set("slice", []int{1, 2, 3})
+	tree.Set("map", map[string]int{"a": 1})
+
+	tests := []struct {
+		name            string
+		makeEntrySafeFn func(any) any
+		key             string
+		validate        func(t *testing.T, value any)
+	}{
+		{
+			name: "Defensive Copy Slice",
+			makeEntrySafeFn: func(v any) any {
+				original := v.([]int)
+				return append([]int{}, original...)
+			},
+			key: "slice",
+			validate: func(t *testing.T, value any) {
+				slice := value.([]int)
+				// Modify the returned slice
+				slice[0] = 999
+				// Verify original is unchanged
+				originalValue, _ := tree.Get("slice")
+				original := originalValue.([]int)
+				if original[0] != 1 {
+					t.Error("Original slice was modified")
+				}
+			},
+		},
+		// Add more test cases for different makeEntrySafeFn implementations
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roTree := Wrap(tree, tt.makeEntrySafeFn)
+			value, exists := roTree.Get(tt.key)
+			if !exists {
+				t.Fatal("Key not found")
+			}
+			tt.validate(t, value)
+		})
+	}
+}
+
+func TestNilMakeEntrySafeFn(t *testing.T) {
+	// Create a tree with some test data
+	tree := avl.NewTree()
+	originalValue := []int{1, 2, 3}
+	tree.Set("test", originalValue)
+
+	// Create a ReadOnlyTree with nil makeEntrySafeFn
+	roTree := Wrap(tree, nil)
+
+	// Test that we get back the original value
+	value, exists := roTree.Get("test")
+	if !exists {
+		t.Fatal("Key not found")
+	}
+
+	// Verify it's the exact same slice (not a copy)
+	retrievedSlice := value.([]int)
+	if &retrievedSlice[0] != &originalValue[0] {
+		t.Error("Expected to get back the original slice reference")
+	}
+
+	// Test through iteration as well
+	roTree.Iterate("", "", func(key string, value any) bool {
+		retrievedSlice := value.([]int)
+		if &retrievedSlice[0] != &originalValue[0] {
+			t.Error("Expected to get back the original slice reference in iteration")
+		}
+		return false
+	})
+}

--- a/vendored/gno.land/p/samcrew/avl/tree.gno
+++ b/vendored/gno.land/p/samcrew/avl/tree.gno
@@ -1,0 +1,124 @@
+package avl
+
+type ITree interface {
+	// read operations
+
+	Size() int
+	Has(key string) bool
+	Get(key string) (value any, exists bool)
+	GetByIndex(index int) (key string, value any)
+	Iterate(start, end string, cb IterCbFn) bool
+	ReverseIterate(start, end string, cb IterCbFn) bool
+	IterateByOffset(offset int, count int, cb IterCbFn) bool
+	ReverseIterateByOffset(offset int, count int, cb IterCbFn) bool
+
+	// write operations
+
+	Set(key string, value any) (updated bool)
+	Remove(key string) (value any, removed bool)
+}
+
+type IterCbFn func(key string, value any) bool
+
+//----------------------------------------
+// Tree
+
+// The zero struct can be used as an empty tree.
+type Tree struct {
+	node *Node
+}
+
+// NewTree creates a new empty AVL tree.
+func NewTree() *Tree {
+	return &Tree{
+		node: nil,
+	}
+}
+
+// Size returns the number of key-value pair in the tree.
+func (tree *Tree) Size() int {
+	return tree.node.Size()
+}
+
+// Has checks whether a key exists in the tree.
+// It returns true if the key exists, otherwise false.
+func (tree *Tree) Has(key string) (has bool) {
+	return tree.node.Has(key)
+}
+
+// Get retrieves the value associated with the given key.
+// It returns the value and a boolean indicating whether the key exists.
+func (tree *Tree) Get(key string) (value any, exists bool) {
+	_, value, exists = tree.node.Get(key)
+	return
+}
+
+// GetByIndex retrieves the key-value pair at the specified index in the tree.
+// It returns the key and value at the given index.
+func (tree *Tree) GetByIndex(index int) (key string, value any) {
+	return tree.node.GetByIndex(index)
+}
+
+// Set inserts a key-value pair into the tree.
+// If the key already exists, the value will be updated.
+// It returns a boolean indicating whether the key was newly inserted or updated.
+func (tree *Tree) Set(key string, value any) (updated bool) {
+	newnode, updated := tree.node.Set(key, value)
+	tree.node = newnode
+	return updated
+}
+
+// Remove removes a key-value pair from the tree.
+// It returns the removed value and a boolean indicating whether the key was found and removed.
+func (tree *Tree) Remove(key string) (value any, removed bool) {
+	newnode, _, value, removed := tree.node.Remove(key)
+	tree.node = newnode
+	return value, removed
+}
+
+// Iterate performs an in-order traversal of the tree within the specified key range.
+// It calls the provided callback function for each key-value pair encountered.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) Iterate(start, end string, cb IterCbFn) bool {
+	return tree.node.TraverseInRange(start, end, true, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// ReverseIterate performs a reverse in-order traversal of the tree within the specified key range.
+// It calls the provided callback function for each key-value pair encountered.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) ReverseIterate(start, end string, cb IterCbFn) bool {
+	return tree.node.TraverseInRange(start, end, false, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// IterateByOffset performs an in-order traversal of the tree starting from the specified offset.
+// It calls the provided callback function for each key-value pair encountered, up to the specified count.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) IterateByOffset(offset int, count int, cb IterCbFn) bool {
+	return tree.node.TraverseByOffset(offset, count, true, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// ReverseIterateByOffset performs a reverse in-order traversal of the tree starting from the specified offset.
+// It calls the provided callback function for each key-value pair encountered, up to the specified count.
+// If the callback returns true, the iteration is stopped.
+func (tree *Tree) ReverseIterateByOffset(offset int, count int, cb IterCbFn) bool {
+	return tree.node.TraverseByOffset(offset, count, false, true,
+		func(node *Node) bool {
+			return cb(node.Key(), node.Value())
+		},
+	)
+}
+
+// Verify that Tree implements TreeInterface
+var _ ITree = (*Tree)(nil)

--- a/vendored/gno.land/p/samcrew/avl/tree_test.gno
+++ b/vendored/gno.land/p/samcrew/avl/tree_test.gno
@@ -1,0 +1,212 @@
+package avl
+
+import "testing"
+
+func TestNewTree(t *testing.T) {
+	tree := NewTree()
+	if tree.node != nil {
+		t.Error("Expected tree.node to be nil")
+	}
+}
+
+func TestTreeSize(t *testing.T) {
+	tree := NewTree()
+	if tree.Size() != 0 {
+		t.Error("Expected empty tree size to be 0")
+	}
+
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	if tree.Size() != 2 {
+		t.Error("Expected tree size to be 2")
+	}
+}
+
+func TestTreeHas(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	if !tree.Has("key1") {
+		t.Error("Expected tree to have key1")
+	}
+
+	if tree.Has("key2") {
+		t.Error("Expected tree to not have key2")
+	}
+}
+
+func TestTreeGet(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	value, exists := tree.Get("key1")
+	if !exists || value != "value1" {
+		t.Error("Expected Get to return value1 and true")
+	}
+
+	_, exists = tree.Get("key2")
+	if exists {
+		t.Error("Expected Get to return false for non-existent key")
+	}
+}
+
+func TestTreeGetByIndex(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+
+	key, value := tree.GetByIndex(0)
+	if key != "key1" || value != "value1" {
+		t.Error("Expected GetByIndex(0) to return key1 and value1")
+	}
+
+	key, value = tree.GetByIndex(1)
+	if key != "key2" || value != "value2" {
+		t.Error("Expected GetByIndex(1) to return key2 and value2")
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected GetByIndex to panic for out-of-range index")
+		}
+	}()
+	tree.GetByIndex(2)
+}
+
+func TestTreeRemove(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+
+	value, removed := tree.Remove("key1")
+	if !removed || value != "value1" || tree.Size() != 0 {
+		t.Error("Expected Remove to remove key-value pair")
+	}
+
+	_, removed = tree.Remove("key2")
+	if removed {
+		t.Error("Expected Remove to return false for non-existent key")
+	}
+}
+
+func TestTreeIterate(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.Iterate("", "", func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key1", "key2", "key3"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterate(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.ReverseIterate("", "", func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key3", "key2", "key1"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeIterateByOffset(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.IterateByOffset(1, 2, func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key2", "key3"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterateByOffset(t *testing.T) {
+	tree := NewTree()
+	tree.Set("key1", "value1")
+	tree.Set("key2", "value2")
+	tree.Set("key3", "value3")
+
+	var keys []string
+	tree.ReverseIterateByOffset(1, 2, func(key string, value any) bool {
+		keys = append(keys, key)
+		return false
+	})
+
+	expectedKeys := []string{"key2", "key1"}
+	if !slicesEqual(keys, expectedKeys) {
+		t.Errorf("Expected keys %v, got %v", expectedKeys, keys)
+	}
+}
+
+func TestTreeReverseIterateByOffsetVaried(t *testing.T) {
+	tree := NewTree()
+	tree.Set("a", 1)
+	tree.Set("b", 2)
+	tree.Set("c", 3)
+	tree.Set("d", 4)
+	tree.Set("e", 5)
+
+	// All keys in reverse: e d c b a
+	cases := []struct {
+		offset int
+		limit  int
+		want   []string
+	}{
+		{0, 5, []string{"e", "d", "c", "b", "a"}},
+		{0, 1, []string{"e"}},
+		{0, 3, []string{"e", "d", "c"}},
+		{1, 2, []string{"d", "c"}},
+		{2, 2, []string{"c", "b"}},
+		{3, 5, []string{"b", "a"}},
+		{4, 1, []string{"a"}},
+		{4, 10, []string{"a"}},
+		{5, 1, nil},
+		{0, 0, nil},
+		{10, 1, nil},
+	}
+
+	for _, tc := range cases {
+		var got []string
+		tree.ReverseIterateByOffset(tc.offset, tc.limit, func(key string, value any) bool {
+			got = append(got, key)
+			return false
+		})
+		if !slicesEqual(got, tc.want) {
+			t.Errorf("ReverseIterateByOffset(%d, %d): got %v, want %v",
+				tc.offset, tc.limit, got, tc.want)
+		}
+	}
+
+	// Early termination: stop after 2 items from offset 1.
+	var got []string
+	tree.ReverseIterateByOffset(1, 5, func(key string, value any) bool {
+		got = append(got, key)
+		return len(got) >= 2
+	})
+	want := []string{"d", "c"}
+	if !slicesEqual(got, want) {
+		t.Errorf("ReverseIterateByOffset early stop: got %v, want %v", got, want)
+	}
+}

--- a/vendored/gno.land/p/samcrew/avl/z_0_filetest.gno
+++ b/vendored/gno.land/p/samcrew/avl/z_0_filetest.gno
@@ -1,0 +1,23 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/samcrew/avl"
+)
+
+var node *avl.Node
+
+func init() {
+	node = avl.NewNode("key0", "value0")
+	// node, _ = node.Set("key0", "value0")
+}
+
+func main(cur realm) {
+	var updated bool
+	node, updated = node.Set("key1", "value1")
+	// println(node, updated)
+	println(updated, node.Size())
+}
+
+// Output:
+// false 2

--- a/vendored/gno.land/p/samcrew/avl/z_1_filetest.gno
+++ b/vendored/gno.land/p/samcrew/avl/z_1_filetest.gno
@@ -1,0 +1,23 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/samcrew/avl"
+)
+
+var node *avl.Node
+
+func init() {
+	node = avl.NewNode("key0", "value0")
+	node, _ = node.Set("key1", "value1")
+}
+
+func main(cur realm) {
+	var updated bool
+	node, updated = node.Set("key2", "value2")
+	// println(node, updated)
+	println(updated, node.Size())
+}
+
+// Output:
+// false 3

--- a/vendored/gno.land/p/samcrew/avl/z_2_filetest.gno
+++ b/vendored/gno.land/p/samcrew/avl/z_2_filetest.gno
@@ -1,0 +1,22 @@
+// PKGPATH: gno.land/r/test
+package test
+
+import (
+	"gno.land/p/samcrew/avl"
+)
+
+var tree avl.Tree
+
+func init() {
+	tree.Set("key0", "value0")
+	tree.Set("key1", "value1")
+}
+
+func main(cur realm) {
+	var updated bool
+	updated = tree.Set("key2", "value2")
+	println(updated, tree.Size())
+}
+
+// Output:
+// false 3

--- a/vendored/gno.land/p/samcrew/piechart/README.md
+++ b/vendored/gno.land/p/samcrew/piechart/README.md
@@ -1,0 +1,41 @@
+# `piechart` - SVG pie charts 
+
+Generate pie charts with legends as SVG markup for gnoweb rendering.
+
+## Usage
+
+```go
+slices := []piechart.PieSlice{
+    {Value: 30, Color: "#ff6b6b", Label: "Frontend"},
+    {Value: 25, Color: "#4ecdc4", Label: "Backend"},
+    {Value: 20, Color: "#45b7d1", Label: "DevOps"},
+    {Value: 15, Color: "#96ceb4", Label: "Mobile"},
+    {Value: 10, Color: "#ffeaa7", Label: "Other"},
+}
+
+// With title
+titledChart := piechart.Render(slices, "Team Distribution")
+
+// Without title  
+untitledChart := piechart.Render(slices, "")
+```
+
+## API Reference
+
+```go
+type PieSlice struct {
+    Value float64 // Numeric value for the slice
+    Color string  // Hex color code (e.g., "#ff6b6b")
+    Label string  // Display label for the slice
+}
+
+// slices: Array of PieSlice structs containing the data
+// title: Chart title (empty string for no title)
+// Returns: SVG markup as a string
+func Render(slices []PieSlice, title string) string
+```
+
+## Live Example
+
+- [/r/docs/charts:piechart](/r/docs/charts:piechart)
+- [/r/samcrew/daodemo/custom_condition:members](/r/samcrew/daodemo/custom_condition:members)

--- a/vendored/gno.land/p/samcrew/piechart/gnomod.toml
+++ b/vendored/gno.land/p/samcrew/piechart/gnomod.toml
@@ -1,0 +1,5 @@
+module = "gno.land/p/samcrew/piechart"
+gno = "0.9"
+
+[addpkg]
+  creator = "g1kfd9f5zlvcvy6aammcmqswa7cyjpu2nyt9qfen"

--- a/vendored/gno.land/p/samcrew/piechart/piechart.gno
+++ b/vendored/gno.land/p/samcrew/piechart/piechart.gno
@@ -1,0 +1,115 @@
+// Package piechart provides functionality to render a pie chart as an SVG image.
+// It takes a list of PieSlice objects, each representing a slice of the pie with a value,
+// color, and label, and generates an SVG representation of the pie chart.
+package piechart
+
+import (
+	"math"
+
+	"gno.land/p/demo/svg"
+	"gno.land/p/nt/ufmt/v0"
+	"gno.land/p/sunspirit/md"
+)
+
+type PieSlice struct {
+	Value float64
+	Color string
+	Label string
+}
+
+// Render creates an SVG pie chart from given slices (value, color and label).
+// It returns an img svg markup as a string, including a markdown header if a non-empty title is provided.
+func Render(slices []PieSlice, title string) string {
+	// Validate input slices length
+	if len(slices) == 0 {
+		return "\npiechart fails: no data provided"
+	}
+
+	const (
+		canvasWidth  = 500
+		canvasHeight = 200
+		centerX      = 100.0
+		centerY      = 100.0
+		radius       = 80.0
+		legendX      = 210
+		legendStartY = 30
+		lineHeight   = 26
+		squareSize   = 16
+		fontSize     = 16
+	)
+
+	canvas := svg.NewCanvas(canvasWidth, canvasHeight)
+
+	// Sum all values to compute slices proportions
+	var total float64
+	for _, s := range slices {
+		total += s.Value
+	}
+
+	// Draw pie slices and legend in one pass
+	startAngle := -math.Pi / 2
+	for i, s := range slices {
+		if s.Value > 0 {
+			// --- PIE SLICE ---
+			// Calculate angle span for current slice
+			angle := (s.Value / total) * 2 * math.Pi
+			endAngle := startAngle + angle
+
+			// Compute start and end points on the circle circumference
+			cosStart, sinStart := math.Cos(startAngle), math.Sin(startAngle)
+			cosEnd, sinEnd := math.Cos(endAngle), math.Sin(endAngle)
+			x1 := centerX + radius*cosStart
+			y1 := centerY + radius*sinStart
+			x2 := centerX + radius*cosEnd
+			y2 := centerY + radius*sinEnd
+
+			// Determine if the arc should be a large arc (> 180 degrees) (Arc direction)
+			largeArcFlag := 0
+			if angle > math.Pi {
+				largeArcFlag = 1
+			}
+
+			// Build the SVG path for the pie slice
+			path := ufmt.Sprintf(
+				"M%.2f,%.2f L%.2f,%.2f A%.2f,%.2f 0 %d 1 %.2f,%.2f Z",
+				centerX, centerY, x1, y1, radius, radius, largeArcFlag, x2, y2,
+			)
+
+			// Colored slice
+			canvas.Append(svg.Path{
+				D:    path,
+				Fill: s.Color,
+			})
+
+			startAngle = endAngle
+		}
+
+		// --- LEGEND ---
+		y := legendStartY + i*lineHeight
+		// Colored square representing slice color
+		canvas.Append(svg.Rectangle{
+			X:      legendX,
+			Y:      y - squareSize/2,
+			Width:  squareSize,
+			Height: squareSize,
+			Fill:   s.Color,
+		})
+
+		// Legend text showing label, value and percentage
+		text := ufmt.Sprintf("%s: %.0f (%.1f%%)", s.Label, s.Value, s.Value*100/total)
+		canvas.Append(svg.Text{
+			X:    legendX + squareSize + 8,
+			Y:    y + fontSize/3,
+			Text: text,
+			Fill: "#54595D",
+			Attr: svg.BaseAttrs{
+				Style: ufmt.Sprintf("font-family:'Inter var',sans-serif;font-size:%dpx;", fontSize),
+			},
+		})
+	}
+
+	if title == "" {
+		return canvas.Render("Pie Chart")
+	}
+	return md.H2(title) + canvas.Render("Pie Chart "+title)
+}

--- a/vendored/gno.land/p/samcrew/piechart/piechart_test.gno
+++ b/vendored/gno.land/p/samcrew/piechart/piechart_test.gno
@@ -1,0 +1,35 @@
+package piechart
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRender(t *testing.T) {
+	title := "Test"
+	slices := []PieSlice{
+		{Value: 10, Color: "#00FF00", Label: "Green"},
+		{Value: 20, Color: "#FFFF00", Label: "Yellow"},
+		{Value: 30, Color: "#FF0000", Label: "Red"},
+	}
+
+	result := Render(slices, title)
+
+	// Check if the result contains the expected image SVG structure
+	if !strings.Contains(result, "data:image/svg+xml;base64,") {
+		t.Errorf("Expected result to contain data:image/svg+xml;base64, got %s", result)
+	}
+
+	// Check if the result contains the title
+	if !strings.Contains(result, title) {
+		t.Errorf("SVG does not contain the title %q", title)
+	}
+
+	// Check if the result contains non-empty slices
+	emptySlices := []PieSlice{}
+	emptyResult := Render(emptySlices, title)
+	expectedErr := "\npiechart fails: no data provided"
+	if emptyResult != expectedErr {
+		t.Errorf("Expected exact error for empty slices: %q, got %q", expectedErr, emptyResult)
+	}
+}

--- a/vendored/gno.land/p/sunspirit/md/gnomod.toml
+++ b/vendored/gno.land/p/sunspirit/md/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/p/sunspirit/md"
+gno = "0.9"

--- a/vendored/gno.land/p/sunspirit/md/md.gno
+++ b/vendored/gno.land/p/sunspirit/md/md.gno
@@ -1,0 +1,179 @@
+package md
+
+import (
+	"strings"
+
+	"gno.land/p/nt/ufmt/v0"
+)
+
+// Builder helps to build a Markdown string from individual elements
+type Builder struct {
+	elements []string
+}
+
+// NewBuilder creates a new Builder instance
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// Add adds a Markdown element to the builder
+func (m *Builder) Add(md ...string) *Builder {
+	m.elements = append(m.elements, md...)
+	return m
+}
+
+// Render returns the final Markdown string joined with the specified separator
+func (m *Builder) Render(separator string) string {
+	return strings.Join(m.elements, separator)
+}
+
+// Bold returns bold text for markdown
+func Bold(text string) string {
+	return ufmt.Sprintf("**%s**", text)
+}
+
+// Italic returns italicized text for markdown
+func Italic(text string) string {
+	return ufmt.Sprintf("*%s*", text)
+}
+
+// Strikethrough returns strikethrough text for markdown
+func Strikethrough(text string) string {
+	return ufmt.Sprintf("~~%s~~", text)
+}
+
+// H1 returns a level 1 header for markdown
+func H1(text string) string {
+	return ufmt.Sprintf("# %s\n", text)
+}
+
+// H2 returns a level 2 header for markdown
+func H2(text string) string {
+	return ufmt.Sprintf("## %s\n", text)
+}
+
+// H3 returns a level 3 header for markdown
+func H3(text string) string {
+	return ufmt.Sprintf("### %s\n", text)
+}
+
+// H4 returns a level 4 header for markdown
+func H4(text string) string {
+	return ufmt.Sprintf("#### %s\n", text)
+}
+
+// H5 returns a level 5 header for markdown
+func H5(text string) string {
+	return ufmt.Sprintf("##### %s\n", text)
+}
+
+// H6 returns a level 6 header for markdown
+func H6(text string) string {
+	return ufmt.Sprintf("###### %s\n", text)
+}
+
+// BulletList returns an bullet list for markdown
+func BulletList(items []string) string {
+	var sb strings.Builder
+	for _, item := range items {
+		sb.WriteString(ufmt.Sprintf("- %s\n", item))
+	}
+	return sb.String()
+}
+
+// OrderedList returns an ordered list for markdown
+func OrderedList(items []string) string {
+	var sb strings.Builder
+	for i, item := range items {
+		sb.WriteString(ufmt.Sprintf("%d. %s\n", i+1, item))
+	}
+	return sb.String()
+}
+
+// TodoList returns a list of todo items with checkboxes for markdown
+func TodoList(items []string, done []bool) string {
+	var sb strings.Builder
+
+	for i, item := range items {
+		checkbox := " "
+		if done[i] {
+			checkbox = "x"
+		}
+		sb.WriteString(ufmt.Sprintf("- [%s] %s\n", checkbox, item))
+	}
+	return sb.String()
+}
+
+// Blockquote returns a blockquote for markdown
+func Blockquote(text string) string {
+	lines := strings.Split(text, "\n")
+	var sb strings.Builder
+	for _, line := range lines {
+		sb.WriteString(ufmt.Sprintf("> %s\n", line))
+	}
+
+	return sb.String()
+}
+
+// InlineCode returns inline code for markdown
+func InlineCode(code string) string {
+	return ufmt.Sprintf("`%s`", code)
+}
+
+// CodeBlock creates a markdown code block
+func CodeBlock(content string) string {
+	return ufmt.Sprintf("```\n%s\n```", content)
+}
+
+// LanguageCodeBlock creates a markdown code block with language-specific syntax highlighting
+func LanguageCodeBlock(language, content string) string {
+	return ufmt.Sprintf("```%s\n%s\n```", language, content)
+}
+
+// LineBreak returns the specified number of line breaks for markdown
+func LineBreak(count uint) string {
+	if count > 0 {
+		return strings.Repeat("\n", int(count)+1)
+	}
+	return ""
+}
+
+// HorizontalRule returns a horizontal rule for markdown
+func HorizontalRule() string {
+	return "---\n"
+}
+
+// Link returns a hyperlink for markdown
+func Link(text, url string) string {
+	return ufmt.Sprintf("[%s](%s)", text, url)
+}
+
+// Image returns an image for markdown
+func Image(altText, url string) string {
+	return ufmt.Sprintf("![%s](%s)", altText, url)
+}
+
+// Footnote returns a footnote for markdown
+func Footnote(reference, text string) string {
+	return ufmt.Sprintf("[%s]: %s", reference, text)
+}
+
+// Paragraph wraps the given text in a Markdown paragraph
+func Paragraph(content string) string {
+	return ufmt.Sprintf("%s\n", content)
+}
+
+// MdTable is an interface for table types that can be converted to Markdown format
+type MdTable interface {
+	String() string
+}
+
+// Table takes any MdTable implementation and returns its markdown representation
+func Table(table MdTable) string {
+	return table.String()
+}
+
+// EscapeMarkdown escapes special markdown characters in a string
+func EscapeMarkdown(text string) string {
+	return ufmt.Sprintf("``%s``", text)
+}

--- a/vendored/gno.land/p/sunspirit/md/md_test.gno
+++ b/vendored/gno.land/p/sunspirit/md/md_test.gno
@@ -1,0 +1,175 @@
+package md
+
+import (
+	"testing"
+
+	"gno.land/p/nt/uassert/v0"
+	"gno.land/p/sunspirit/table"
+)
+
+func TestNewBuilder(t *testing.T) {
+	mdBuilder := NewBuilder()
+
+	uassert.Equal(t, len(mdBuilder.elements), 0, "Expected 0 elements")
+}
+
+func TestAdd(t *testing.T) {
+	mdBuilder := NewBuilder()
+
+	header := H1("Hi")
+	body := Paragraph("This is a test")
+
+	mdBuilder.Add(header, body)
+
+	uassert.Equal(t, len(mdBuilder.elements), 2, "Expected 2 element")
+	uassert.Equal(t, mdBuilder.elements[0], header, "Expected element %s, got %s", header, mdBuilder.elements[0])
+	uassert.Equal(t, mdBuilder.elements[1], body, "Expected element %s, got %s", body, mdBuilder.elements[1])
+}
+
+func TestRender(t *testing.T) {
+	mdBuilder := NewBuilder()
+
+	header := H1("Hello")
+	body := Paragraph("This is a test")
+
+	seperator := "\n"
+	expected := header + seperator + body
+
+	output := mdBuilder.Add(header, body).Render(seperator)
+
+	uassert.Equal(t, output, expected, "Expected rendered string %s, got %s", expected, output)
+}
+
+func Test_Bold(t *testing.T) {
+	uassert.Equal(t, Bold("Hello"), "**Hello**")
+}
+
+func Test_Italic(t *testing.T) {
+	uassert.Equal(t, Italic("Hello"), "*Hello*")
+}
+
+func Test_Strikethrough(t *testing.T) {
+	uassert.Equal(t, Strikethrough("Hello"), "~~Hello~~")
+}
+
+func Test_H1(t *testing.T) {
+	uassert.Equal(t, H1("Header 1"), "# Header 1\n")
+}
+
+func Test_H2(t *testing.T) {
+	uassert.Equal(t, H2("Header 2"), "## Header 2\n")
+}
+
+func Test_H3(t *testing.T) {
+	uassert.Equal(t, H3("Header 3"), "### Header 3\n")
+}
+
+func Test_H4(t *testing.T) {
+	uassert.Equal(t, H4("Header 4"), "#### Header 4\n")
+}
+
+func Test_H5(t *testing.T) {
+	uassert.Equal(t, H5("Header 5"), "##### Header 5\n")
+}
+
+func Test_H6(t *testing.T) {
+	uassert.Equal(t, H6("Header 6"), "###### Header 6\n")
+}
+
+func Test_BulletList(t *testing.T) {
+	items := []string{"Item 1", "Item 2", "Item 3"}
+	result := BulletList(items)
+	expected := "- Item 1\n- Item 2\n- Item 3\n"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_OrderedList(t *testing.T) {
+	items := []string{"Item 1", "Item 2", "Item 3"}
+	result := OrderedList(items)
+	expected := "1. Item 1\n2. Item 2\n3. Item 3\n"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_TodoList(t *testing.T) {
+	items := []string{"Task 1", "Task 2"}
+	done := []bool{true, false}
+	result := TodoList(items, done)
+	expected := "- [x] Task 1\n- [ ] Task 2\n"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_Blockquote(t *testing.T) {
+	text := "This is a blockquote.\nIt has multiple lines."
+	result := Blockquote(text)
+	expected := "> This is a blockquote.\n> It has multiple lines.\n"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_InlineCode(t *testing.T) {
+	result := InlineCode("code")
+	uassert.Equal(t, result, "`code`")
+}
+
+func Test_LanguageCodeBlock(t *testing.T) {
+	result := LanguageCodeBlock("python", "print('Hello')")
+	expected := "```python\nprint('Hello')\n```"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_CodeBlock(t *testing.T) {
+	result := CodeBlock("print('Hello')")
+	expected := "```\nprint('Hello')\n```"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_LineBreak(t *testing.T) {
+	result := LineBreak(2)
+	expected := "\n\n\n"
+	uassert.Equal(t, result, expected)
+
+	result = LineBreak(0)
+	expected = ""
+	uassert.Equal(t, result, expected)
+}
+
+func Test_HorizontalRule(t *testing.T) {
+	result := HorizontalRule()
+	uassert.Equal(t, result, "---\n")
+}
+
+func Test_Link(t *testing.T) {
+	result := Link("Google", "http://google.com")
+	uassert.Equal(t, result, "[Google](http://google.com)")
+}
+
+func Test_Image(t *testing.T) {
+	result := Image("Alt text", "http://image.url")
+	uassert.Equal(t, result, "![Alt text](http://image.url)")
+}
+
+func Test_Footnote(t *testing.T) {
+	result := Footnote("1", "This is a footnote.")
+	uassert.Equal(t, result, "[1]: This is a footnote.")
+}
+
+func Test_Paragraph(t *testing.T) {
+	result := Paragraph("This is a paragraph.")
+	uassert.Equal(t, result, "This is a paragraph.\n")
+}
+
+func Test_Table(t *testing.T) {
+	tb, err := table.New([]string{"Header1", "Header2"}, [][]string{
+		{"Row1Col1", "Row1Col2"},
+		{"Row2Col1", "Row2Col2"},
+	})
+	uassert.NoError(t, err)
+
+	result := Table(tb)
+	expected := "| Header1 | Header2 |\n| ---|---|\n| Row1Col1 | Row1Col2 |\n| Row2Col1 | Row2Col2 |\n"
+	uassert.Equal(t, result, expected)
+}
+
+func Test_EscapeMarkdown(t *testing.T) {
+	result := EscapeMarkdown("- This is `code`")
+	uassert.Equal(t, result, "``- This is `code```")
+}

--- a/vendored/gno.land/r/demo/profile/gnomod.toml
+++ b/vendored/gno.land/r/demo/profile/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/demo/profile"
+gno = "0.9"

--- a/vendored/gno.land/r/demo/profile/profile.gno
+++ b/vendored/gno.land/r/demo/profile/profile.gno
@@ -1,0 +1,144 @@
+package profile
+
+import (
+	"chain"
+
+	"gno.land/p/nt/avl/v0"
+	"gno.land/p/nt/mux/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+var (
+	fields = avl.NewTree()
+	router = mux.NewRouter()
+)
+
+// Standard fields
+const (
+	DisplayName        = "DisplayName"
+	Homepage           = "Homepage"
+	Bio                = "Bio"
+	Age                = "Age"
+	Location           = "Location"
+	Avatar             = "Avatar"
+	GravatarEmail      = "GravatarEmail"
+	AvailableForHiring = "AvailableForHiring"
+	InvalidField       = "InvalidField"
+)
+
+// Events
+const (
+	ProfileFieldCreated = "ProfileFieldCreated"
+	ProfileFieldUpdated = "ProfileFieldUpdated"
+)
+
+// Field types used when emitting event
+const FieldType = "FieldType"
+
+const (
+	BoolField   = "BoolField"
+	StringField = "StringField"
+	IntField    = "IntField"
+)
+
+func init() {
+	router.HandleFunc("", homeHandler)
+	router.HandleFunc("u/{addr}", profileHandler)
+	router.HandleFunc("f/{addr}/{field}", fieldHandler)
+}
+
+// List of supported string fields
+var stringFields = map[string]bool{
+	DisplayName:   true,
+	Homepage:      true,
+	Bio:           true,
+	Location:      true,
+	Avatar:        true,
+	GravatarEmail: true,
+}
+
+// List of support int fields
+var intFields = map[string]bool{
+	Age: true,
+}
+
+// List of support bool fields
+var boolFields = map[string]bool{
+	AvailableForHiring: true,
+}
+
+// Setters
+
+func SetStringField(cur realm, field, value string) bool {
+	addr := cur.Previous().Address()
+	key := addr.String() + ":" + field
+	updated := fields.Set(key, value)
+
+	event := ProfileFieldCreated
+	if updated {
+		event = ProfileFieldUpdated
+	}
+
+	chain.Emit(event, FieldType, StringField, field, value)
+
+	return updated
+}
+
+func SetIntField(cur realm, field string, value int) bool {
+	addr := cur.Previous().Address()
+	key := addr.String() + ":" + field
+	updated := fields.Set(key, value)
+
+	event := ProfileFieldCreated
+	if updated {
+		event = ProfileFieldUpdated
+	}
+
+	chain.Emit(event, FieldType, IntField, field, string(value))
+
+	return updated
+}
+
+func SetBoolField(cur realm, field string, value bool) bool {
+	addr := cur.Previous().Address()
+	key := addr.String() + ":" + field
+	updated := fields.Set(key, value)
+
+	event := ProfileFieldCreated
+	if updated {
+		event = ProfileFieldUpdated
+	}
+
+	chain.Emit(event, FieldType, BoolField, field, ufmt.Sprintf("%t", value))
+
+	return updated
+}
+
+// Getters
+
+func GetStringField(addr address, field, def string) string {
+	key := addr.String() + ":" + field
+	if value, ok := fields.Get(key); ok {
+		return value.(string)
+	}
+
+	return def
+}
+
+func GetBoolField(addr address, field string, def bool) bool {
+	key := addr.String() + ":" + field
+	if value, ok := fields.Get(key); ok {
+		return value.(bool)
+	}
+
+	return def
+}
+
+func GetIntField(addr address, field string, def int) int {
+	key := addr.String() + ":" + field
+	if value, ok := fields.Get(key); ok {
+		return value.(int)
+	}
+
+	return def
+}

--- a/vendored/gno.land/r/demo/profile/profile_test.gno
+++ b/vendored/gno.land/r/demo/profile/profile_test.gno
@@ -1,0 +1,141 @@
+package profile
+
+import (
+	"testing"
+
+	"gno.land/p/nt/testutils/v0"
+	"gno.land/p/nt/uassert/v0"
+)
+
+// Global addresses for test users
+var (
+	alice   = testutils.TestAddress("alice")
+	bob     = testutils.TestAddress("bob")
+	charlie = testutils.TestAddress("charlie")
+	dave    = testutils.TestAddress("dave")
+	eve     = testutils.TestAddress("eve")
+	frank   = testutils.TestAddress("frank")
+	user1   = testutils.TestAddress("user1")
+	user2   = testutils.TestAddress("user2")
+)
+
+func TestStringFields(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(alice))
+
+	// Get before setting
+	name := GetStringField(alice, DisplayName, "anon")
+	uassert.Equal(t, "anon", name)
+
+	// Set new key
+	updated := SetStringField(cross(cur), DisplayName, "Alice foo")
+	uassert.Equal(t, updated, false)
+	updated = SetStringField(cross(cur), Homepage, "https://example.com")
+	uassert.Equal(t, updated, false)
+
+	// Update the key
+	updated = SetStringField(cross(cur), DisplayName, "Alice foo")
+	uassert.Equal(t, updated, true)
+
+	// Get after setting
+	name = GetStringField(alice, DisplayName, "anon")
+	homepage := GetStringField(alice, Homepage, "")
+	bio := GetStringField(alice, Bio, "42")
+
+	uassert.Equal(t, "Alice foo", name)
+	uassert.Equal(t, "https://example.com", homepage)
+	uassert.Equal(t, "42", bio)
+}
+
+func TestIntFields(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(bob))
+
+	// Get before setting
+	age := GetIntField(bob, Age, 25)
+	uassert.Equal(t, 25, age)
+
+	// Set new key
+	updated := SetIntField(cross(cur), Age, 30)
+	uassert.Equal(t, updated, false)
+
+	// Update the key
+	updated = SetIntField(cross(cur), Age, 30)
+	uassert.Equal(t, updated, true)
+
+	// Get after setting
+	age = GetIntField(bob, Age, 25)
+	uassert.Equal(t, 30, age)
+}
+
+func TestBoolFields(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(charlie))
+
+	// Get before setting
+	hiring := GetBoolField(charlie, AvailableForHiring, false)
+	uassert.Equal(t, false, hiring)
+
+	// Set
+	updated := SetBoolField(cross(cur), AvailableForHiring, true)
+	uassert.Equal(t, updated, false)
+
+	// Update the key
+	updated = SetBoolField(cross(cur), AvailableForHiring, true)
+	uassert.Equal(t, updated, true)
+
+	// Get after setting
+	hiring = GetBoolField(charlie, AvailableForHiring, false)
+	uassert.Equal(t, true, hiring)
+}
+
+func TestMultipleProfiles(cur realm, t *testing.T) {
+	// Set profile for user1
+	testing.SetRealm(testing.NewUserRealm(user1))
+	updated := SetStringField(cross(cur), DisplayName, "User One")
+	uassert.Equal(t, updated, false)
+
+	// Set profile for user2
+	testing.SetRealm(testing.NewUserRealm(user2))
+	updated = SetStringField(cross(cur), DisplayName, "User Two")
+	uassert.Equal(t, updated, false)
+
+	// Get profiles
+	testing.SetRealm(testing.NewUserRealm(user1)) // Switch back to user1
+	name1 := GetStringField(user1, DisplayName, "anon")
+	testing.SetRealm(testing.NewUserRealm(user2)) // Switch back to user2
+	name2 := GetStringField(user2, DisplayName, "anon")
+
+	uassert.Equal(t, "User One", name1)
+	uassert.Equal(t, "User Two", name2)
+}
+
+func TestArbitraryStringField(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(user1))
+
+	// Set arbitrary string field
+	updated := SetStringField(cross(cur), "MyEmail", "my@email.com")
+	uassert.Equal(t, updated, false)
+
+	val := GetStringField(user1, "MyEmail", "")
+	uassert.Equal(t, val, "my@email.com")
+}
+
+func TestArbitraryIntField(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(user1))
+
+	// Set arbitrary int field
+	updated := SetIntField(cross(cur), "MyIncome", 100_000)
+	uassert.Equal(t, updated, false)
+
+	val := GetIntField(user1, "MyIncome", 0)
+	uassert.Equal(t, val, 100_000)
+}
+
+func TestArbitraryBoolField(cur realm, t *testing.T) {
+	testing.SetRealm(testing.NewUserRealm(user1))
+
+	// Set arbitrary bool field
+	updated := SetBoolField(cross(cur), "IsWinner", true)
+	uassert.Equal(t, updated, false)
+
+	val := GetBoolField(user1, "IsWinner", false)
+	uassert.Equal(t, val, true)
+}

--- a/vendored/gno.land/r/demo/profile/render.gno
+++ b/vendored/gno.land/r/demo/profile/render.gno
@@ -1,0 +1,102 @@
+package profile
+
+import (
+	"bytes"
+	"net/url"
+
+	"gno.land/p/nt/mux/v0"
+	"gno.land/p/nt/ufmt/v0"
+)
+
+const (
+	BaseURL           = "/r/demo/profile"
+	SetStringFieldURL = BaseURL + "$help&func=SetStringField&field=%s"
+	SetIntFieldURL    = BaseURL + "$help&func=SetIntField&field=%s"
+	SetBoolFieldURL   = BaseURL + "$help&func=SetBoolField&field=%s"
+	ViewAllFieldsURL  = BaseURL + ":u/%s"
+	ViewFieldURL      = BaseURL + ":f/%s/%s"
+)
+
+func homeHandler(res *mux.ResponseWriter, req *mux.Request) {
+	var b bytes.Buffer
+
+	b.WriteString("## Setters\n")
+	for field := range stringFields {
+		link := ufmt.Sprintf(SetStringFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- [Set %s](%s)\n", field, link))
+	}
+
+	for field := range intFields {
+		link := ufmt.Sprintf(SetIntFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- [Set %s](%s)\n", field, link))
+	}
+
+	for field := range boolFields {
+		link := ufmt.Sprintf(SetBoolFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- [Set %s Field](%s)\n", field, link))
+	}
+
+	b.WriteString("\n---\n\n")
+
+	res.Write(b.String())
+}
+
+func profileHandler(res *mux.ResponseWriter, req *mux.Request) {
+	var b bytes.Buffer
+	addr := req.GetVar("addr")
+
+	b.WriteString(ufmt.Sprintf("# Profile %s\n", addr))
+
+	address_XXX := address(addr)
+
+	for field := range stringFields {
+		value := GetStringField(address_XXX, field, "n/a")
+		link := ufmt.Sprintf(SetStringFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- %s: %s [Edit](%s)\n", field, value, link))
+	}
+
+	for field := range intFields {
+		value := GetIntField(address_XXX, field, 0)
+		link := ufmt.Sprintf(SetIntFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- %s: %d [Edit](%s)\n", field, value, link))
+	}
+
+	for field := range boolFields {
+		value := GetBoolField(address_XXX, field, false)
+		link := ufmt.Sprintf(SetBoolFieldURL, field)
+		b.WriteString(ufmt.Sprintf("- %s: %t [Edit](%s)\n", field, value, link))
+	}
+
+	res.Write(b.String())
+}
+
+func fieldHandler(res *mux.ResponseWriter, req *mux.Request) {
+	var b bytes.Buffer
+	addr := req.GetVar("addr")
+	field := req.GetVar("field")
+
+	b.WriteString(ufmt.Sprintf("# Field %s for %s\n", field, addr))
+
+	address_XXX := address(addr)
+	value := "n/a"
+	var editLink string
+
+	if _, ok := stringFields[field]; ok {
+		value = ufmt.Sprintf("%s", GetStringField(address_XXX, field, "n/a"))
+		editLink = ufmt.Sprintf(SetStringFieldURL+"&addr=%s&value=%s", field, addr, url.QueryEscape(value))
+	} else if _, ok := intFields[field]; ok {
+		value = ufmt.Sprintf("%d", GetIntField(address_XXX, field, 0))
+		editLink = ufmt.Sprintf(SetIntFieldURL+"&addr=%s&value=%s", field, addr, value)
+	} else if _, ok := boolFields[field]; ok {
+		value = ufmt.Sprintf("%t", GetBoolField(address_XXX, field, false))
+		editLink = ufmt.Sprintf(SetBoolFieldURL+"&addr=%s&value=%s", field, addr, value)
+	}
+
+	b.WriteString(ufmt.Sprintf("- %s: %s [Edit](%s)\n", field, value, editLink))
+
+	res.Write(b.String())
+}
+
+func Render(path string) string {
+	return router.Render(path)
+}


### PR DESCRIPTION
## Why CI is red, and why bumping the pin doesn't fix it

CI has been red since **2026-06-04**, and the cause is not in this repo's code.

`gno lint` and `gno test` don't resolve dependencies from a lockfile — they derive the source from the **pkgpath domain** (`rpcpkgfetcher.go`: `https://rpc.%s:443`), and `rpc.gno.land` CNAMEs to betanet, a **mutable testnet**. So a hermetically pinned compiler was being fed by a live, unversioned dependency source. Any upstream redeploy retroactively breaks every branch, including already-merged history.

There are two independent failure classes, and **bumping `GNOVERSION` fixes neither**:

1. **Syntax skew** — the chain serves *pre*-interrealm-v2 sources, i.e. the deps are **older** than the pinned compiler. Bumping moves further away, not closer.
2. **Packages simply gone** — `r/demo/profile` returns a server-side "package is not available". The failed fetch leaves the cache directory uncreated, which then resurfaces as a *misleading* `open …/p/onbloc/json: no such file or directory`. That ENOENT is a masked download failure, not cache corruption — which is why it has been so hard to read.

A control experiment confirms it: PR #62 pins a toolchain **byte-identical to `main`'s** and still fails. The only package that passes anywhere is `realmid`, the one with zero chain-hosted dependencies.

## The fix

Vendor the dependency closure. It removes the network from the build, which is the only thing that closes both classes.

- **Zero code changes, zero Makefile changes** — `load.go` short-circuits the fetch on any workspace-local match.
- **Placement at the repository root, not under `gno/`, is load-bearing.** `make lint`, `make test` and `make fmt` all target `./gno/...`, so vendored third-party code is resolved but never linted, tested or reformatted. Verified: `gno fmt -w` touches zero vendored files, so the existing no-diff gate still passes.
- 23 packages, 100 `.gno` files, ~1 MB.

**Result, with the network unavailable:** lint clean · 6/6 packages `ok` · `gno fmt` zero diff · **no `gno: downloading` line at all**.

## The avl role is vendored from the fork, deliberately

This is the part that matters most, and it is a correction to the original plan.

topaz-1's stdlib `p/nt/avl/v0` exposes a **single-value** `Get`, while this codebase calls the **two-value** form. Vendoring upstream `p/nt/avl/v0` for the data-structure role would produce a **green build compiled against an ABI the target chain does not have** — a false green in exactly the place a gate exists to prevent one, and it would mask the very failure the ceremony most needs caught.

So `gno.land/p/samcrew/avl` is vendored from the fork (byte-identical to `deps/avl` in samcrew-deployer, which carries its own guard pinning it to upstream `f3d5a5d13`). This is also why the branch targets `feat/topaz-v2-rename` rather than `main`: `main` is pre-interrealm-v2, its unsuffixed `p/nt/*` imports cannot resolve on topaz-1 at all, and it is not locally buildable.

The one remaining stdlib avl import — `ntavl` in `gno/p/basedao/utils.gno` — is correct and stays: `svg.Canvas.Style` is a `*nt/avl/v0.Tree`, so that boundary must match the stdlib ABI exactly. It only calls `NewTree()`, never `Get`, so it carries no arity exposure.

## Two guards, so this cannot rot

- **Hermeticity** — the lint job now fails if `gno: downloading` ever appears, so the closure cannot silently become incomplete.
- **Provenance** — a new `vendored-provenance` job proves every vendored file is byte-identical to `gnolang/gno@GNOVERSION`. Currently **118 files checked, zero drift**. It refuses to pass vacuously if it ever checks nothing, and it asserts the fork still exposes the two-value `Get`.

`GNOVERSION` is read from the checked-out tree, so it is validated as a bare hex sha and passed through `env:` rather than interpolated into a `run:` block — otherwise a fork PR could inject via the `Makefile`.

## What this unblocks

The "CI all green" merge gate is currently **unsatisfiable** on this repo, so no PR can legitimately land. This makes it satisfiable again, which is a prerequisite for #65, #66, #67 and the freeze.

Also worth noting: `make gno-mod-tidy` is a **silent no-op** — it runs `find gno -name gno.mod`, but the repo uses `gnomod.toml`, so it matches zero files. Left alone here deliberately; repairing it may produce a diff and fail the no-diff gate, so it deserves its own change.