### PR TITLE
fix(basedao,daokit): bind the DAO's identity to its own live realm

### DIFF
--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -9,7 +9,6 @@ import (
 	"gno.land/p/nt/mux/v0"
 	"gno.land/p/samcrew/daocond"
 	"gno.land/p/samcrew/daokit"
-	"gno.land/p/samcrew/realmid"
 )
 
 type daoPublic struct {
@@ -35,16 +34,16 @@ func (d *daoPublic) ExtensionsList() daokit.ExtensionsList {
 	return d.impl.Core.Extensions.List()
 }
 
-func (d *daoPublic) Propose(req daokit.ProposalRequest) uint64 {
-	return d.impl.Propose(req)
+func (d *daoPublic) Propose(req daokit.ProposalRequest, rlm realm) uint64 {
+	return d.impl.Propose(req, rlm)
 }
 
 func (d *daoPublic) Execute(id uint64, rlm realm) {
 	d.impl.Execute(id, rlm)
 }
 
-func (d *daoPublic) Vote(id uint64, vote daocond.Vote) {
-	d.impl.Vote(id, vote)
+func (d *daoPublic) Vote(id uint64, vote daocond.Vote, rlm realm) {
+	d.impl.Vote(id, vote, rlm)
 }
 
 func (d *daoPublic) Render(path string) string {
@@ -64,9 +63,23 @@ type DAOPrivate struct {
 	InitialConfig *Config // mostly there in case we need this data during upgrade
 }
 
-// Function type that returns the identifier of the current caller.
-// Used to identify who is making calls to DAO functions.
-type CallerIDFn func() string
+// CallerIDFn resolves the identity of the DAO's immediate caller.
+//
+// It receives the DAO realm's own threaded realm, so the implementation can use
+// rlm.Previous(), which is statically scoped to that crossing function.
+//
+// On every path the entry gate admits, a stack walk would name the same realm:
+// the gate has already established that the DAO's own frame is the live one, so
+// unsafe.PreviousRealm() and rlm.Previous() agree. The walk goes wrong only in
+// the shape the gate now rejects — a caller invoking these methods through the
+// DAO handle, with no DAO realm frame on the stack at all, where the walk names
+// the signing account instead. Deriving from the threaded realm is preferred
+// because it does not depend on the gate having run first.
+//
+// The realm is deliberately the SECOND parameter: a function whose first
+// parameter is a realm is read as crossing, and /p/ packages may not declare
+// crossing functions.
+type CallerIDFn func(dao *DAOPrivate, rlm realm) string
 
 type Config struct {
 	// Basic DAO information
@@ -93,7 +106,7 @@ type Config struct {
 	SetImplemFn       SetImplemRaw      // Function called when DAO implementation changes via governance
 	MigrationParamsFn MigrationParamsFn // Function providing parameters for DAO upgrades
 	RenderFn          RenderFn          // Rendering function for Gnoweb
-	CallerID          CallerIDFn        // Custom function to identify the current caller, defaults to realmid.Previous
+	CallerID          CallerIDFn        // Resolves the immediate caller from the DAO's threaded realm; defaults to defaultCallerID
 
 	// Internal configuration
 	PrivateVarName string // Name of the private DAO variable for member querying extensions
@@ -117,7 +130,7 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 	}
 
 	if conf.CallerID == nil {
-		conf.CallerID = realmid.Previous
+		conf.CallerID = defaultCallerID
 	}
 
 	core := daokit.NewCore()
@@ -222,27 +235,87 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 	return pubdao, dao
 }
 
-func (d *DAOPrivate) Vote(proposalID uint64, vote daocond.Vote) {
+func (d *DAOPrivate) Vote(proposalID uint64, vote daocond.Vote, rlm realm) {
 	if len(vote) > 16 {
 		panic("invalid vote")
 	}
 
-	voterID := d.assertCallerIsMember()
+	assertRealmIsOwn(d, rlm)
+	voterID := d.assertCallerIsMember(d.CallerID(d, rlm))
 	d.Core.Vote(voterID, proposalID, vote)
 }
 
 func (d *DAOPrivate) Execute(proposalID uint64, rlm realm) {
-	_ = d.assertCallerIsMember()
+	assertRealmIsOwn(d, rlm)
+	_ = d.assertCallerIsMember(d.CallerID(d, rlm))
 	d.Core.Execute(proposalID, rlm)
 }
 
-func (d *DAOPrivate) Propose(req daokit.ProposalRequest) uint64 {
-	proposerID := d.assertCallerIsMember()
+func (d *DAOPrivate) Propose(req daokit.ProposalRequest, rlm realm) uint64 {
+	assertRealmIsOwn(d, rlm)
+	proposerID := d.assertCallerIsMember(d.CallerID(d, rlm))
 	return d.Core.Propose(proposerID, req)
 }
 
-func (d *DAOPrivate) assertCallerIsMember() string {
-	id := d.CallerID()
+// Resolves the DAO's immediate caller from the DAO's own threaded realm.
+// rlm.Previous() is statically scoped to the DAO realm's crossing function, so
+// unlike a stack walk it cannot be shifted by how deep the call chain is.
+//
+// At the root of a call chain — a package init, or an entry point an account
+// reached directly — the previous realm is the origin realm: the signing
+// account, with an empty pkgpath. IsUser() holds there, so this resolves to
+// that account's address, which is how an ordinary member is authenticated.
+//
+// It yields "" only where the machine carries no signing account at all. That
+// is not an identity, and assertCallerIsMember refuses it.
+func defaultCallerID(dao *DAOPrivate, rlm realm) string {
+	p := rlm.Previous()
+	if p.IsUser() {
+		return p.Address().String()
+	}
+	return p.PkgPath()
+}
+
+// The realm threaded into an entry point must be the DAO realm's own live one.
+//
+// Execute forwards this realm to the action handlers, which cross out under it,
+// so whoever supplies it decides the identity the DAO acts as. Left unchecked, a
+// third realm holding the DAO value could pass its own realm and have the DAO
+// write to that realm's profile — or, through MigrateFn, reach anywhere the
+// caller controls. Realm values are unforgeable and cannot be persisted across
+// transactions, so a caller can only ever pass its own; requiring it to equal
+// the DAO's own realm therefore closes the donation path outright.
+//
+// The pkgpath alone is not enough. Every realm the DAO crosses out into during
+// an action receives the DAO's own realm value as its cur.Previous(), and can
+// hand that value straight back within the same transaction — same pkgpath,
+// but belonging to a frame that is no longer executing. IsCurrent() is what
+// separates the two: it holds only for the realm minted for the crossing
+// function currently on the stack, by frame identity rather than by name. It
+// survives the /p/ hop into this package, and it is true during a realm's own
+// init, so neither the ordinary path nor construction is affected.
+//
+// Given both, rlm.Previous() is by construction the DAO's immediate caller.
+//
+// This takes the DAO as its first parameter rather than being a method on it:
+// the VM reads any function whose FIRST parameter is a realm as crossing, and
+// /p/ packages may not declare crossing functions. Receivers do not count, so a
+// method would hit the same rule.
+func assertRealmIsOwn(d *DAOPrivate, rlm realm) {
+	if rlm.PkgPath() != d.Realm.PkgPath() || !rlm.IsCurrent() {
+		panic("realm mismatch: the DAO may only act as " + d.Realm.PkgPath())
+	}
+}
+
+func (d *DAOPrivate) assertCallerIsMember(id string) string {
+	// An empty id is never a real caller, and the store can hold one: AddMember
+	// does not reject it, and Members is an exported avl.Tree that a same-realm
+	// write or a MigrateFn can seed directly. Reject it here, where every entry
+	// point passes, so one such entry cannot authenticate every unattributable
+	// call.
+	if id == "" {
+		panic(errors.New("caller id is empty"))
+	}
 	if !d.Members.IsMember(id) {
 		panic(errors.New("caller is not a member"))
 	}

--- a/gno/p/basedao/basedao_test.gno
+++ b/gno/p/basedao/basedao_test.gno
@@ -16,6 +16,16 @@ var (
 	dave  = testutils.TestAddress("dave")
 )
 
+// The DAO under test is told who its caller is, rather than inferring one.
+//
+// testing.SetRealm fabricates a cur with no frame beneath it: cur.Previous()
+// resolves to gno.land/p/samcrew/basedao itself, so the harness cannot express
+// a caller chain in either direction. Leaning on it is what let the original
+// identity defect and #66's New() regression both pass CI.
+//
+// Caller resolution is therefore not asserted here. It is asserted across real
+// realm boundaries in gno/r/daoidentity, which is the only place it can be.
+
 func TestNewDAO(cur realm, t *testing.T) {
 	initialRoles := []RoleInfo{
 		{Name: "admin", Description: "Admin is the superuser", Color: "#329175"},
@@ -133,9 +143,9 @@ func TestPropose(cur realm, t *testing.T) {
 			}
 			*tdao.mockHandlerCalled = false
 			func() {
-				testing.SetOriginCaller(test.input.proposer)
+				tdao.setCaller(test.input.proposer)
 			}()
-			id := tdao.dao.Propose(test.input.proposalReq)
+			id := tdao.dao.Propose(test.input.proposalReq, cur)
 
 			urequire.False(t, *tdao.mockHandlerCalled, "execute should not be called")
 
@@ -164,7 +174,7 @@ func TestVote(cur realm, t *testing.T) {
 	}
 	tdao := newTestingDAO(cur, t, 0.6, members)
 
-	tdao.dao.Propose(tdao.mockProposalRequest)
+	tdao.dao.Propose(tdao.mockProposalRequest, cur)
 
 	type testVoteInput struct {
 		proposalID uint64
@@ -241,9 +251,9 @@ func TestVote(cur realm, t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			run := func() {
 				func() {
-					testing.SetOriginCaller(test.input.voter)
+					tdao.setCaller(test.input.voter)
 				}()
-				tdao.dao.Vote(test.input.proposalID, test.input.vote)
+				tdao.dao.Vote(test.input.proposalID, test.input.vote, cur)
 
 			}
 
@@ -272,7 +282,7 @@ func TestExecuteProposal(cur realm, t *testing.T) {
 	}
 	tdao := newTestingDAO(cur, t, 0.6, members)
 
-	tdao.dao.Propose(tdao.mockProposalRequest)
+	tdao.dao.Propose(tdao.mockProposalRequest, cur)
 
 	type testExecuteInput struct {
 		proposalID uint64
@@ -351,14 +361,14 @@ func TestExecuteProposal(cur realm, t *testing.T) {
 
 			if test.input.haveVote {
 				func() {
-					testing.SetOriginCaller(test.input.voter)
+					tdao.setCaller(test.input.voter)
 				}()
-				tdao.dao.Vote(test.input.proposalID, "yes")
+				tdao.dao.Vote(test.input.proposalID, "yes", cur)
 
 			}
 
 			func() {
-				testing.SetOriginCaller(test.input.executor)
+				tdao.setCaller(test.input.executor)
 			}()
 			tdao.dao.Execute(test.input.proposalID, cur)
 
@@ -436,9 +446,9 @@ func TestInstantExecute(cur realm, t *testing.T) {
 			}
 
 			func() {
-				testing.SetOriginCaller(test.input.executor)
+				tdao.setCaller(test.input.executor)
 			}()
-			tdao.dao.Propose(test.input.proposalReq)
+			tdao.dao.Propose(test.input.proposalReq, cur)
 		})
 	}
 }
@@ -632,7 +642,7 @@ func TestRemoveRoleFromUserProposal(cur realm, t *testing.T) {
 		Description: "My Proposal Description",
 		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: alice, Role: "unknown"}),
 	}
-	testing.SetOriginCaller(alice)
+	tdao.setCaller(alice)
 	daokit.InstantExecute(tdao.dao, proposalWithUnknowkRole, cur)
 
 	defer func() {
@@ -646,7 +656,7 @@ func TestRemoveRoleFromUserProposal(cur realm, t *testing.T) {
 		Description: "My Proposal Description",
 		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: carol, Role: "admin"}),
 	}
-	testing.SetOriginCaller(alice)
+	tdao.setCaller(alice)
 	daokit.InstantExecute(tdao.dao, proposalWithNonMember, cur)
 
 	defer func() {
@@ -660,11 +670,12 @@ func TestRemoveRoleFromUserProposal(cur realm, t *testing.T) {
 		Description: "My Proposal Description",
 		Action:      NewUnassignRoleAction(&ActionUnassignRole{Address: bob, Role: "admin"}),
 	}
-	testing.SetOriginCaller(alice)
+	tdao.setCaller(alice)
 	daokit.InstantExecute(tdao.dao, proposalWithNonRole, cur)
 }
 
 type testingDAOContext struct {
+	caller                 *string
 	dao                    daokit.DAO
 	privdao                *DAOPrivate
 	mockHandlerCalled      *bool
@@ -678,12 +689,14 @@ func newTestingDAO(cur realm, t *testing.T, threshold float64, members []Member)
 	membersStore := NewMembersStore(roles, members)
 	initialCondition := daocond.MembersThreshold(threshold, membersStore.IsMember, membersStore.MembersCount)
 
+	caller := alice.String()
 	conf := &Config{
 		Name:             "My DAO",
 		Description:      "My DAO Description",
 		Members:          membersStore,
 		InitialCondition: initialCondition,
 		GetProfileString: func(addr address, field, def string) string { return "" },
+		CallerID:         func(dao *DAOPrivate, rlm realm) string { return caller },
 	}
 
 	daoRealm := testing.NewCodeRealm("gno.land/r/testing/daorealm")
@@ -711,6 +724,7 @@ func newTestingDAO(cur realm, t *testing.T, threshold float64, members []Member)
 	}
 
 	return &testingDAOContext{
+		caller:                 &caller,
 		dao:                    pubdao,
 		privdao:                dao,
 		mockHandlerCalled:      &mockHandlerCalled,
@@ -718,4 +732,11 @@ func newTestingDAO(cur realm, t *testing.T, threshold float64, members []Member)
 		mockProposalRequest:    mockProposalRequest,
 		unknownProposalRequest: unknownProposalRequest,
 	}
+}
+
+// setCaller points both the transaction origin and the identity this DAO
+// resolves at the same account, so these tests read as they did before.
+func (c *testingDAOContext) setCaller(a address) {
+	testing.SetOriginCaller(a)
+	*c.caller = a.String()
 }

--- a/gno/p/basedao/identity_guards_test.gno
+++ b/gno/p/basedao/identity_guards_test.gno
@@ -1,0 +1,50 @@
+package basedao
+
+import (
+	"testing"
+
+	"gno.land/p/samcrew/avl"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// The empty-id guard, on controlled input.
+//
+// It is asserted here rather than through a realm fixture because "" is a
+// property of the input, not of the environment: under `gno test` the harness
+// leaves OriginCaller unset, so a root-of-chain call happens to resolve to ""
+// there while on-chain it resolves to the signing account. A test that inferred
+// the empty id from the environment would be pinning the harness.
+//
+// The guard is load-bearing rather than cosmetic. MembersStore.Members is an
+// exported avl.Tree, so a same-realm write or a MigrateFn can seed "" past
+// AddMember — and any call the machine cannot attribute to a signer resolves to
+// "". Without this, one such entry would authenticate all of them.
+func TestAnEmptyCallerIdIsNeverAMember(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, []Member{{alice.String(), nil}})
+	d := &DAOPrivate{Members: store}
+
+	urequire.PanicsWithMessage(t, cur, "caller id is empty", func() {
+		d.assertCallerIsMember("")
+	})
+}
+
+// Even with "" seeded directly into the store, past AddMember.
+func TestAnEmptyCallerIdIsRefusedEvenWhenSeededIntoTheStore(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, []Member{{alice.String(), nil}})
+	store.Members.Set("", avl.NewTree())
+	d := &DAOPrivate{Members: store}
+
+	urequire.True(t, store.IsMember(""), "the store does hold the empty id")
+	urequire.PanicsWithMessage(t, cur, "caller id is empty", func() {
+		d.assertCallerIsMember("")
+	})
+}
+
+// A real member still passes, so the guard discriminates.
+func TestARealCallerIdIsAccepted(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, []Member{{alice.String(), nil}})
+	d := &DAOPrivate{Members: store}
+
+	urequire.Equal(t, alice.String(), d.assertCallerIsMember(alice.String()))
+}

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -6,14 +6,29 @@ import (
 	"gno.land/p/samcrew/daocond"
 )
 
+// Every entry point threads the DAO realm's own realm value.
+//
+// It serves two purposes. Execute forwards it to the action handlers, which
+// cross out under it, so the implementation must refuse any realm that is not
+// its own — otherwise a caller holding this handle could make the DAO act under
+// the CALLER's identity. And because the realm is then known to be the DAO's,
+// rlm.Previous() names the DAO's immediate caller, which a stack walk cannot do:
+// reached through this handle there is no DAO realm frame on the stack at all,
+// so a walk reports the signing account instead.
+//
+// An implementation must require the realm to be BOTH its own by pkgpath and
+// current: every realm the DAO crosses out into receives the DAO's own realm as
+// its cur.Previous() and can hand it back within the same transaction, and only
+// IsCurrent() tells that apart from the live one.
+//
+// The realm is deliberately never the first parameter: a function whose first
+// parameter is a realm is read as crossing, which /p/ packages may not declare.
 type DAO interface {
 	// Creates a new proposal and returns its ID.
-	Propose(req ProposalRequest) uint64
+	Propose(req ProposalRequest, rlm realm) uint64
 	// Casts a vote on a specific proposal.
-	Vote(id uint64, vote daocond.Vote)
+	Vote(id uint64, vote daocond.Vote, rlm realm)
 	// Executes a proposal if it meets the required conditions.
-	// The rlm realm is threaded so action handlers can perform
-	// cross-realm calls (e.g. editing the DAO profile).
 	Execute(id uint64, rlm realm)
 
 	// Generates a web interface representation for the given path.
@@ -32,8 +47,8 @@ type SetImplemFn = func(implem DAO)
 // Useful when you have enough permission to execute an action directly.
 // Examples: migrations, adding members
 func InstantExecute(d DAO, req ProposalRequest, rlm realm) uint64 {
-	id := d.Propose(req)
-	d.Vote(id, daocond.VoteYes)
+	id := d.Propose(req, rlm)
+	d.Vote(id, daocond.VoteYes, rlm)
 	d.Execute(id, rlm)
 	return id
 }

--- a/gno/r/daodemo/custom_condition/simple_dao.gno
+++ b/gno/r/daodemo/custom_condition/simple_dao.gno
@@ -52,12 +52,12 @@ func init(cur realm) {
 // To execute this function, you must use a MsgRun (maketx run)
 // See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
 func Propose(cur realm, req daokit.ProposalRequest) {
-	localDAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 // Vote allows DAO members to cast their vote on a specific proposal
 func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
-	localDAO.Vote(proposalID, vote)
+	localDAO.Vote(proposalID, vote, cur)
 }
 
 // Execute triggers the implementation of a proposal's actions

--- a/gno/r/daodemo/custom_condition/utils.gno
+++ b/gno/r/daodemo/custom_condition/utils.gno
@@ -61,7 +61,7 @@ func initDemoProposals() {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
-	id := daoPrivate.CallerID()
+	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }
 

--- a/gno/r/daodemo/custom_resource/blog.gno
+++ b/gno/r/daodemo/custom_resource/blog.gno
@@ -15,12 +15,15 @@ type Blog struct {
 	Post []Post
 }
 
-func (a *Blog) NewPost(title string, content string) {
+// The realm is threaded in from the action handler, which receives the DAO's
+// own. It is last because the VM reads a leading realm parameter as a crossing
+// function, and receivers do not exempt a method from that rule.
+func (a *Blog) NewPost(title string, content string, rlm realm) {
 	newPost := Post{
 		Title:   title,
 		Content: content,
 		Created: time.Now(),
-		Creator: daoPrivate.CallerID(),
+		Creator: daoPrivate.CallerID(daoPrivate, rlm),
 	}
 	a.Post = append(a.Post, newPost)
 }

--- a/gno/r/daodemo/custom_resource/custom_resource.gno
+++ b/gno/r/daodemo/custom_resource/custom_resource.gno
@@ -32,11 +32,11 @@ func NewPostAction(title, content string) daokit.Action {
 
 func NewPostHandler(blog *Blog) daokit.ActionHandler {
 	// def: daoKit.NewActionHandler(kind: String, payload: func(interface{}))
-	return daokit.NewActionHandler(ActionNewPostKind, func(payload interface{}, _ realm) {
+	return daokit.NewActionHandler(ActionNewPostKind, func(payload interface{}, rlm realm) {
 		action, ok := payload.(*ActionNewPost)
 		if !ok {
 			panic(errors.New("invalid action type"))
 		}
-		blog.NewPost(action.Title, action.Content)
+		blog.NewPost(action.Title, action.Content, rlm)
 	})
 }

--- a/gno/r/daodemo/custom_resource/simple_dao.gno
+++ b/gno/r/daodemo/custom_resource/simple_dao.gno
@@ -66,12 +66,12 @@ func init(cur realm) {
 // To execute this function, you must use a MsgRun (maketx run)
 // See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
 func Propose(cur realm, req daokit.ProposalRequest) {
-	localDAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 // Vote allows DAO members to cast their vote on a specific proposal
 func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
-	localDAO.Vote(proposalID, vote)
+	localDAO.Vote(proposalID, vote, cur)
 }
 
 // Execute triggers the implementation of a proposal's actions

--- a/gno/r/daodemo/custom_resource/utils.gno
+++ b/gno/r/daodemo/custom_resource/utils.gno
@@ -35,7 +35,7 @@ func initBlogProposals() {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
-	id := daoPrivate.CallerID()
+	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }
 

--- a/gno/r/daodemo/simple_dao/simple_dao.gno
+++ b/gno/r/daodemo/simple_dao/simple_dao.gno
@@ -68,12 +68,12 @@ func init(cur realm) {
 // To execute this function, you must use a MsgRun `gnokey maketx run“
 // See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
 func Propose(cur realm, req daokit.ProposalRequest) {
-	localDAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 // Allows DAO members to cast their vote on a specific proposal
 func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
-	localDAO.Vote(proposalID, vote)
+	localDAO.Vote(proposalID, vote, cur)
 }
 
 // Triggers the implementation of a proposal's actions

--- a/gno/r/daodemo/simple_dao/utils.gno
+++ b/gno/r/daodemo/simple_dao/utils.gno
@@ -80,7 +80,7 @@ func initProposals(cur realm, nb int) {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
-	id := daoPrivate.CallerID()
+	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }
 
@@ -102,7 +102,7 @@ func ProposeAddMember(cur realm, address address, roles string) {
 			Roles:   rs,
 		}),
 	}
-	localDAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 func renderDemo() string {

--- a/gno/r/daoidentity/attacker/attacker.gno
+++ b/gno/r/daoidentity/attacker/attacker.gno
@@ -1,0 +1,33 @@
+// Package attacker holds the DAO value and calls its entry points directly,
+// bypassing the DAO realm's own crossing functions.
+//
+// This is the shape both identity blockers reduce to. Because no frame of the
+// DAO realm is on the stack, the DAO's /p/ code sees this realm as the current
+// realm and this realm's caller as the previous one — so the old stack-walking
+// identity named the signer, whose membership then satisfied the check while
+// this realm supplied the realm the DAO acted under.
+package attacker
+
+import (
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/dao"
+)
+
+// Propose hands the DAO this realm's own realm value.
+func Propose(cur realm, req daokit.ProposalRequest) uint64 {
+	return dao.Handle().Propose(req, cur)
+}
+
+// Vote hands the DAO this realm's own realm value.
+func Vote(cur realm, id uint64, vote daocond.Vote) {
+	dao.Handle().Vote(id, vote, cur)
+}
+
+// Execute is the worst reach: Execute forwards the realm to the action
+// handlers, which cross out under it, so a realm accepted here decides the
+// identity the DAO acts as — and through MigrateFn, reaches anywhere the
+// caller controls.
+func Execute(cur realm, id uint64) {
+	dao.Handle().Execute(id, cur)
+}

--- a/gno/r/daoidentity/attacker/gnomod.toml
+++ b/gno/r/daoidentity/attacker/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/attacker"
+gno = "0.9"

--- a/gno/r/daoidentity/callback/callback.gno
+++ b/gno/r/daoidentity/callback/callback.gno
@@ -1,0 +1,38 @@
+// Package callback stands in for any realm a DAO action crosses out into —
+// a profile realm, a treasury, a third-party integration.
+//
+// Such a realm necessarily receives the DAO's own realm value as its
+// cur.Previous(). It is therefore the one place from which a re-entrant call
+// carrying a DAO-looking realm can be made, which is what the entry gate has
+// to refuse.
+package callback
+
+import "gno.land/p/samcrew/daokit"
+
+var (
+	target daokit.DAO
+	// reentered records whether the re-entrant call got through. A refusal
+	// panics inside the DAO, so the test observes this staying false.
+	reentered bool
+)
+
+// Reentered reports whether the re-entrant call was ever accepted.
+func Reentered() bool { return reentered }
+
+// SetTarget is called by the DAO realm at construction. The DAO hands us its
+// own handle, which is exactly what basedao's README teaches realms to expose.
+func SetTarget(cur realm, dao daokit.DAO) {
+	target = dao
+}
+
+// Reenter is invoked by a DAO action handler, so cur.Previous() here is the
+// DAO's own realm value. We hand that value straight back to the DAO.
+//
+// The value has the DAO's pkgpath, so a gate that only compares pkgpaths
+// accepts it — but it is a value from a frame that is no longer the live
+// crossing frame, so cur.IsCurrent() on it is false.
+func Reenter(cur realm, req daokit.ProposalRequest) {
+	stolen := cur.Previous()
+	target.Propose(req, stolen)
+	reentered = true
+}

--- a/gno/r/daoidentity/callback/gnomod.toml
+++ b/gno/r/daoidentity/callback/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/callback"
+gno = "0.9"

--- a/gno/r/daoidentity/dao/dao.gno
+++ b/gno/r/daoidentity/dao/dao.gno
@@ -1,0 +1,128 @@
+// Package dao hosts a DAO the way a real realm does, so the identity rules can
+// be exercised across genuine realm boundaries.
+//
+// testing.SetRealm cannot stand in for this: it fabricates a cur with no frame
+// beneath it, so cur.Previous() resolves to gno.land/p/samcrew/basedao itself
+// rather than to any caller. No SetRealm-based test can tell a correct
+// caller-identity implementation from a broken one in either direction, which
+// is why both the original defect and #66's New() regression passed CI.
+package dao
+
+import (
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/callback"
+)
+
+const (
+	// Self is this realm's own pkgpath — the only realm the DAO may act as.
+	Self = "gno.land/r/samcrew/daoidentity/dao"
+	// RelayID reaches the DAO through an intermediary realm.
+	RelayID = "gno.land/r/samcrew/daoidentity/relay"
+	// SuiteID is the test realm. It is a member on purpose: it plays the
+	// signer whose membership used to satisfy the check while a foreign realm
+	// supplied the acting identity.
+	SuiteID = "gno.land/r/samcrew/daoidentity/suite"
+
+	// ActionCrossOut is an action whose handler crosses out of the DAO, as
+	// the built-in EditProfile action does.
+	ActionCrossOut = "gno.land/r/samcrew/daoidentity/dao.CrossOut"
+)
+
+var (
+	localDAO   daokit.DAO
+	daoPrivate *basedao.DAOPrivate
+
+	// seenByCallerID records the realm a custom CallerIDFn was handed, so a
+	// test can show the entry gate ran before it.
+	seenByCallerID string
+)
+
+// SeenByCallerID reports the realm the DAO's CallerIDFn last observed.
+func SeenByCallerID() string { return seenByCallerID }
+
+// StatusOf reports a proposal's status.
+func StatusOf(id uint64) string {
+	return daoPrivate.Core.Proposals.GetProposal(id).Status.String()
+}
+
+func init(cur realm) {
+	members := basedao.NewMembersStore(nil, []basedao.Member{
+		{Address: RelayID},
+		{Address: SuiteID},
+	})
+
+	// Any single member can carry a proposal, so nothing in these tests turns
+	// on vote arithmetic.
+	cond := daocond.MembersThreshold(0.1, members.IsMember, members.MembersCount)
+
+	localDAO, daoPrivate = basedao.New(&basedao.Config{
+		Name:             "Identity DAO",
+		Description:      "realm-to-realm identity fixture",
+		Members:          members,
+		InitialCondition: cond,
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		PrivateVarName:   "daoPrivate",
+		NoCreationEvent:  true,
+		// A custom CallerIDFn is a frozen extension point, so what it is handed
+		// is part of the contract: it must only ever see the DAO's own realm.
+		CallerID: func(d *basedao.DAOPrivate, rlm realm) string {
+			seenByCallerID = rlm.PkgPath()
+			p := rlm.Previous()
+			if p.IsUser() {
+				return p.Address().String()
+			}
+			return p.PkgPath()
+		},
+	}, cur)
+
+	daoPrivate.Core.Resources.Set(&daokit.Resource{
+		Handler: daokit.NewActionHandler(ActionCrossOut, func(payload interface{}, rlm realm) {
+			callback.Reenter(cross(rlm), payload.(daokit.ProposalRequest))
+		}),
+		Condition:   cond,
+		DisplayName: "Cross Out",
+		Description: "Crosses out of the DAO, handing a callee the DAO's realm.",
+	})
+
+	callback.SetTarget(cross(cur), localDAO)
+}
+
+// Propose is the legitimate entry point, declared exactly as the demo realms
+// declare theirs.
+func Propose(cur realm, req daokit.ProposalRequest) uint64 {
+	return localDAO.Propose(req, cur)
+}
+
+// Vote is the legitimate voting entry point.
+func Vote(cur realm, id uint64, vote daocond.Vote) {
+	localDAO.Vote(id, vote, cur)
+}
+
+// Execute is the legitimate execution entry point.
+func Execute(cur realm, id uint64) {
+	localDAO.Execute(id, cur)
+}
+
+// Handle hands out the DAO value. basedao's README teaches realms to expose
+// this, and it is the precondition for the whole donation class: a third realm
+// that holds it can call the entry points directly, bypassing this realm's
+// crossing functions entirely.
+func Handle() daokit.DAO {
+	return localDAO
+}
+
+// ProposerOf reports the identity the DAO resolved for a proposal's creator.
+func ProposerOf(id uint64) string {
+	return daoPrivate.Core.Proposals.GetProposal(id).ProposerID
+}
+
+// NewCrossOutRequest builds a proposal whose execution crosses out of the DAO.
+func NewCrossOutRequest(inner daokit.ProposalRequest) daokit.ProposalRequest {
+	return daokit.ProposalRequest{
+		Title:       "cross out",
+		Description: "hands the DAO's realm to a callee",
+		Action:      daokit.NewAction(ActionCrossOut, inner),
+	}
+}

--- a/gno/r/daoidentity/dao/gnomod.toml
+++ b/gno/r/daoidentity/dao/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/dao"
+gno = "0.9"

--- a/gno/r/daoidentity/initdao/gnomod.toml
+++ b/gno/r/daoidentity/initdao/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/initdao"
+gno = "0.9"

--- a/gno/r/daoidentity/initdao/initdao.gno
+++ b/gno/r/daoidentity/initdao/initdao.gno
@@ -1,0 +1,59 @@
+// Package initdao pins that the realm gate does not break construction.
+//
+// A realm's own init IS a live crossing frame — cur.IsCurrent() holds there —
+// so requiring the threaded realm to be current costs nothing at deploy time. A
+// gate that refused during init would brick every DAO on publication, which is
+// strictly worse than the hole it closes, so this is worth its own fixture.
+//
+// What init does NOT do is leave the caller unnamed. cur.Previous() at the root
+// of a call chain is the origin realm — {signer, ""} — so IsUser() holds and the
+// resolved caller is the SIGNING ACCOUNT's address. On-chain that is the
+// deploying account, which is why seeding a DAO with the deployer as a member
+// and calling InstantExecute from init works.
+//
+// It reads as the empty string under `gno test` only because the harness leaves
+// OriginCaller unset unless a test sets it. Nothing here may assert on that:
+// it is a property of the harness, not of the code being frozen. The empty-id
+// guard is asserted directly, on controlled input, in basedao's own tests.
+package initdao
+
+import (
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+)
+
+const Self = "gno.land/r/samcrew/daoidentity/initdao"
+
+var (
+	localDAO   daokit.DAO
+	daoPrivate *basedao.DAOPrivate
+
+	// RealmWasCurrentDuringInit records that a realm's own init holds its live
+	// realm, so the gate's IsCurrent() requirement cannot brick construction.
+	RealmWasCurrentDuringInit bool
+	// PreviousWasTheOriginRealm records that init sits at the root of the call
+	// chain: its previous realm is the signer, not another realm.
+	PreviousWasTheOriginRealm bool
+)
+
+func init(cur realm) {
+	members := basedao.NewMembersStore(nil, []basedao.Member{{Address: Self}})
+	cond := daocond.MembersThreshold(0.1, members.IsMember, members.MembersCount)
+
+	localDAO, daoPrivate = basedao.New(&basedao.Config{
+		Name:             "Init DAO",
+		Description:      "construction-time gate fixture",
+		Members:          members,
+		InitialCondition: cond,
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		PrivateVarName:   "daoPrivate",
+		NoCreationEvent:  true,
+	}, cur)
+
+	RealmWasCurrentDuringInit = cur.IsCurrent()
+	PreviousWasTheOriginRealm = cur.Previous().IsUserCall()
+}
+
+// Members reports the member count.
+func Members() uint64 { return daoPrivate.Members.MembersCount() }

--- a/gno/r/daoidentity/initdao/initdao_test.gno
+++ b/gno/r/daoidentity/initdao/initdao_test.gno
@@ -1,0 +1,24 @@
+package initdao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// The gate requires the threaded realm to be current. A realm's own init must
+// therefore hold its live realm, or publishing any DAO would panic on the first
+// gated call it makes during construction.
+func TestARealmsOwnInitHoldsItsLiveRealm(t *testing.T) {
+	urequire.True(t, RealmWasCurrentDuringInit,
+		"a realm's init must hold its own live realm, or the gate would brick construction")
+}
+
+// And init sits at the root of the chain: no realm called it, so the identity
+// resolved there is the signing account, not another realm.
+func TestInitSitsAtTheRootOfTheCallChain(t *testing.T) {
+	urequire.True(t, PreviousWasTheOriginRealm,
+		"init's previous realm must be the origin realm, so the caller resolves to the signer")
+	urequire.Equal(t, uint64(1), Members(),
+		"construction must not have added anyone on its own")
+}

--- a/gno/r/daoidentity/nonmember/gnomod.toml
+++ b/gno/r/daoidentity/nonmember/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/nonmember"
+gno = "0.9"

--- a/gno/r/daoidentity/nonmember/nonmember.gno
+++ b/gno/r/daoidentity/nonmember/nonmember.gno
@@ -1,0 +1,10 @@
+// Package nonmember reaches the DAO the supported way — through the DAO realm's
+// own crossing function — but is not a member. The realm gate passes for it; the
+// membership check is the only thing that must not.
+package nonmember
+
+import "gno.land/r/samcrew/daoidentity/dao"
+
+func Execute(cur realm, id uint64) {
+	dao.Execute(cross(cur), id)
+}

--- a/gno/r/daoidentity/relay/gnomod.toml
+++ b/gno/r/daoidentity/relay/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/relay"
+gno = "0.9"

--- a/gno/r/daoidentity/relay/relay.gno
+++ b/gno/r/daoidentity/relay/relay.gno
@@ -1,0 +1,14 @@
+// Package relay is an ordinary intermediary realm: it calls the DAO's own
+// crossing function, so the DAO's immediate caller is this realm.
+package relay
+
+import (
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/dao"
+)
+
+// Propose reaches the DAO the supported way — through the DAO realm's crossing
+// function — so the DAO sees this realm, not whoever called us.
+func Propose(cur realm, req daokit.ProposalRequest) uint64 {
+	return dao.Propose(cross(cur), req)
+}

--- a/gno/r/daoidentity/suite/gnomod.toml
+++ b/gno/r/daoidentity/suite/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/daoidentity/suite"
+gno = "0.9"

--- a/gno/r/daoidentity/suite/suite_test.gno
+++ b/gno/r/daoidentity/suite/suite_test.gno
@@ -1,0 +1,148 @@
+// Package suite drives the DAO across genuine realm boundaries.
+//
+// Every assertion here is unreachable from a testing.SetRealm harness: SetRealm
+// fabricates a cur with no frame beneath it, so cur.Previous() resolves to
+// gno.land/p/samcrew/basedao rather than to a caller. That harness cannot tell
+// a correct caller-identity implementation from a broken one, which is why the
+// original defect and #66's New() regression both passed CI.
+package suite
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/attacker"
+	"gno.land/r/samcrew/daoidentity/callback"
+	"gno.land/r/samcrew/daoidentity/dao"
+	"gno.land/r/samcrew/daoidentity/nonmember"
+	"gno.land/r/samcrew/daoidentity/relay"
+)
+
+const realmMismatch = "realm mismatch: the DAO may only act as gno.land/r/samcrew/daoidentity/dao"
+
+func addMemberReq() daokit.ProposalRequest {
+	return daokit.ProposalRequest{
+		Title:       "add a member",
+		Description: "any registered action will do",
+		Action: basedao.NewAddMemberAction(&basedao.ActionAddMember{
+			Address: "g1v9kxjcm9ta047h6lta047h6lta047h6lzd40gh",
+		}),
+	}
+}
+
+// The control for every refusal below. This realm is a DAO member, so a call
+// that reaches the membership check from here passes it. Any refusal in the
+// other tests is therefore the realm gate, not an incidental membership
+// failure — and, before the gate existed, this membership is exactly what let
+// a foreign realm's call through.
+func TestSuiteIsAMemberSoMembershipIsSatisfiable(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addMemberReq())
+
+	urequire.Equal(t, dao.SuiteID, dao.ProposerOf(id),
+		"the DAO must resolve its immediate caller, which is this realm")
+}
+
+// The DAO's immediate caller is the relay, not the account that signed the
+// transaction.
+//
+// A stack walk gets this same answer, because the DAO realm's own frame is on
+// the stack here. It is not a regression test for the identity derivation; it
+// pins that reaching the DAO the supported way resolves the immediate caller,
+// which is the behaviour the demos and every realm integration depend on.
+func TestTheResolvedCallerIsTheImmediateOne(cur realm, t *testing.T) {
+	id := relay.Propose(cross(cur), addMemberReq())
+
+	urequire.Equal(t, dao.RelayID, dao.ProposerOf(id),
+		"the relay called the DAO, so the relay is the proposer")
+}
+
+// P0-B, the donation path: a third realm holding the DAO value hands it its own
+// realm. Execute forwards that realm to the action handlers, which cross out
+// under it, so an accepted foreign realm makes the DAO act as the caller —
+// writing to the caller's profile, and through MigrateFn reaching any realm the
+// caller controls.
+//
+// Realm values are unforgeable and cannot be persisted across transactions, so
+// a caller can only ever pass its own. Requiring the realm to be the DAO's own
+// therefore closes the path outright, without trusting the caller.
+func TestAForeignRealmMayNotDonateItsIdentityToExecute(cur realm, t *testing.T) {
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		// The proposal id is irrelevant: the realm gate runs before any
+		// lookup, so a foreign realm never reaches proposal state at all.
+		attacker.Execute(cross(cur), 0)
+	})
+}
+
+// P0-A is the same defect from the other side. Reached this way there is no DAO
+// realm frame on the stack, so basedao's old stack-walking identity named the
+// signer rather than the attacker — and the signer is a member, as
+// TestSuiteIsAMemberSoMembershipIsSatisfiable establishes. The membership check
+// passed while the attacker supplied the realm the DAO acted under.
+func TestAForeignRealmMayNotDonateItsIdentityToPropose(cur realm, t *testing.T) {
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		attacker.Propose(cross(cur), addMemberReq())
+	})
+}
+
+func TestAForeignRealmMayNotDonateItsIdentityToVote(cur realm, t *testing.T) {
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		attacker.Vote(cross(cur), 0, daocond.VoteYes)
+	})
+}
+
+// A realm the DAO crosses out into receives the DAO's own realm value as its
+// cur.Previous(). That value carries the DAO's pkgpath, so a gate that only
+// compares pkgpaths accepts it back — letting a callee re-enter the DAO under
+// the DAO's own identity, from a frame the DAO never intended to be re-entered
+// from.
+//
+// It is not the live crossing frame's cur, so IsCurrent() is false and the gate
+// refuses it. Nothing but IsCurrent() distinguishes it.
+func TestADAORealmValueFromADeadFrameIsRefused(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), dao.NewCrossOutRequest(addMemberReq()))
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.False(t, callback.Reentered(),
+		"the re-entrant proposal must never have been accepted")
+}
+
+// The entry gate must run BEFORE CallerID, not after.
+//
+// CallerIDFn is a frozen extension point, so the realm it receives is part of
+// the contract. If the membership check ran first, a custom CallerIDFn would be
+// handed an attacker-controlled realm and asked to derive an identity from it —
+// which is the whole defect, relocated into the extension point. Nothing else
+// in the suite pins the ordering: swapping the two lines leaves every other
+// test green.
+func TestTheGateRunsBeforeCallerIDEverSeesTheRealm(cur realm, t *testing.T) {
+	// A legitimate call, to show CallerID does run and does record.
+	dao.Propose(cross(cur), addMemberReq())
+	urequire.Equal(t, dao.Self, dao.SeenByCallerID(),
+		"CallerID must be handed the DAO's own realm on the supported path")
+
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		attacker.Propose(cross(cur), addMemberReq())
+	})
+	urequire.Equal(t, dao.Self, dao.SeenByCallerID(),
+		"a refused call must never reach CallerID, so the recorded realm is unchanged")
+}
+
+// Execute requires membership, not merely a valid realm. The DAO realm's own
+// crossing functions are callable by anyone, so without this a non-member could
+// execute any proposal that had reached its threshold.
+func TestExecuteRequiresMembershipNotJustTheRightRealm(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addMemberReq())
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+
+	// nonmember reaches the DAO through its own crossing function, so the realm
+	// gate passes and only the membership check stands between it and execution.
+	urequire.AbortsWithMessage(t, cur, "caller is not a member", func() {
+		nonmember.Execute(cross(cur), id)
+	})
+}


