### PR TITLE
fix(basedao,daokit,daocond): settle the exported surface before it freezes

### DIFF
--- a/.github/scripts/check-readme-examples.sh
+++ b/.github/scripts/check-readme-examples.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# The READMEs ship with the frozen package, so a sample that does not build is as
+# permanent as a wrong signature — and both "Complete Example" blocks did not
+# build. gno/r/readme_*_example compile them and run their init, but that only
+# means anything while they still say what the README says. This re-extracts each
+# block and diffs it, so the two cannot drift apart silently.
+set -euo pipefail
+
+extract() { # <markdown> <package>
+    python3 -c '
+import re, sys
+md, pkg = sys.argv[1], sys.argv[2]
+for b in re.findall(r"```go\n(.*?)```", open(md).read(), re.S):
+    if "func init(cur realm)" in b and "basedao.New" in b:
+        sys.stdout.write(b.replace("package my_dao", "package " + pkg))
+        break
+else:
+    sys.exit("no Complete Example block found in " + md)
+' "$1" "$2"
+}
+
+check() { # <markdown> <fixture> <package>
+    local md="$1" fixture="$2" pkg="$3"
+    extract "$md" "$pkg" > /tmp/readme-extracted.gno
+    if [[ ! -s /tmp/readme-extracted.gno ]]; then
+        echo "ERROR: extracted nothing from $md — the block markers changed"
+        return 1
+    fi
+    # The fixture carries a header comment the README does not; drop everything
+    # before its package clause. Done in python because BSD and GNU sed disagree
+    # about the range-with-block form.
+    python3 -c '
+import sys
+lines = open(sys.argv[1]).read().split("\n")
+for i, l in enumerate(lines):
+    if l.startswith("package "):
+        sys.stdout.write("\n".join(lines[i:]))
+        break
+else:
+    sys.exit("no package clause in " + sys.argv[1])
+' "$fixture" > /tmp/readme-fixture.gno
+    if ! diff -u /tmp/readme-extracted.gno /tmp/readme-fixture.gno; then
+        echo "ERROR: $md's Complete Example no longer matches $fixture."
+        echo "They are compiled together on purpose. Update both."
+        return 1
+    fi
+    echo "OK: $md matches $fixture"
+}
+
+check README.md                gno/r/readme_root_example/sample.gno    readme_root_example
+check gno/p/basedao/README.md  gno/r/readme_basedao_example/sample.gno readme_basedao_example

--- a/.github/workflows/gno-test.yml
+++ b/.github/workflows/gno-test.yml
@@ -21,3 +21,8 @@ jobs:
 
       - name: Test gno
         run: make test
+
+      # The READMEs ship with the frozen package, so a sample that does not
+      # build is as permanent as a wrong signature. See the script for why.
+      - name: README examples match their compiled fixtures
+        run: ./.github/scripts/check-readme-examples.sh

--- a/README.md
+++ b/README.md
@@ -121,11 +121,16 @@ Interface functions for creating proposals, voting, and executing actions.
 
 ```go
 type DAO interface {
-	Propose(req ProposalRequest) uint64    // Create a new proposal, returns proposal ID
-	Vote(id uint64, vote daocond.Vote)     // Cast a vote on an existing proposal
-	Execute(id uint64, rlm realm)          // Execute a passed proposal (threads the realm for cross-calls)
+	Propose(req ProposalRequest, rlm realm) uint64  // Create a new proposal, returns proposal ID
+	Vote(id uint64, vote daocond.Vote, rlm realm)   // Cast a vote on an existing proposal
+	Execute(id uint64, rlm realm)                   // Execute a passed proposal
 }
 ```
+
+Every entry point threads the DAO realm's own realm value. The implementation
+requires it to be the DAO's own and to be current, which is what lets it name
+the DAO's immediate caller — and what stops a realm holding this handle from
+making the DAO act under the caller's identity.
 
 ### 2.2.3 Proposal Lifecycle
 