### PR DESCRIPTION
Completes the P0-A / P0-B interface work. This is the last interface-breaking change before the topaz-1 freeze, so it is now-or-never.

## The defect

Both blockers are the same defect seen from two sides.

`Execute` forwards the threaded realm to the action handlers, which cross out under it. Whoever supplies that realm therefore decides the identity the DAO acts as — a third realm holding the DAO value could pass its own and have the DAO write to that realm's profile, or through `MigrateFn` reach anywhere it controls.

And reached through the DAO handle there is **no DAO realm frame on the stack at all**, so the old stack-walking identity named the *signing account*. A member's signature satisfied the membership check while the caller supplied the realm the DAO acted under.

## The fix

`Propose(req, rlm)` / `Vote(id, vote, rlm)` / `Execute(id, rlm)` each assert the threaded realm is the DAO realm's own **live** one before doing anything else. Realm values are unforgeable and cannot be persisted across transactions, so a caller can only ever pass its own; requiring it to equal the DAO's own closes the donation path outright. Given that, `rlm.Previous()` is by construction the DAO's immediate caller.

The gate requires the realm to be **current**, not merely to match by pkgpath. Every realm the DAO crosses out into during an action receives the DAO's own realm as its `cur.Previous()` and can hand it straight back within the same transaction: same pkgpath, dead frame. Reproduced end to end — with a pkgpath-only gate a callee re-entered `Propose` under the DAO's own identity and was accepted. `IsCurrent()` is frame identity rather than name; verified it survives the `/p/` hop into basedao and holds during a realm's own `init`, so neither the ordinary path nor construction is affected.