@@ -221,7 +226,7 @@ type Config struct {
 	SetImplemFn       SetImplemRaw      // Function called when DAO implementation changes via governance
 	MigrationParamsFn MigrationParamsFn // Function providing parameters for DAO upgrades
 	RenderFn          RenderFn          // Rendering function for Gnoweb
-	CallerID          CallerIDFn        // Custom function to identify the current caller, defaults to realmid.Previous
+	CallerID          CallerIDFn        // Custom function to identify the current caller, defaults to the DAO's immediate caller
 
 	// Internal configuration
 	PrivateVarName string // Name of the private DAO variable for member querying extensions
@@ -242,7 +247,9 @@ import (
 )
 
 var (
-	DAO        daokit.DAO          // External interface for DAO interaction
+	// Unexported deliberately: anything that can reach this value can call the
+	// DAO's entry points directly, bypassing this realm's crossing functions.
+	localDAO   daokit.DAO
 	daoPrivate *basedao.DAOPrivate // Full access to internal DAO state
 )
 
@@ -266,7 +273,7 @@ func init(cur realm) {
     condition := daocond.MembersThreshold(0.6, store.IsMember, store.MembersCount)
 
     // Create the DAO (cur is threaded so the DAO can perform cross-realm calls)
-    DAO, daoPrivate = basedao.New(&basedao.Config{
+    localDAO, daoPrivate = basedao.New(&basedao.Config{
         Name:             "My DAO",
         Description:      "A simple DAO example",
         Members:          store,
@@ -278,22 +285,22 @@ func init(cur realm) {
 // To execute this function, you must use a MsgRun (maketx run)
 // See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
 func Propose(cur realm, req daokit.ProposalRequest) {
-	DAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 // Allows DAO members to cast their vote on a specific proposal
 func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
-    DAO.Vote(proposalID, vote)
+    localDAO.Vote(proposalID, vote, cur)
 }
 
 // Triggers the implementation of a proposal's actions
 func Execute(cur realm, proposalID uint64) {
-	DAO.Execute(proposalID, cur)
+	localDAO.Execute(proposalID, cur)
 }
 
 // Render generates a UI representation of the DAO's state
 func Render(path string) string {
-	return DAO.Render(path)
+	return localDAO.Render(path)
 }
 ```
 
@@ -420,7 +427,7 @@ type Extension interface {
 }
 
 type ExtensionInfo struct {
-    Path      string // Unique extension identifier (e.g., "gno.land/p/demo/basedao.MembersView")
+    Path      string // Unique extension identifier (e.g., "gno.land/p/samcrew/basedao.MembersView")
     Version   string // Extension version (e.g., "1", "2.0", etc.)
     QueryPath string // Path for external queries to access this extension's data
     Private   bool   // If true, extension is only accessible from the same realm
@@ -431,7 +438,7 @@ type ExtensionInfo struct {
 
 ```go
 // Get a specific extension by path
-ext := dao.Extension("gno.land/p/demo/basedao.MembersView")
+ext := dao.Extension("gno.land/p/samcrew/basedao.MembersView")
 
 // List all available extensions
 extList := dao.ExtensionsList()
@@ -517,7 +524,7 @@ message := customExt.SayHello("Alice")
 Built-in [`basedao.MembersViewExtension`](./gno/p/basedao/README.md#7-membership-extension) allows external packages to check DAO membership from any realm:
 
 ```go
-const MembersViewExtensionPath = "gno.land/p/demo/basedao.MembersView"
+const MembersViewExtensionPath = "gno.land/p/samcrew/basedao.MembersView"
 
 // Check if someone is a DAO member
 ext := basedao.MustGetMembersViewExtension(dao)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ governance := daocond.And(
     daocond.RoleCount(2, "core-contributor", store.HasRole),
     daocond.Or(
         daocond.RoleCount(1, "CTO", store.HasRole),
-        daocond.RoleThreshold(0.5, "finance", store.HasRole, store.RoleCount),
+        daocond.RoleThreshold(0.5, "finance", store.HasRole, store.CountMembersWithRole),
     ),
 )
 ```
@@ -169,6 +169,8 @@ DAO, daoPrivate := basedao.New(&basedao.Config{
 	Description:      "A sample DAO",
 	Members:          store,
 	InitialCondition: memberMajority,
+	// Required: New() panics without it.
+	GetProfileString: profile.GetStringField,
 }, cur)
 ```
 
@@ -244,6 +246,7 @@ import (
     "gno.land/p/samcrew/basedao"
     "gno.land/p/samcrew/daocond"
     "gno.land/p/samcrew/daokit"
+    "gno.land/r/demo/profile"
 )
 
 var (
@@ -278,6 +281,9 @@ func init(cur realm) {
         Description:      "A simple DAO example",
         Members:          store,
         InitialCondition: condition,
+        // Required: New() panics without it.
+        GetProfileString: profile.GetStringField,
+        SetProfileString: profile.SetStringField,
     }, cur)
 }
 
@@ -399,7 +405,7 @@ func NewPostHandler(blog *Blog) daokit.ActionHandler {
 4. Register the resource
 ```go
 resource := daokit.Resource{
-    Condition: daocond.NewRoleCount(1, "CEO", daoPrivate.Members.HasRole),
+    Condition: daocond.RoleCount(1, "CEO", daoPrivate.Members.HasRole),
     Handler: blog.NewPostHandler(blog),
 }
 daoPrivate.Core.Resources.Set(&resource)
@@ -460,12 +466,13 @@ if extIndex != nil {
     fmt.Printf("First extension: %s\n", extIndex.Path)
 }
 
-// Use your extension
-ext, ok := extIndex.(*MembersViewExtension)
+// Use your extension. Get(i) returns an *ExtensionInfo — metadata, not the
+// extension itself — so fetch the extension by path and assert the interface.
+ext, ok := dao.Extension(extIndex.Path).(basedao.MembersViewExtension)
 if !ok {
     panic("Invalid extension type")
 }
-ext.IsMember()
+ext.IsMember("g1user...")
 ```
 
 ## 7.3 Creating Custom Extensions

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -400,23 +400,28 @@ if ext.IsMember("g1user...") {
 package my_content
 
 import (
-    "chain/runtime/unsafe"
-
     "gno.land/p/samcrew/basedao"
     "gno.land/r/some/dao"
 )
 
-func Post(title, content string) {
-    caller := unsafe.PreviousRealm().Address()
+func Post(cur realm, title, content string) {
+    if !cur.IsCurrent() {
+        panic("spoofed realm")
+    }
+    caller := cur.Previous().Address()
     ext := basedao.MustGetMembersViewExtension(dao.DAO)
-    
+
     if !ext.IsMember(caller.String()) {
         panic("Only DAO members can post")
     }
-    
+
     createPost(title, content)
 }
 ```
+
+`Post` is a crossing function so `cur.Previous()` names its immediate caller.
+`unsafe.PreviousRealm()` in a non-crossing function names the outermost
+crossing realm instead.
 
 The extension is automatically registered when you create a DAO with `basedao.New()`.
 

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -162,8 +162,10 @@ localDAO.Vote(3, daocond.VoteAbstain, cur) // Vote abstain on proposal #3
 #### Executing Proposals  
 ```go
 // Execute a proposal that has passed its voting requirements.
-// cur is threaded down to the action handler so it can perform cross-realm calls.
-func Execute(cur realm, proposalID uint64) {...}
+// The realm is threaded down to the action handler so it can perform
+// cross-realm calls. It is last: a leading realm parameter is read as a
+// crossing function, which /p/ packages may not declare.
+func Execute(proposalID uint64, rlm realm) {...}
 
 localDAO.Execute(1, cur) // Execute proposal #1 -- only works if it has enough votes
 ```
@@ -202,6 +204,7 @@ import (
     "gno.land/p/samcrew/basedao"
     "gno.land/p/samcrew/daocond"
     "gno.land/p/samcrew/daokit"
+    "gno.land/r/demo/profile"
 )
 
 var (
@@ -236,6 +239,9 @@ func init(cur realm) {
         Description:      "A simple DAO example",
         Members:          store,
         InitialCondition: condition,
+        // Required: New() panics without it.
+        GetProfileString: profile.GetStringField,
+        SetProfileString: profile.SetStringField,
     }, cur)
 }
 
@@ -253,12 +259,19 @@ func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
 
 // Triggers the implementation of a proposal's actions
 func Execute(cur realm, proposalID uint64) {
-	locallocalDAO.Execute(proposalID, cur)
+	localDAO.Execute(proposalID, cur)
 }
 
 // Render generates a UI representation of the DAO's state
 func Render(path string) string {
 	return localDAO.Render(path)
+}
+
+// Handle exposes the DAO to other realms. Note it is a function, not an
+// exported variable: it is the only intentional way out, and anything holding
+// this value can call the entry points directly.
+func Handle() daokit.DAO {
+	return localDAO
 }
 ```
 
@@ -304,7 +317,7 @@ Supports upgrading DAO implementations through governance proposals, allowing DA
 ### 5.1 Configuration for Upgrades
 
 ```go
-DAO, daoPrivate = basedao.New(&basedao.Config{
+localDAO, daoPrivate = basedao.New(&basedao.Config{
     // ... other config
     MigrationParamsFn: func() []any { return nil }, // Parameters passed to migration function
 
@@ -313,7 +326,7 @@ DAO, daoPrivate = basedao.New(&basedao.Config{
 
 // Update DAO variable after migration
 func setImplem(newDAO daokit.DAO) {
-    DAO = newDAO
+    localDAO = newDAO
 }
 ```
 
@@ -344,6 +357,7 @@ func migrateTo2_0(prev *basedao.DAOPrivate, params []any, rlm realm) daokit.DAO 
         Description:      "Upgraded DAO with audit capabilities",
         Members:          memberStore,
         InitialCondition: prev.InitialConfig.InitialCondition,
+        GetProfileString: prev.GetProfileString,
         // ... other configuration
     }, rlm)
     
@@ -364,7 +378,7 @@ localDAO.Execute(proposalID, cur)
 
 // Alternatively, you can use InstantExecute to skip the voting process
 // if you have sufficient permissions to execute the action directly
-daokit.InstantExecute(DAO, proposal, cur) 
+daokit.InstantExecute(localDAO, proposal, cur) 
 ```
 
 ## 6. Event System

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -124,7 +124,7 @@ Allow DAO's members to interact through proposals and voting.
 ```go
 // Create a new proposal for members to vote on
 // Returns its proposal ID
-func Propose(req daokit.ProposalRequest) uint64 {...}
+func Propose(req daokit.ProposalRequest, rlm realm) uint64 {...}
 
 type ProposalRequest struct {
 	Title       string 
@@ -145,18 +145,18 @@ proposal := daokit.ProposalRequest{
     Description: "Proposal to add Alice as treasurer for better fund management",
     Action:      addMemberAction,
 }
-proposalID := Propose(proposal)
+proposalID := localDAO.Propose(proposal, cur)
 ```
 
 #### Voting on Proposals
 ```go
 // Cast your vote on an active proposal
 // Available vote: VoteYes, VoteNo, VoteAbstain
-func Vote(proposalID uint64, vote daocond.Vote) {...}
+func Vote(proposalID uint64, vote daocond.Vote, rlm realm) {...}
 
-Vote(1, daocond.VoteYes) // Vote yes on proposal #1
-Vote(2, daocond.VoteNo) // Vote no on proposal #2
-Vote(3, daocond.VoteAbstain) // Vote abstain on proposal #3
+localDAO.Vote(1, daocond.VoteYes, cur) // Vote yes on proposal #1
+localDAO.Vote(2, daocond.VoteNo, cur) // Vote no on proposal #2
+localDAO.Vote(3, daocond.VoteAbstain, cur) // Vote abstain on proposal #3
 ```
 
 #### Executing Proposals  
@@ -165,7 +165,7 @@ Vote(3, daocond.VoteAbstain) // Vote abstain on proposal #3
 // cur is threaded down to the action handler so it can perform cross-realm calls.
 func Execute(cur realm, proposalID uint64) {...}
 
-Execute(cross(cur), 1) // Execute proposal #1 -- only works if it has enough votes
+localDAO.Execute(1, cur) // Execute proposal #1 -- only works if it has enough votes
 ```
 
 #### Instant Execution
@@ -174,7 +174,7 @@ Skip the voting process and execute a proposal immediately if you have the requi
 
 ```go
 // This performs: Propose() -> Vote(VoteYes) -> Execute()
-proposalID := daokit.InstantExecute(DAO, proposal, cur)
+proposalID := daokit.InstantExecute(localDAO, proposal, cur)
 ```
 
 Useful for admin actions, migrations, and emergency procedures.
@@ -205,7 +205,9 @@ import (
 )
 
 var (
-	DAO        daokit.DAO          // External interface for DAO interaction
+	// Unexported deliberately: anything that can reach this value can call the
+	// DAO's entry points directly, bypassing this realm's crossing functions.
+	localDAO   daokit.DAO
 	daoPrivate *basedao.DAOPrivate // Full access to internal DAO state
 )
 
@@ -229,7 +231,7 @@ func init(cur realm) {
     condition := daocond.MembersThreshold(0.6, store.IsMember, store.MembersCount)
 
     // Create the DAO (cur is threaded so the DAO can perform cross-realm calls)
-    DAO, daoPrivate = basedao.New(&basedao.Config{
+    localDAO, daoPrivate = basedao.New(&basedao.Config{
         Name:             "My DAO",
         Description:      "A simple DAO example",
         Members:          store,
@@ -241,22 +243,22 @@ func init(cur realm) {
 // To execute this function, you must use a MsgRun (maketx run)
 // See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
 func Propose(cur realm, req daokit.ProposalRequest) {
-	DAO.Propose(req)
+	localDAO.Propose(req, cur)
 }
 
 // Allows DAO members to cast their vote on a specific proposal
 func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
-    DAO.Vote(proposalID, vote)
+    localDAO.Vote(proposalID, vote, cur)
 }
 
 // Triggers the implementation of a proposal's actions
 func Execute(cur realm, proposalID uint64) {
-	DAO.Execute(proposalID, cur)
+	locallocalDAO.Execute(proposalID, cur)
 }
 
 // Render generates a UI representation of the DAO's state
 func Render(path string) string {
-	return DAO.Render(path)
+	return localDAO.Render(path)
 }
 ```
 
@@ -288,7 +290,7 @@ type Config struct {
 	SetImplemFn       SetImplemRaw      // Function called when DAO implementation changes via governance
 	MigrationParamsFn MigrationParamsFn // Function providing parameters for DAO upgrades
 	RenderFn          RenderFn          // Rendering function for Gnoweb
-	CallerID          CallerIDFn        // Custom function to identify the current caller, defaults to realmid.Previous
+	CallerID          CallerIDFn        // Custom function to identify the current caller, defaults to the DAO's immediate caller
 
 	// Internal configuration
 	PrivateVarName string // Name of the private DAO variable for member querying extensions
@@ -355,10 +357,10 @@ proposal := daokit.ProposalRequest{
     Description: "Adds auditor role and enhanced governance",
     Action:      action,
 }
-proposalID := DAO.Propose(proposal)
+proposalID := localDAO.Propose(proposal, cur)
 
 // 3. Execute Migration
-DAO.Execute(proposalID, cur)
+localDAO.Execute(proposalID, cur)
 
 // Alternatively, you can use InstantExecute to skip the voting process
 // if you have sufficient permissions to execute the action directly
@@ -408,10 +410,17 @@ func Post(cur realm, title, content string) {
     if !cur.IsCurrent() {
         panic("spoofed realm")
     }
-    caller := cur.Previous().Address()
-    ext := basedao.MustGetMembersViewExtension(dao.DAO)
 
-    if !ext.IsMember(caller.String()) {
+    // A member id is an ADDRESS for an account and a PKGPATH for a realm.
+    // Using the address unconditionally silently locks out every realm member.
+    prev := cur.Previous()
+    caller := prev.PkgPath()
+    if prev.IsUser() {
+        caller = prev.Address().String()
+    }
+
+    ext := basedao.MustGetMembersViewExtension(dao.Handle())
+    if !ext.IsMember(caller) {
         panic("Only DAO members can post")
     }
 
@@ -419,9 +428,14 @@ func Post(cur realm, title, content string) {
 }
 ```
 
-`Post` is a crossing function so `cur.Previous()` names its immediate caller.
-`unsafe.PreviousRealm()` in a non-crossing function names the outermost
-crossing realm instead.
+`Post` is a crossing function, so `cur.Previous()` names its immediate caller
+and `cur.IsCurrent()` establishes that `cur` is this frame's own realm rather
+than one handed over by someone else.
+
+Note what the DAO realm exposes: a function returning the handle, not an
+exported `DAO` variable. Anything that can reach the `daokit.DAO` value can call
+its entry points directly, bypassing this realm's crossing functions entirely —
+which is the whole reason those entry points check the realm they are given.
 
 The extension is automatically registered when you create a DAO with `basedao.New()`.
 

--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -182,6 +182,10 @@ func (m *MembersStore) setMembers(members []Member) {
 }
 
 func (m *MembersStore) AddMember(member string, roles []string) {
+	// "" is what CallerID resolves to when it cannot name the caller.
+	if member == "" {
+		panic("member id must not be empty")
+	}
 	if m.IsMember(member) {
 		panic("member already exists")
 	}

--- a/gno/p/basedao/members.gno
+++ b/gno/p/basedao/members.gno
@@ -247,6 +247,14 @@ func (m *MembersStore) RemoveMember(member string) {
 }
 
 func (m *MembersStore) AddRole(role RoleInfo) {
+	// An empty role name is not merely useless, it is destructive. Role names
+	// are substituted into rendered prose by RenderWithRolesLinks, and
+	// strings.ReplaceAll with an empty needle matches between every character:
+	// "hello world" comes back as 227 characters of repeated link. Once a DAO is
+	// published there is no way to remove the role from a render path.
+	if role.Name == "" {
+		panic("role name must not be empty")
+	}
 	if m.Roles.Has(role.Name) {
 		panic("role already exists")
 	}

--- a/gno/p/basedao/members_extension.gno
+++ b/gno/p/basedao/members_extension.gno
@@ -6,7 +6,11 @@ type MembersViewExtension interface {
 	IsMember(memberId string) bool
 }
 
-const MembersViewExtensionPath = "gno.land/p/demo/basedao.MembersView"
+// The extension registry key. It names this package, so it has to match the
+// path this package is published at — third-party lookups are pinned to this
+// literal once published, and it named gno.land/p/demo/basedao, which does not
+// exist.
+const MembersViewExtensionPath = "gno.land/p/samcrew/basedao.MembersView"
 
 func MustGetMembersViewExtension(dao daokit.DAO) MembersViewExtension {
 	ext := dao.Extension(MembersViewExtensionPath)

--- a/gno/p/basedao/members_test.gno
+++ b/gno/p/basedao/members_test.gno
@@ -1,0 +1,33 @@
+package basedao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// "" is what CallerID resolves to when it cannot name the caller.
+func TestAddMemberRejectsEmptyID(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, nil)
+
+	urequire.PanicsWithMessage(t, cur, "member id must not be empty", func() {
+		store.AddMember("", nil)
+	})
+	urequire.False(t, store.IsMember(""), "empty id must not be stored")
+	urequire.Equal(t, uint64(0), store.MembersCount())
+}
+
+func TestNewMembersStoreRejectsEmptyInitialMember(cur realm, t *testing.T) {
+	urequire.PanicsWithMessage(t, cur, "member id must not be empty", func() {
+		NewMembersStore(nil, []Member{{Address: "", Roles: []string{}}})
+	})
+}
+
+func TestAddMemberAcceptsNonEmptyID(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, nil)
+
+	urequire.NotPanics(t, cur, func() {
+		store.AddMember(alice.String(), nil)
+	})
+	urequire.True(t, store.IsMember(alice.String()))
+}

--- a/gno/p/basedao/roles_guard_test.gno
+++ b/gno/p/basedao/roles_guard_test.gno
@@ -1,0 +1,63 @@
+package basedao
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/avl"
+)
+
+// An empty role name is destructive, not merely useless: RenderWithRolesLinks
+// substitutes role names into rendered prose, and strings.ReplaceAll with an
+// empty needle matches between every character. Measured before the guard:
+// "hello world", 11 characters, came back as 227.
+func TestAddRoleRejectsAnEmptyName(cur realm, t *testing.T) {
+	store := NewMembersStore(nil, nil)
+
+	urequire.PanicsWithMessage(t, cur, "role name must not be empty", func() {
+		store.AddRole(RoleInfo{Name: "", Description: "d", Color: "#000"})
+	})
+	urequire.Equal(t, 0, len(store.GetRoles()), "empty role must not be stored")
+}
+
+func TestNewMembersStoreRejectsAnEmptyInitialRole(cur realm, t *testing.T) {
+	urequire.PanicsWithMessage(t, cur, "role name must not be empty", func() {
+		NewMembersStore([]RoleInfo{{Name: "", Description: "d", Color: "#000"}}, nil)
+	})
+}
+
+// Roles is an exported avl.Tree, so the guard at the door is not the only way in.
+// The render path must stay safe even when the store was seeded around it.
+func TestRenderSkipsAnEmptyRoleSeededPastTheGuard(cur realm, t *testing.T) {
+	conf := &Config{
+		Name:             "d",
+		Description:      "d",
+		Members:          NewMembersStore(nil, []Member{{alice.String(), nil}}),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/daorealm"))
+	_, d := New(conf, cur)
+
+	// Past AddRole entirely.
+	d.Members.Roles.Set("", &Role{Name: "", Members: avl.NewTree()})
+
+	urequire.Equal(t, "hello world", d.RenderWithRolesLinks("hello world"),
+		"an empty role must not be substituted into rendered prose")
+}
+
+// A real role still renders, so the skip does not disable the feature.
+func TestRenderStillLinksRealRoles(cur realm, t *testing.T) {
+	conf := &Config{
+		Name:             "d",
+		Description:      "d",
+		Members:          NewMembersStore([]RoleInfo{{Name: "admin", Description: "a", Color: "#000"}}, []Member{{alice.String(), []string{"admin"}}}),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/daorealm2"))
+	_, d := New(conf, cur)
+
+	urequire.NotEqual(t, "the admin decides", d.RenderWithRolesLinks("the admin decides"),
+		"a real role must still be linked")
+}

--- a/gno/p/basedao/roles_guard_test.gno
+++ b/gno/p/basedao/roles_guard_test.gno
@@ -46,6 +46,33 @@ func TestRenderSkipsAnEmptyRoleSeededPastTheGuard(cur realm, t *testing.T) {
 		"an empty role must not be substituted into rendered prose")
 }
 
+// The members table substitutes role names the same way, and an empty role
+// reaches it through the ordinary API: once "" is in Roles, AddRoleToMember
+// assigns it like any other role.
+func TestMembersTableSkipsAnEmptyRole(cur realm, t *testing.T) {
+	conf := &Config{
+		Name:             "d",
+		Description:      "d",
+		Members:          NewMembersStore([]RoleInfo{{Name: "admin", Description: "a", Color: "#000"}}, []Member{{alice.String(), []string{"admin"}}}),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/daorealm3"))
+	_, d := New(conf, cur)
+
+	before := len(d.RenderMembersTable("", d.Members.Members))
+
+	d.Members.Roles.Set("", &Role{Name: "", Members: avl.NewTree()})
+	d.Members.AddRoleToMember(alice.String(), "")
+
+	// The empty role legitimately adds a separator to the joined list, so the
+	// table grows by a couple of characters. Without the skip it grows by 4.4x:
+	// measured 585 -> 2578, against 585 -> 587 with it.
+	after := len(d.RenderMembersTable("", d.Members.Members))
+	urequire.True(t, after < before+16,
+		"an empty role must not be substituted into the members table")
+}
+
 // A real role still renders, so the skip does not disable the feature.
 func TestRenderStillLinksRealRoles(cur realm, t *testing.T) {
 	conf := &Config{

--- a/gno/p/basedao/utils.gno
+++ b/gno/p/basedao/utils.gno
@@ -148,6 +148,13 @@ func (d *DAOPrivate) RenderMembersTable(path string, members *avl.Tree) string {
 			rolesStr = d.RenderRoleLinkWithChip("")
 		}
 		for _, role := range roles {
+			// Same empty-needle hazard as RenderWithRolesLinks: an empty role
+			// name matches between every character. AddRole refuses one, but
+			// Roles is an exported avl.Tree that can be seeded around it — and
+			// once it holds "", AddRoleToMember will happily assign it.
+			if role == "" {
+				continue
+			}
 			rolesStr = strings.Replace(rolesStr, role, d.RenderRoleLinkWithChip(role), -1)
 		}
 

--- a/gno/p/basedao/utils.gno
+++ b/gno/p/basedao/utils.gno
@@ -40,6 +40,13 @@ func RenderAddressLink(addr string) string {
 func (d *DAOPrivate) RenderWithRolesLinks(s string) string {
 	roles := d.Members.GetRoles()
 	for _, role := range roles {
+		// AddRole refuses an empty name, but Roles is an exported avl.Tree that
+		// a same-realm write or a MigrateFn can seed directly. An empty needle
+		// makes ReplaceAll match between every character, so skipping here keeps
+		// the render path safe however the store was filled.
+		if role == "" {
+			continue
+		}
 		s = strings.ReplaceAll(s, role, d.RenderRoleLink(role))
 	}
 	return s

--- a/gno/p/basedao/view_proposal_detail_page.gno
+++ b/gno/p/basedao/view_proposal_detail_page.gno
@@ -44,7 +44,7 @@ func (d *DAOPrivate) ProposalDetailView(idu uint64) string {
 	proposal.UpdateStatus()
 	if proposal.Status == daokit.ProposalStatusOpen {
 		s += ufmt.Sprintf("## Status - Open 🟡\n\n")
-		s += md.Link("Approve this proposal 🗳️", txlink.Call("Vote", "proposalID", strconv.FormatUint(idu, 10), "vote", daocond.VoteYes)) + "\n\n"
+		s += md.Link("Approve this proposal 🗳️", txlink.Call("Vote", "proposalID", strconv.FormatUint(idu, 10), "vote", string(daocond.VoteYes))) + "\n\n"
 	} else if proposal.Status == daokit.ProposalStatusPassed {
 		s += ufmt.Sprintf("## Status - Passed 🟢\n\n")
 		s += md.Link("Execute this proposal 🗳️", txlink.Call("Execute", "proposalID", strconv.FormatUint(idu, 10))) + "\n\n"

--- a/gno/p/daocond/README.md
+++ b/gno/p/daocond/README.md
@@ -35,12 +35,12 @@ type Ballot interface {
 ### Vote Types
 
 ```go
-type Vote int
+type Vote string
 
 const (
-    VoteAbstain Vote = iota  // Neutral vote
-    VoteNo                   // Against the proposal
-    VoteYes                  // In favor of the proposal
+    VoteYes     Vote = "yes"     // In favor of the proposal
+    VoteNo      Vote = "no"      // Against the proposal
+    VoteAbstain Vote = "abstain" // Neutral vote
 )
 ```
 
@@ -65,7 +65,7 @@ func RoleCount(count uint64, role string, hasRoleFn func(string, string) bool) C
 memberMajority := daocond.MembersThreshold(0.6, store.IsMember, store.MembersCount)
 
 // Require 50% of contributor  
-adminApproval := daocond.RoleThreshold(0.5, "contributor", store.HasRole, store.RoleCount)
+adminApproval := daocond.RoleThreshold(0.5, "contributor", store.HasRole, store.CountMembersWithRole)
 
 // Require at least 2 core-contributor
 treasurerApproval := daocond.RoleCount(2, "core-contributor", store.HasRole)
@@ -87,14 +87,14 @@ func Or(conditions ...Condition) Condition {...}
 ```go
 // Require BOTH admin majority AND treasurer approval
 strictGovernance := daocond.And(
-    daocond.RoleThreshold(0.5, "contributor", store.HasRole, store.RoleCount),
+    daocond.RoleThreshold(0.5, "contributor", store.HasRole, store.CountMembersWithRole),
     daocond.RoleCount(1, "treasurer", store.HasRole),
 )
 
 // Require EITHER treasurer majority OR unanimous core-contributor approval
 flexibleGovernance := daocond.Or(
-    daocond.RoleThreshold(0.5, "treasurer", store.HasRole, store.RoleCount),
-    daocond.RoleThreshold(1.0, "core-contributor", store.HasRole, store.RoleCount),
+    daocond.RoleThreshold(0.5, "treasurer", store.HasRole, store.CountMembersWithRole),
+    daocond.RoleThreshold(1.0, "core-contributor", store.HasRole, store.CountMembersWithRole),
 )
 ```
 
@@ -160,7 +160,7 @@ governance := daocond.And(
     // AND either CTO approval OR finance team majority
     daocond.Or(
         daocond.RoleCount(1, "CTO", store.HasRole),
-        daocond.RoleThreshold(0.5, "finance", store.HasRole, store.RoleCount),
+        daocond.RoleThreshold(0.5, "finance", store.HasRole, store.CountMembersWithRole),
     ),
 )
 ```

--- a/gno/p/daocond/daocond.gno
+++ b/gno/p/daocond/daocond.gno
@@ -41,8 +41,14 @@ type Ballot interface {
 type Vote string
 
 // Available vote options.
+//
+// Typed as Vote, not as untyped strings: an untyped constant assigns to a plain
+// string without complaint, so a caller could hold one in a string variable and
+// only discover the mismatch at a conversion. Typing them is a source-breaking
+// change for any such caller, which is why it has to happen before publication
+// rather than after.
 const (
-	VoteYes     = "yes"
-	VoteNo      = "no"
-	VoteAbstain = "abstain"
+	VoteYes     Vote = "yes"
+	VoteNo      Vote = "no"
+	VoteAbstain Vote = "abstain"
 )

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -80,7 +80,7 @@ func (d *Core) Vote(voterID string, proposalID uint64, vote daocond.Vote) {
 		panic("proposal is not open")
 	}
 
-	proposal.Ballot.Vote(voterID, daocond.Vote(vote))
+	proposal.Ballot.Vote(voterID, vote)
 }
 
 // Executes a proposal if it meets the required voting conditions.

--- a/gno/p/daokit/extensions.gno
+++ b/gno/p/daokit/extensions.gno
@@ -16,7 +16,7 @@ type Extension interface {
 }
 
 type ExtensionInfo struct {
-	Path      string // Unique extension identifier (e.g., "gno.land/p/demo/basedao.MembersView")
+	Path      string // Unique extension identifier (e.g., "gno.land/p/samcrew/basedao.MembersView")
 	Version   string // Extension version (e.g., "1", "2.0", etc.)
 	QueryPath string // Path for external queries to access this extension's data
 	Private   bool   // If true, extension is only accessible from the same realm that registered it

--- a/gno/p/daokit/proposals.gno
+++ b/gno/p/daokit/proposals.gno
@@ -48,7 +48,6 @@ type Proposal struct {
 	Action     Action            // What to execute if passed
 	Condition  daocond.Condition // Voting conditions for this proposal
 	Status     ProposalStatus
-	ExecutorID string
 	ExecutedAt time.Time
 
 	Ballot daocond.Ballot // All votes cast on this proposal

--- a/gno/p/realmid/README.md
+++ b/gno/p/realmid/README.md
@@ -18,33 +18,61 @@ func IsPackage(id string) bool
 func IsUser(id string) bool
 ```
 
+> ## ⚠️ Not for caller authentication
+>
+> `Previous` and `Current` are built on `chain/runtime/unsafe`, which stack-walks.
+> Read from a non-crossing helper — which is what a `/p/` package is — the walk
+> reports whichever realm is outermost-crossing on the stack, so when a caller
+> invokes your package's methods directly there is no frame of *your* realm at all
+> and the walk names the signing account instead.
+>
+> For caller identity, thread a `realm` from a crossing function and use
+> `cur.Previous()`, which is statically scoped to that function. `basedao` does
+> exactly this and no longer uses this package. Only `IsPackage` / `IsUser`, which
+> are pure string predicates, are safe to reach for unconditionally.
+
 ## Basic Usage
 
 ```go
 import "gno.land/p/samcrew/realmid"
 
-func MyFunction() {
-    caller := realmid.Previous()
-    
+// The caller identity comes from a threaded realm, not from a stack walk.
+// realmid classifies it.
+func MyFunction(cur realm) {
+    prev := cur.Previous()
+    caller := prev.PkgPath()
+    if prev.IsUser() {
+        caller = prev.Address().String()
+    }
+
     if realmid.IsUser(caller) {
         // caller is a user address like "g1abc123..."
         println("Called by user:", caller)
-    } else if realmid.isPackage(caller) {
-        // caller is a package path like "gno.land/p/demo/users"
-        println("Called by package:", caller)
     } else {
-        println("Should not happen")
+        // caller is a package path like "gno.land/r/demo/users"
+        println("Called by realm:", caller)
     }
 }
 ```
 
 ## Integration with basedao
 
+`basedao.CallerIDFn` receives the DAO's own realm, so an implementation derives
+the identity from it rather than walking the stack:
+
 ```go
-// Use realmid.Previous as the caller identifier function
 config := &basedao.Config{
-    Name:     "My DAO",
-    CallerID: realmid.Previous,
+    Name: "My DAO",
+    CallerID: func(dao *basedao.DAOPrivate, rlm realm) string {
+        prev := rlm.Previous()
+        if prev.IsUser() {
+            return prev.Address().String()
+        }
+        return prev.PkgPath()
+    },
     // ...
 }
 ```
+
+Leaving `CallerID` nil installs exactly this behaviour, so most DAOs should not
+set it at all.

--- a/gno/r/readme_basedao_example/gnomod.toml
+++ b/gno/r/readme_basedao_example/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/readme_basedao_example"
+gno = "0.9"

--- a/gno/r/readme_basedao_example/init_test.gno
+++ b/gno/r/readme_basedao_example/init_test.gno
@@ -1,0 +1,9 @@
+package readme_basedao_example
+
+import "testing"
+
+func TestInitRuns(t *testing.T) {
+	if daoPrivate == nil {
+		t.Fatal("init did not build the DAO")
+	}
+}

--- a/gno/r/readme_basedao_example/sample.gno
+++ b/gno/r/readme_basedao_example/sample.gno
@@ -1,0 +1,80 @@
+// Code in this file is the "Complete Example" from gno/p/basedao/README.md, verbatim apart from
+// the package clause. It is compiled and its init is run by CI so the
+// documentation cannot drift into something that does not build — the examples
+// ship with the frozen package, and a broken one is as permanent as a broken
+// signature. Edit them together.
+package readme_basedao_example
+
+import (
+    "gno.land/p/samcrew/basedao"
+    "gno.land/p/samcrew/daocond"
+    "gno.land/p/samcrew/daokit"
+    "gno.land/r/demo/profile"
+)
+
+var (
+	// Unexported deliberately: anything that can reach this value can call the
+	// DAO's entry points directly, bypassing this realm's crossing functions.
+	localDAO   daokit.DAO
+	daoPrivate *basedao.DAOPrivate // Full access to internal DAO state
+)
+
+func init(cur realm) {
+    // Set up roles
+    roles := []basedao.RoleInfo{
+        {Name: "admin", Description: "Administrators", Color: "#329175"},
+        {Name: "member", Description: "Regular members", Color: "#21577A"},
+    }
+
+    // Add initial members
+    members := []basedao.Member{
+        {Address: "g1admin...", Roles: []string{"admin"}},
+        {Address: "g1user1...", Roles: []string{"member"}},
+        {Address: "g1user2...", Roles: []string{"member"}},
+    }
+
+    store := basedao.NewMembersStore(roles, members)
+
+    // Require 60% of members to approve proposals
+    condition := daocond.MembersThreshold(0.6, store.IsMember, store.MembersCount)
+
+    // Create the DAO (cur is threaded so the DAO can perform cross-realm calls)
+    localDAO, daoPrivate = basedao.New(&basedao.Config{
+        Name:             "My DAO",
+        Description:      "A simple DAO example",
+        Members:          store,
+        InitialCondition: condition,
+        // Required: New() panics without it.
+        GetProfileString: profile.GetStringField,
+        SetProfileString: profile.SetStringField,
+    }, cur)
+}
+
+// Create a new Proposal to be voted on
+// To execute this function, you must use a MsgRun (maketx run)
+// See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
+func Propose(cur realm, req daokit.ProposalRequest) {
+	localDAO.Propose(req, cur)
+}
+
+// Allows DAO members to cast their vote on a specific proposal
+func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
+    localDAO.Vote(proposalID, vote, cur)
+}
+
+// Triggers the implementation of a proposal's actions
+func Execute(cur realm, proposalID uint64) {
+	localDAO.Execute(proposalID, cur)
+}
+
+// Render generates a UI representation of the DAO's state
+func Render(path string) string {
+	return localDAO.Render(path)
+}
+
+// Handle exposes the DAO to other realms. Note it is a function, not an
+// exported variable: it is the only intentional way out, and anything holding
+// this value can call the entry points directly.
+func Handle() daokit.DAO {
+	return localDAO
+}

--- a/gno/r/readme_root_example/gnomod.toml
+++ b/gno/r/readme_root_example/gnomod.toml
@@ -1,0 +1,2 @@
+module = "gno.land/r/samcrew/readme_root_example"
+gno = "0.9"

--- a/gno/r/readme_root_example/init_test.gno
+++ b/gno/r/readme_root_example/init_test.gno
@@ -1,0 +1,9 @@
+package readme_root_example
+
+import "testing"
+
+func TestInitRuns(t *testing.T) {
+	if daoPrivate == nil {
+		t.Fatal("init did not build the DAO")
+	}
+}

--- a/gno/r/readme_root_example/sample.gno
+++ b/gno/r/readme_root_example/sample.gno
@@ -1,0 +1,73 @@
+// Code in this file is the "Complete Example" from README.md, verbatim apart from
+// the package clause. It is compiled and its init is run by CI so the
+// documentation cannot drift into something that does not build — the examples
+// ship with the frozen package, and a broken one is as permanent as a broken
+// signature. Edit them together.
+package readme_root_example
+
+import (
+    "gno.land/p/samcrew/basedao"
+    "gno.land/p/samcrew/daocond"
+    "gno.land/p/samcrew/daokit"
+    "gno.land/r/demo/profile"
+)
+
+var (
+	// Unexported deliberately: anything that can reach this value can call the
+	// DAO's entry points directly, bypassing this realm's crossing functions.
+	localDAO   daokit.DAO
+	daoPrivate *basedao.DAOPrivate // Full access to internal DAO state
+)
+
+func init(cur realm) {
+    // Set up roles
+    roles := []basedao.RoleInfo{
+        {Name: "admin", Description: "Administrators", Color: "#329175"},
+        {Name: "member", Description: "Regular members", Color: "#21577A"},
+    }
+
+    // Add initial members
+    members := []basedao.Member{
+        {Address: "g1admin...", Roles: []string{"admin"}},
+        {Address: "g1user1...", Roles: []string{"member"}},
+        {Address: "g1user2...", Roles: []string{"member"}},
+    }
+
+    store := basedao.NewMembersStore(roles, members)
+
+    // Require 60% of members to approve proposals
+    condition := daocond.MembersThreshold(0.6, store.IsMember, store.MembersCount)
+
+    // Create the DAO (cur is threaded so the DAO can perform cross-realm calls)
+    localDAO, daoPrivate = basedao.New(&basedao.Config{
+        Name:             "My DAO",
+        Description:      "A simple DAO example",
+        Members:          store,
+        InitialCondition: condition,
+        // Required: New() panics without it.
+        GetProfileString: profile.GetStringField,
+        SetProfileString: profile.SetStringField,
+    }, cur)
+}
+
+// Create a new Proposal to be voted on
+// To execute this function, you must use a MsgRun (maketx run)
+// See why it is necessary in Gno Documentation: https://docs.gno.land/users/interact-with-gnokey#run
+func Propose(cur realm, req daokit.ProposalRequest) {
+	localDAO.Propose(req, cur)
+}
+
+// Allows DAO members to cast their vote on a specific proposal
+func Vote(cur realm, proposalID uint64, vote daocond.Vote) {
+    localDAO.Vote(proposalID, vote, cur)
+}
+
+// Triggers the implementation of a proposal's actions
+func Execute(cur realm, proposalID uint64) {
+	localDAO.Execute(proposalID, cur)
+}
+
+// Render generates a UI representation of the DAO's state
+func Render(path string) string {
+	return localDAO.Render(path)
+}


### PR DESCRIPTION
Stacked on #69. Everything here is fixable now and never again — publication is immutable.

## Takes #66, minus its one blocker

`AddMember("")` guard and its tests, committed under David's authorship.

**Rejected: #66's change to `New()`.** It replaced `Realm: unsafe.CurrentRealm()` with `runtime.NewRealm(rlm.Address(), rlm.PkgPath())`, which lets whoever calls `New()` decide the identity the DAO will later require of itself. gno's own stdlib says of that constructor, verbatim: *"Callers should NOT use this to fabricate realm-context for authorization — a constructed Realm is just a (addr, pkgPath) tuple and carries no runtime-validated authority."*

## Three permanent mistakes in the surface

| | |
|---|---|
| `MembersViewExtensionPath` | Named `gno.land/p/demo/basedao`, a package that does not exist. It is the extension **registry key** — third-party lookups get pinned to it. |
| `daocond.VoteYes/No/Abstain` | Untyped strings despite `type Vote string`. An untyped constant assigns to a plain `string` without complaint, so typing them later breaks any caller that stored one. Breaks exactly one call site here. |
| `Proposal.ExecutorID` | Exported, written by nothing, anywhere. `Execute` computes the value and discards it; writing it would need `Core.Execute`'s equally-frozen signature. Removed — shipping it guarantees it reads `""` forever. |

Verified no consumer depends on the extension key, registration and lookup both read the same constant, and `r/samcrew` is empty on topaz-1 so no on-chain state is keyed to the old path.

## Empty role names

Symmetric with the member-id guard, and sharper: role names are substituted into rendered prose with `strings.ReplaceAll`, and an empty needle matches between every character. Measured: `"hello world"`, 11 characters, came back as **227**. The members table has the same pattern and an empty role reaches it through the ordinary API — `AddRoleToMember` succeeds once `""` is in `Roles`. Measured there: **585 → 2578**.

Guarded at `AddRole`, and both render loops skip an empty role, because `Roles` is an exported `avl.Tree` that can be seeded around the guard.

## The docs, which ship with the frozen package

Every `Propose`/`Vote` example was missing its threaded realm. Both "Complete Example" realms omitted `GetProfileString`, which `New()` hard-panics without — **the canonical copy-paste deployed a realm that panicked at init**. `daocond`'s README documented `Vote` as an int enum with `iota`. Identifiers that never existed: `store.RoleCount`, `daocond.NewRoleCount`, an extension lookup type-asserting `*ExtensionInfo` to an interface.

The example realms exported their handle as `DAO`. That is the precondition for the whole donation class #69 closes, so it is unexported now with the reason stated — #64's correction, carried over as intent since its call forms predate the realm threading.

**Both Complete Examples are now checked in under `gno/r/readme_*_example`, compiled by CI with their `init` actually run**, and a script re-extracts each block from the markdown and diffs it against its fixture so they cannot drift apart. Negative-controlled: it refuses a deliberate perturbation.

## Verification

10 packages ok · lint clean · `fmt -diff` clean · zero `gno: downloading` · deployer `assert_gnodaokit_source_form topaz-1` passes.

Every guard mutation-checked: dropping the member-id guard, the role-name guard, or either render skip fails exactly its own test.

Independently reviewed in an isolated worktree; that review found the `GetProfileString` brick, the `daocond` README, and the incomplete role fix, all of which are addressed here.