The realm is never a first parameter — the VM reads that as a crossing function, which `/p/` packages may not declare. Receivers do not count, so `assertRealmIsOwn` and `defaultCallerID` take the DAO first.

## Tests

`testing.SetRealm` fabricates a `cur` with no frame beneath it: `cur.Previous()` resolves to `gno.land/p/samcrew/basedao` itself. It cannot express a caller chain in either direction, which is why the original defect *and* the `New()` regression in #66 both passed CI.

Tests are therefore realm-to-realm, under `gno/r/daoidentity/` — a DAO realm, a relay, a non-member, an attacker holding the DAO value, and a callee re-entering with the DAO's own dead-frame realm. These are fixtures only; the deployer publishes an explicit 7-directory list that excludes them, and `assert_gnodaokit_source_form topaz-1` passes against this branch.

Five properties are **mutation-checked**, each failing exactly one test:

| Mutation | Caught by |
|---|---|
| drop `!rlm.IsCurrent()` | `TestADAORealmValueFromADeadFrameIsRefused` |
| drop the pkgpath equality | the three `MayNotDonateItsIdentity` tests |
| drop the empty-id guard | `TestAnEmptyCallerIdIsNeverAMember` |
| membership checked before the realm gate | `TestTheGateRunsBeforeCallerIDEverSeesTheRealm` |
| drop `Execute`'s membership check | `TestExecuteRequiresMembershipNotJustTheRightRealm` |

Ordering is pinned because `CallerIDFn` is a frozen extension point: running membership first would hand a custom implementation an attacker-controlled realm.

`basedao`'s unit tests now declare the caller they act as rather than leaning on the harness, and `realm_identity_test.gno` is dropped — SetRealm-based identity tests claim coverage that cannot exist.

## Two corrections found in review

- **The stack walk is not wrong the way earlier notes recorded.** On every path the gate admits, `unsafe.PreviousRealm()` and `rlm.Previous()` name the same realm — the gate has already established the DAO's frame is live. The walk goes wrong only in the shape the gate now rejects. Comments were corrected to say this; the threaded form is kept because it does not depend on the gate having run first.
- **Root-of-chain does not yield `""` on-chain.** `buildOriginRealm` sets `{OriginCaller, ""}`, so `IsUser()` holds and a root-of-chain call resolves to the *signing account*. The empty id is a `gno test` artifact (the harness leaves `OriginCaller` unset). The empty-id guard is asserted on controlled input instead, and it is load-bearing: `AddMember` does not reject `""`, `Members` is an exported `avl.Tree` a `MigrateFn` can seed directly, and any unattributable call resolves to `""`.

## Verification

`gno test ./gno/...` green (8 packages) · `gno lint` clean · `gno fmt -diff` clean · zero `gno: downloading` · deployer `assert_gnodaokit_source_form topaz-1` passes.

Base is `feat/topaz-v2-rename`, not `main`: `main` is pre-interrealm-v2 and not locally buildable.