### PR TITLE
fix(daokit,basedao): proposal lifecycle, the extension gate, and the migration threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ type ExtensionInfo struct {
 
 ```go
 // Get a specific extension by path
-ext := dao.Extension("gno.land/p/samcrew/basedao.MembersView")
+ext := dao.Extension("gno.land/p/samcrew/basedao.MembersView", cur)
 
 // List all available extensions
 extList := dao.ExtensionsList()
@@ -468,7 +468,7 @@ if extIndex != nil {
 
 // Use your extension. Get(i) returns an *ExtensionInfo — metadata, not the
 // extension itself — so fetch the extension by path and assert the interface.
-ext, ok := dao.Extension(extIndex.Path).(basedao.MembersViewExtension)
+ext, ok := dao.Extension(extIndex.Path, cur).(basedao.MembersViewExtension)
 if !ok {
     panic("Invalid extension type")
 }
@@ -513,7 +513,7 @@ removed, ok := daoPrivate.Core.Extensions.Remove("gno.land/p/mydao/custom.Custom
 ### Using Your Custom Extension
 
 ```go
-ext := dao.Extension("gno.land/p/mydao/custom.CustomView")
+ext := dao.Extension("gno.land/p/mydao/custom.CustomView", cur)
 if ext == nil {
     panic("Extension not found")
 }
@@ -534,7 +534,7 @@ Built-in [`basedao.MembersViewExtension`](./gno/p/basedao/README.md#7-membership
 const MembersViewExtensionPath = "gno.land/p/samcrew/basedao.MembersView"
 
 // Check if someone is a DAO member
-ext := basedao.MustGetMembersViewExtension(dao)
+ext := basedao.MustGetMembersViewExtension(dao, cur)
 isMember := ext.IsMember("g1user...")
 ```
 

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -365,7 +365,7 @@ func migrateTo2_0(prev *basedao.DAOPrivate, params []any, rlm realm) daokit.DAO 
 }
 
 // 2. Create and submit upgrade proposal
-action := basedao.NewChangeDAOImplementationAction(migrateTo2_0)
+action := basedao.NewChangeDAOImplementationAction("v2.0 — adds audit capabilities", migrateTo2_0)
 proposal := daokit.ProposalRequest{
     Title:       "Upgrade to DAO v2.0",
     Description: "Adds auditor role and enhanced governance",

--- a/gno/p/basedao/README.md
+++ b/gno/p/basedao/README.md
@@ -404,7 +404,7 @@ Allows other packages and realms to check if an address is a member of your DAO.
 import "gno.land/p/samcrew/basedao"
 
 // Check if someone is a DAO member
-ext := basedao.MustGetMembersViewExtension(dao)
+ext := basedao.MustGetMembersViewExtension(dao, cur)
 if ext.IsMember("g1user...") {
     // User is a member
 }
@@ -433,7 +433,7 @@ func Post(cur realm, title, content string) {
         caller = prev.Address().String()
     }
 
-    ext := basedao.MustGetMembersViewExtension(dao.Handle())
+    ext := basedao.MustGetMembersViewExtension(dao.Handle(), cur)
     if !ext.IsMember(caller) {
         panic("Only DAO members can post")
     }

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -19,13 +19,28 @@ type SetImplemRaw func(newDAO daokit.DAO)
 
 type RenderFn func(path string, dao *DAOPrivate) string
 
-func (d *daoPublic) Extension(path string) daokit.Extension {
+func (d *daoPublic) Extension(path string, rlm realm) daokit.Extension {
 	ext, ok := d.impl.Core.Extensions.Get(path)
 	if !ok {
 		return nil
 	}
-	if ext.Info().Private && unsafe.CurrentRealm().PkgPath() != d.impl.Realm.PkgPath() {
-		panic("attempt to get private extension outside of DAO realm")
+	// Only private extensions are gated; a public one is readable by anyone and
+	// ignores the realm entirely.
+	//
+	// This used to ask unsafe.CurrentRealm(), which is a stack walk and answers
+	// a different question: "is a DAO frame the innermost live one", not "is my
+	// caller the DAO". It was wrong in both directions. Too lax, because
+	// anything the DAO invoked WITHOUT crossing inherited the DAO's realm —
+	// including a proposer-authored ExecuteLambda callback, which could read a
+	// private extension. And too strict, because a DAO-realm helper that is not
+	// itself a crossing function had no frame of its own for the walk to find.
+	//
+	// Requiring the DAO's own live realm answers the intended question directly.
+	// It also closes the lambda case by construction rather than by check: a
+	// callback that receives no realm cannot produce one, and realm values
+	// cannot be persisted or forged.
+	if ext.Info().Private {
+		assertRealmIsOwn(d.impl, rlm)
 	}
 	return ext
 }

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -120,6 +120,12 @@ type Config struct {
 	// Advanced customization hooks
 	SetImplemFn       SetImplemRaw      // Function called when DAO implementation changes via governance
 	MigrationParamsFn MigrationParamsFn // Function providing parameters for DAO upgrades
+	// Condition for replacing the DAO's implementation. A passing migration
+	// hands proposer-authored code the DAO's live realm and its full private
+	// state, so it is a takeover in the general case — it should not be as easy
+	// as adding a member. Defaults to an 80% member majority, deliberately
+	// stricter than InitialCondition's 60%; set it explicitly for anything else.
+	MigrationCondition daocond.Condition
 	RenderFn          RenderFn          // Rendering function for Gnoweb
 	CallerID          CallerIDFn        // Resolves the immediate caller from the DAO's threaded realm; defaults to defaultCallerID
 
@@ -202,11 +208,15 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 				conf.MigrationParamsFn = func() []any { return nil }
 			}
 
+			if conf.MigrationCondition == nil {
+				conf.MigrationCondition = daocond.MembersThreshold(0.8, members.IsMember, members.MembersCount)
+			}
+
 			dao.Core.Resources.Set(&daokit.Resource{
 				Handler:     NewChangeDAOImplementationHandler(dao, setImplemFn, conf.MigrationParamsFn),
-				Condition:   conf.InitialCondition,
+				Condition:   conf.MigrationCondition,
 				DisplayName: "Change DAO Implementation",
-				Description: "Change the underlying DAO implementation.",
+				Description: "Replaces the DAO implementation. The migration receives the DAO's live realm and private state.",
 			})
 		}
 

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -130,11 +130,17 @@ type Config struct {
 	// state, so it is a takeover in the general case — it should not be as easy
 	// as adding a member.
 	//
-	// Defaults to InitialCondition AND an 80% member majority, so it is strictly
-	// harder than every ordinary action in every dimension. Set it explicitly to
-	// choose something else — but note that anything not conjoined with
-	// InitialCondition can end up WEAKER along a dimension InitialCondition
-	// covers, which is the trap this default exists to avoid.
+	// If you leave InitialCondition to its default, this defaults to an 80%
+	// member majority — the same dimension, raised.
+	//
+	// If you SET InitialCondition, this defaults to it unchanged, and you should
+	// set this too. A Condition is opaque, so nothing here can strengthen yours:
+	// conjoining a members threshold onto role-based governance can demand a
+	// majority such a DAO never assembles, and migration is the one rule that
+	// cannot be repaired afterwards — changing it requires a migration. Whatever
+	// you choose, make it at least as hard as InitialCondition along every
+	// dimension; a condition that merely replaces yours can be WEAKER where it
+	// matters.
 	MigrationCondition daocond.Condition
 	RenderFn          RenderFn          // Rendering function for Gnoweb
 	CallerID          CallerIDFn        // Resolves the immediate caller from the DAO's threaded realm; defaults to defaultCallerID
@@ -195,6 +201,9 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 	}
 
 	if !conf.NoDefaultHandlers {
+		// Whether the DAO chose its own governance decides how far the migration
+		// default may go, below. Captured before the default is filled in.
+		governanceIsCallerChosen := conf.InitialCondition != nil
 		if conf.InitialCondition == nil {
 			conf.InitialCondition = daocond.MembersThreshold(0.6, members.IsMember, members.MembersCount)
 		}
@@ -218,23 +227,38 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 				conf.MigrationParamsFn = func() []any { return nil }
 			}
 
-			if conf.MigrationCondition == nil {
-				// Conjoined with the DAO's ordinary condition, never replacing
-				// it. A Condition is opaque, so there is no way to "raise" one —
-				// and substituting a members threshold for a role-gated
-				// condition would DROP the role gate, making a takeover easier
-				// than adding a member rather than harder. Measured: with
-				// And(MembersThreshold(0.4), RoleCount(1,"officer")), a ballot
-				// that fails the ordinary action passed a bare 0.8 migration.
-				conf.MigrationCondition = daocond.And(
-					conf.InitialCondition,
-					daocond.MembersThreshold(0.8, members.IsMember, members.MembersCount),
-				)
+			// Held locally rather than written back into conf: New must not
+			// mutate its caller's Config, and this closure captures THIS DAO's
+			// member store — reusing one Config for a second DAO would otherwise
+			// give it a migration condition evaluating the first one's members.
+			migrationCondition := conf.MigrationCondition
+			if migrationCondition == nil {
+				if governanceIsCallerChosen {
+					// The DAO designed its own governance, and a Condition is
+					// opaque, so there is no way to strengthen it from here. A
+					// members threshold is not a strengthening: conjoined with
+					// role-based governance it can demand a member majority that
+					// role-governed DAOs never assemble, and migration is the one
+					// rule that cannot be repaired afterwards — changing it needs
+					// a migration. Substituting one is worse still: against
+					// And(MembersThreshold(0.4), RoleCount(1,"officer")) a ballot
+					// that fails an ordinary action passed a bare 0.8 migration,
+					// making a takeover CHEAPER than adding a member.
+					//
+					// So: match the DAO's own bar, and say plainly that a
+					// takeover deserves a higher one. Set MigrationCondition.
+					migrationCondition = conf.InitialCondition
+				} else {
+					// Default governance, so a members threshold is the same
+					// dimension the DAO is already judged on and raising it is a
+					// genuine strengthening: 80% against the default 60%.
+					migrationCondition = daocond.MembersThreshold(0.8, members.IsMember, members.MembersCount)
+				}
 			}
 
 			dao.Core.Resources.Set(&daokit.Resource{
 				Handler:     NewChangeDAOImplementationHandler(dao, setImplemFn, conf.MigrationParamsFn),
-				Condition:   conf.MigrationCondition,
+				Condition:   migrationCondition,
 				DisplayName: "Change DAO Implementation",
 				Description: "Replaces the DAO implementation. The migration receives the DAO's live realm and private state.",
 			})

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -45,6 +45,11 @@ func (d *daoPublic) Extension(path string, rlm realm) daokit.Extension {
 	return ext
 }
 
+// Not gated, deliberately. It exposes ExtensionInfo — paths and versions — and
+// not extension values, so it grants no capability; and realm state is
+// world-readable over ABCI anyway, so gating it would suggest a confidentiality
+// this cannot provide. Getting the VALUE of a private extension goes through
+// Extension, which is gated.
 func (d *daoPublic) ExtensionsList() daokit.ExtensionsList {
 	return d.impl.Core.Extensions.List()
 }

--- a/gno/p/basedao/basedao.gno
+++ b/gno/p/basedao/basedao.gno
@@ -123,8 +123,13 @@ type Config struct {
 	// Condition for replacing the DAO's implementation. A passing migration
 	// hands proposer-authored code the DAO's live realm and its full private
 	// state, so it is a takeover in the general case — it should not be as easy
-	// as adding a member. Defaults to an 80% member majority, deliberately
-	// stricter than InitialCondition's 60%; set it explicitly for anything else.
+	// as adding a member.
+	//
+	// Defaults to InitialCondition AND an 80% member majority, so it is strictly
+	// harder than every ordinary action in every dimension. Set it explicitly to
+	// choose something else — but note that anything not conjoined with
+	// InitialCondition can end up WEAKER along a dimension InitialCondition
+	// covers, which is the trap this default exists to avoid.
 	MigrationCondition daocond.Condition
 	RenderFn          RenderFn          // Rendering function for Gnoweb
 	CallerID          CallerIDFn        // Resolves the immediate caller from the DAO's threaded realm; defaults to defaultCallerID
@@ -209,7 +214,17 @@ func New(conf *Config, rlm realm) (daokit.DAO, *DAOPrivate) {
 			}
 
 			if conf.MigrationCondition == nil {
-				conf.MigrationCondition = daocond.MembersThreshold(0.8, members.IsMember, members.MembersCount)
+				// Conjoined with the DAO's ordinary condition, never replacing
+				// it. A Condition is opaque, so there is no way to "raise" one —
+				// and substituting a members threshold for a role-gated
+				// condition would DROP the role gate, making a takeover easier
+				// than adding a member rather than harder. Measured: with
+				// And(MembersThreshold(0.4), RoleCount(1,"officer")), a ballot
+				// that fails the ordinary action passed a bare 0.8 migration.
+				conf.MigrationCondition = daocond.And(
+					conf.InitialCondition,
+					daocond.MembersThreshold(0.8, members.IsMember, members.MembersCount),
+				)
 			}
 
 			dao.Core.Resources.Set(&daokit.Resource{

--- a/gno/p/basedao/members_extension.gno
+++ b/gno/p/basedao/members_extension.gno
@@ -12,8 +12,11 @@ type MembersViewExtension interface {
 // exist.
 const MembersViewExtensionPath = "gno.land/p/samcrew/basedao.MembersView"
 
-func MustGetMembersViewExtension(dao daokit.DAO) MembersViewExtension {
-	ext := dao.Extension(MembersViewExtensionPath)
+// The realm is threaded because daokit.DAO.Extension takes one. This extension
+// is public, so any realm may fetch it and the realm is not checked — pass your
+// own cur.
+func MustGetMembersViewExtension(dao daokit.DAO, rlm realm) MembersViewExtension {
+	ext := dao.Extension(MembersViewExtensionPath, rlm)
 	if ext == nil {
 		panic("no such extension: " + MembersViewExtensionPath)
 	}

--- a/gno/p/basedao/migrate.gno
+++ b/gno/p/basedao/migrate.gno
@@ -14,11 +14,16 @@ type MigrateFn = func(prev *DAOPrivate, params []any, rlm realm) daokit.DAO
 type MigrationParamsFn = func() []any
 
 type actionChangeDAOImplementation struct {
+	label   string
 	migrate MigrateFn
 }
 
 func (a *actionChangeDAOImplementation) String() string {
-	return "WARNING: thoroughly check the migration code before approving this"
+	return "WARNING: this replaces the DAO's implementation.\n\n" +
+		"The migration function receives the DAO's live realm and full private\n" +
+		"state, so approving it grants whoever wrote it the DAO's authority.\n" +
+		"Read the code it refers to before voting.\n\n" +
+		"Migration: " + a.label
 }
 
 func NewChangeDAOImplementationHandler(dao *DAOPrivate, setImplem daokit.SetImplemFn, paramsFn MigrationParamsFn) daokit.ActionHandler {
@@ -36,6 +41,21 @@ func NewChangeDAOImplementationHandler(dao *DAOPrivate, setImplem daokit.SetImpl
 	})
 }
 
-func NewChangeDAOImplementationAction(migrate MigrateFn) daokit.Action {
-	return daokit.NewAction(ActionChangeDAOImplementationKind, &actionChangeDAOImplementation{migrate: migrate})
+// The label is required and appears in the proposal a member votes on.
+//
+// Without it every migration renders as the same fixed sentence, so a voter
+// sees nothing distinguishing a routine upgrade from a takeover. A function
+// value cannot be rendered, so the caller has to say what it is — name the
+// version, the commit, or the change.
+func NewChangeDAOImplementationAction(label string, migrate MigrateFn) daokit.Action {
+	if label == "" {
+		panic("migration label must not be empty")
+	}
+	if migrate == nil {
+		panic("migration function must not be nil")
+	}
+	return daokit.NewAction(ActionChangeDAOImplementationKind, &actionChangeDAOImplementation{
+		label:   label,
+		migrate: migrate,
+	})
 }

--- a/gno/p/basedao/migrate.gno
+++ b/gno/p/basedao/migrate.gno
@@ -43,10 +43,15 @@ func NewChangeDAOImplementationHandler(dao *DAOPrivate, setImplem daokit.SetImpl
 
 // The label is required and appears in the proposal a member votes on.
 //
-// Without it every migration renders as the same fixed sentence, so a voter
-// sees nothing distinguishing a routine upgrade from a takeover. A function
-// value cannot be rendered, so the caller has to say what it is — name the
-// version, the commit, or the change.
+// Without it every migration renders as the same fixed sentence, so a voter sees
+// nothing distinguishing a routine upgrade from a takeover. A function value
+// cannot be rendered, so the caller has to say what it is — name the version,
+// the commit, or the change.
+//
+// It is NOT a safety control. Whoever writes the migration writes the label, so
+// a takeover can ship as "routine security patch". It exists so an honest
+// proposal can be told apart from another honest proposal, and so a voter has
+// something to check the code against. Read the migration.
 func NewChangeDAOImplementationAction(label string, migrate MigrateFn) daokit.Action {
 	if label == "" {
 		panic("migration label must not be empty")

--- a/gno/p/basedao/migration_guard_test.gno
+++ b/gno/p/basedao/migration_guard_test.gno
@@ -1,0 +1,62 @@
+package basedao
+
+import (
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+)
+
+func noopMigrate(prev *DAOPrivate, params []any, rlm realm) daokit.DAO { return nil }
+
+// A migration is a takeover in the general case: the function receives the DAO's
+// live realm and its full private state. A voter must be able to tell one
+// migration from another, and every migration used to render as the same fixed
+// sentence.
+func TestAMigrationMustIdentifyItself(cur realm, t *testing.T) {
+	urequire.PanicsWithMessage(t, cur, "migration label must not be empty", func() {
+		NewChangeDAOImplementationAction("", noopMigrate)
+	})
+	urequire.PanicsWithMessage(t, cur, "migration function must not be nil", func() {
+		NewChangeDAOImplementationAction("v2", nil)
+	})
+
+	action := NewChangeDAOImplementationAction("v2.0 — adds auditing", noopMigrate)
+	rendered := action.String()
+	urequire.True(t, strings.Contains(rendered, "v2.0 — adds auditing"),
+		"the label must reach the voter")
+	urequire.True(t, strings.Contains(rendered, "live realm"),
+		"the warning must say what is being granted")
+}
+
+// Replacing the implementation must not be as easy as adding a member.
+func TestMigrationIsHarderThanAddingAMember(cur realm, t *testing.T) {
+	members := NewMembersStore(nil, []Member{
+		{alice.String(), nil}, {bob.String(), nil}, {carol.String(), nil},
+	})
+	conf := &Config{
+		Name:             "d",
+		Description:      "d",
+		Members:          members,
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		SetImplemFn:      func(daokit.DAO) {},
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/migdao"))
+	_, d := New(conf, cur)
+
+	addMember := d.Core.Resources.Get(ActionAddMemberKind)
+	migration := d.Core.Resources.Get(ActionChangeDAOImplementationKind)
+
+	// Two of three members: enough for the default 60% action, short of the
+	// 80% the migration now requires.
+	ballot := daocond.NewBallot()
+	ballot.Vote(alice.String(), daocond.VoteYes)
+	ballot.Vote(bob.String(), daocond.VoteYes)
+	urequire.True(t, addMember.Condition.Eval(ballot),
+		"two of three must carry an ordinary action")
+	urequire.False(t, migration.Condition.Eval(ballot),
+		"two of three must NOT carry a migration")
+}

--- a/gno/p/basedao/migration_guard_test.gno
+++ b/gno/p/basedao/migration_guard_test.gno
@@ -109,3 +109,95 @@ func TestMigrationNeverWeakensARoleGatedCondition(cur realm, t *testing.T) {
 		"so the migration must refuse it too — anything the ordinary condition "+
 			"refuses, a takeover must refuse")
 }
+
+// The defaulted migration threshold is pinned, not merely "higher than
+// ordinary". Ten members distinguish 0.8 from 0.7; five cannot, because both
+// round to the same count.
+func TestTheDefaultMigrationThresholdIsEightyPercent(cur realm, t *testing.T) {
+	var ms []Member
+	addrs := []string{}
+	for i := 0; i < 10; i++ {
+		a := "g1member" + string(rune('a'+i)) + "0000000000000000000000000000000"
+		addrs = append(addrs, a)
+		ms = append(ms, Member{a, nil})
+	}
+	members := NewMembersStore(nil, ms)
+	conf := &Config{
+		Name: "d", Description: "d", Members: members,
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		SetImplemFn:      func(daokit.DAO) {},
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/thresholddao"))
+	_, d := New(conf, cur)
+
+	migration := d.Core.Resources.Get(ActionChangeDAOImplementationKind).Condition
+
+	seven := daocond.NewBallot()
+	for _, a := range addrs[:7] {
+		seven.Vote(a, daocond.VoteYes)
+	}
+	urequire.False(t, migration.Eval(seven), "70% must not carry a migration")
+
+	eight := daocond.NewBallot()
+	for _, a := range addrs[:8] {
+		eight.Vote(a, daocond.VoteYes)
+	}
+	urequire.True(t, migration.Eval(eight), "80% must")
+}
+
+// A DAO that chose its own governance keeps it for migration too.
+//
+// Nothing here can strengthen an opaque Condition. Conjoining a members
+// threshold onto role-based governance can demand a majority such a DAO never
+// assembles — and migration is the one rule that cannot be repaired afterwards,
+// since changing it requires a migration. Matching the DAO's own bar is the only
+// default that cannot brick it.
+func TestCallerChosenGovernanceIsNotOverriddenForMigration(cur realm, t *testing.T) {
+	members := NewMembersStore(
+		[]RoleInfo{{Name: "admin", Description: "a", Color: "#000"}},
+		[]Member{
+			{alice.String(), []string{"admin"}},
+			{bob.String(), nil}, {carol.String(), nil}, {dave.String(), nil},
+		},
+	)
+	conf := &Config{
+		Name: "d", Description: "d", Members: members,
+		// Role-only governance: the admin decides, member count is irrelevant.
+		InitialCondition: daocond.RoleCount(1, "admin", members.HasRole),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		SetImplemFn:      func(daokit.DAO) {},
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/rolegovdao"))
+	_, d := New(conf, cur)
+
+	adminAlone := daocond.NewBallot()
+	adminAlone.Vote(alice.String(), daocond.VoteYes)
+
+	urequire.True(t, d.Core.Resources.Get(ActionAddMemberKind).Condition.Eval(adminAlone),
+		"the admin carries an ordinary action")
+	urequire.True(t, d.Core.Resources.Get(ActionChangeDAOImplementationKind).Condition.Eval(adminAlone),
+		"and must still be able to migrate — a migration rule this DAO cannot "+
+			"meet is unrepairable, because repairing it needs a migration")
+}
+
+// New must not write derived defaults into the caller's Config.
+//
+// The migration condition closes over the member store, so a Config reused for a
+// second DAO would otherwise hand it a condition evaluating the FIRST DAO's
+// membership.
+func TestNewDoesNotContaminateAReusedConfig(cur realm, t *testing.T) {
+	conf := &Config{
+		Name: "d", Description: "d",
+		Members:          NewMembersStore(nil, []Member{{alice.String(), nil}}),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		SetImplemFn:      func(daokit.DAO) {},
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/reuse1"))
+	New(conf, cur)
+
+	urequire.True(t, conf.MigrationCondition == nil,
+		"New must leave the caller's MigrationCondition alone")
+}

--- a/gno/p/basedao/migration_guard_test.gno
+++ b/gno/p/basedao/migration_guard_test.gno
@@ -60,3 +60,52 @@ func TestMigrationIsHarderThanAddingAMember(cur realm, t *testing.T) {
 	urequire.False(t, migration.Condition.Eval(ballot),
 		"two of three must NOT carry a migration")
 }
+
+// The defaulted migration condition must be strictly harder than the DAO's
+// ordinary one, in every dimension — not merely harder in the one dimension a
+// members threshold measures.
+//
+// A Condition is opaque, so there is no way to "raise" one. Substituting a
+// members threshold for a role-gated condition drops the role gate: measured
+// with And(MembersThreshold(0.4), RoleCount(1,"officer")), a ballot that FAILED
+// the ordinary action PASSED a bare 0.8 migration. That makes a takeover easier
+// than adding a member, which is the opposite of the point.
+func TestMigrationNeverWeakensARoleGatedCondition(cur realm, t *testing.T) {
+	eve := "g1eve000000000000000000000000000000000000"
+	members := NewMembersStore(
+		[]RoleInfo{{Name: "officer", Description: "o", Color: "#000"}},
+		[]Member{
+			{alice.String(), []string{"officer"}},
+			{bob.String(), nil}, {carol.String(), nil}, {dave.String(), nil}, {eve, nil},
+		},
+	)
+	conf := &Config{
+		Name:        "d",
+		Description: "d",
+		Members:     members,
+		InitialCondition: daocond.And(
+			daocond.MembersThreshold(0.4, members.IsMember, members.MembersCount),
+			daocond.RoleCount(1, "officer", members.HasRole),
+		),
+		GetProfileString: func(addr address, field, def string) string { return "" },
+		SetImplemFn:      func(daokit.DAO) {},
+	}
+	testing.SetOriginCaller(alice)
+	testing.SetRealm(testing.NewCodeRealm("gno.land/r/testing/rolemigdao"))
+	_, d := New(conf, cur)
+
+	// Four of five in favour, but not the officer: fails the role gate.
+	ballot := daocond.NewBallot()
+	ballot.Vote(bob.String(), daocond.VoteYes)
+	ballot.Vote(carol.String(), daocond.VoteYes)
+	ballot.Vote(dave.String(), daocond.VoteYes)
+	ballot.Vote(eve, daocond.VoteYes)
+
+	ordinary := d.Core.Resources.Get(ActionAddMemberKind).Condition
+	migration := d.Core.Resources.Get(ActionChangeDAOImplementationKind).Condition
+
+	urequire.False(t, ordinary.Eval(ballot), "the role gate refuses this ballot")
+	urequire.False(t, migration.Eval(ballot),
+		"so the migration must refuse it too — anything the ordinary condition "+
+			"refuses, a takeover must refuse")
+}

--- a/gno/p/basedao/render_status_test.gno
+++ b/gno/p/basedao/render_status_test.gno
@@ -1,0 +1,73 @@
+package basedao
+
+import (
+	"strings"
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+)
+
+// Rendering shows the status the votes imply, and changes nothing.
+//
+// The read paths used to write: a proposal that had met its condition was moved
+// Open -> Passed as a side effect of being displayed, which then made it
+// permanently unexecutable. They now compute the display status instead, and
+// nothing outside Execute ever writes Status — so a stored proposal is Open
+// until it is Executed, and Passed exists only as something rendered.
+func TestRenderingShowsTheStatusTheVotesImplyAndWritesNothing(cur realm, t *testing.T) {
+	members := []Member{
+		{alice.String(), []string{"admin"}},
+		{bob.String(), []string{}},
+		{carol.String(), []string{}},
+	}
+	tdao := newTestingDAO(cur, t, 0.2, members)
+
+	// Untouched.
+	openID := tdao.dao.Propose(tdao.mockProposalRequest, cur)
+	// Enough votes to meet the condition, but never executed.
+	passedID := tdao.dao.Propose(tdao.mockProposalRequest, cur)
+	tdao.dao.Vote(passedID, daocond.VoteYes, cur)
+	// Executed.
+	executedID := tdao.dao.Propose(tdao.mockProposalRequest, cur)
+	tdao.dao.Vote(executedID, daocond.VoteYes, cur)
+	tdao.dao.Execute(executedID, cur)
+
+	store := tdao.privdao.Core.Proposals
+	get := func(id uint64) *daokit.Proposal { return store.GetProposal(id) }
+
+	// Stored status: only Execute ever wrote one.
+	urequire.Equal(t, daokit.ProposalStatusOpen.String(), get(openID).Status.String())
+	urequire.Equal(t, daokit.ProposalStatusOpen.String(), get(passedID).Status.String(),
+		"meeting the condition must not have written anything")
+	urequire.Equal(t, daokit.ProposalStatusExecuted.String(), get(executedID).Status.String())
+
+	// Rendered status: what the votes imply.
+	table := tdao.privdao.RenderProposalsTable("", store)
+	urequire.True(t, strings.Contains(table, "Passed"),
+		"a condition-met proposal must render as Passed")
+	urequire.True(t, strings.Contains(table, "Executed"),
+		"an executed proposal must render as Executed")
+	urequire.True(t, strings.Contains(table, "Open"),
+		"an untouched proposal must render as Open")
+
+	// And rendering still wrote nothing.
+	urequire.Equal(t, daokit.ProposalStatusOpen.String(), get(passedID).Status.String(),
+		"rendering must not have moved the condition-met proposal")
+
+	// The JSON view agrees.
+	js := store.GetProposalsJSON()
+	urequire.True(t, strings.Contains(js, `"Passed"`), "JSON must show Passed")
+	urequire.True(t, strings.Contains(js, `"Executed"`), "JSON must show Executed")
+
+	// The active/history split follows the rendered status, not the stored one.
+	active := tdao.privdao.ProposalsView("")
+	history := tdao.privdao.ProposalHistoryView("")
+	urequire.False(t, strings.Contains(history, "Open"),
+		"an open proposal does not belong in history")
+	urequire.True(t, strings.Contains(active, "Passed"),
+		"a condition-met proposal is still active until executed")
+	urequire.True(t, strings.Contains(history, "Executed"),
+		"an executed proposal belongs in history")
+}

--- a/gno/p/basedao/utils.gno
+++ b/gno/p/basedao/utils.gno
@@ -198,7 +198,7 @@ func (d *DAOPrivate) RenderProposalsTable(path string, proposals *daokit.Proposa
 			resource.DisplayName,
 			RenderAddressLink(proposal.ProposerID),
 			FormatDateTimeWithUTCOffset(proposal.CreatedAt),
-			proposal.Status.String())
+			proposal.DisplayStatus().String())
 	}
 
 	s += "\n" + page.Picker(path) + "\n"

--- a/gno/p/basedao/view_proposal_detail_page.gno
+++ b/gno/p/basedao/view_proposal_detail_page.gno
@@ -41,14 +41,14 @@ func (d *DAOPrivate) ProposalDetailView(idu uint64) string {
 	s += ("---\n\n")
 	s += proposal.Action.String() + "\n\n"
 	s += ("---\n\n")
-	proposal.UpdateStatus()
-	if proposal.Status == daokit.ProposalStatusOpen {
+	status := proposal.DisplayStatus()
+	if status == daokit.ProposalStatusOpen {
 		s += ufmt.Sprintf("## Status - Open 🟡\n\n")
 		s += md.Link("Approve this proposal 🗳️", txlink.Call("Vote", "proposalID", strconv.FormatUint(idu, 10), "vote", string(daocond.VoteYes))) + "\n\n"
-	} else if proposal.Status == daokit.ProposalStatusPassed {
+	} else if status == daokit.ProposalStatusPassed {
 		s += ufmt.Sprintf("## Status - Passed 🟢\n\n")
 		s += md.Link("Execute this proposal 🗳️", txlink.Call("Execute", "proposalID", strconv.FormatUint(idu, 10))) + "\n\n"
-	} else if proposal.Status == daokit.ProposalStatusExecuted {
+	} else if status == daokit.ProposalStatusExecuted {
 		s += ufmt.Sprintf("## Status - Executed ✅\n\n")
 	} else {
 		s += ufmt.Sprintf("## Status - Closed 🔴\n\n")

--- a/gno/p/basedao/view_proposal_history_page.gno
+++ b/gno/p/basedao/view_proposal_history_page.gno
@@ -26,8 +26,10 @@ func (d *DAOPrivate) ProposalHistoryHeaderView() string {
 func (d *DAOPrivate) ProposalHistoryView(path string) string {
 	inactiveProposals := d.Core.Proposals.GetProposals(
 		func(p daokit.Proposal) bool {
-			st := p.DisplayStatus()
-			return st != daokit.ProposalStatusOpen && st != daokit.ProposalStatusPassed
+			// Raw status, for the reason in view_proposals_page.gno: this is
+			// exactly "already executed", and the display status would cost a
+			// second condition evaluation per proposal.
+			return p.Status != daokit.ProposalStatusOpen && p.Status != daokit.ProposalStatusPassed
 		},
 	)
 	s := ""

--- a/gno/p/basedao/view_proposal_history_page.gno
+++ b/gno/p/basedao/view_proposal_history_page.gno
@@ -26,7 +26,8 @@ func (d *DAOPrivate) ProposalHistoryHeaderView() string {
 func (d *DAOPrivate) ProposalHistoryView(path string) string {
 	inactiveProposals := d.Core.Proposals.GetProposals(
 		func(p daokit.Proposal) bool {
-			return p.Status != daokit.ProposalStatusOpen && p.Status != daokit.ProposalStatusPassed
+			st := p.DisplayStatus()
+			return st != daokit.ProposalStatusOpen && st != daokit.ProposalStatusPassed
 		},
 	)
 	s := ""

--- a/gno/p/basedao/view_proposals_page.gno
+++ b/gno/p/basedao/view_proposals_page.gno
@@ -26,7 +26,8 @@ func (d *DAOPrivate) ProposalsHeaderView() string {
 func (d *DAOPrivate) ProposalsView(path string) string {
 	activeProposals := d.Core.Proposals.GetProposals(
 		func(p daokit.Proposal) bool {
-			return p.Status == daokit.ProposalStatusOpen || p.Status == daokit.ProposalStatusPassed
+			st := p.DisplayStatus()
+			return st == daokit.ProposalStatusOpen || st == daokit.ProposalStatusPassed
 		},
 	)
 	s := ""

--- a/gno/p/basedao/view_proposals_page.gno
+++ b/gno/p/basedao/view_proposals_page.gno
@@ -26,8 +26,12 @@ func (d *DAOPrivate) ProposalsHeaderView() string {
 func (d *DAOPrivate) ProposalsView(path string) string {
 	activeProposals := d.Core.Proposals.GetProposals(
 		func(p daokit.Proposal) bool {
-			st := p.DisplayStatus()
-			return st == daokit.ProposalStatusOpen || st == daokit.ProposalStatusPassed
+			// Raw status, not DisplayStatus: only Execute writes Status, so a
+			// stored proposal is Open until Executed and this is exactly
+			// "not yet executed". Computing the display status here would
+			// evaluate every proposal's condition a second time — the table
+			// below already does it for the ones that survive the filter.
+			return p.Status == daokit.ProposalStatusOpen || p.Status == daokit.ProposalStatusPassed
 		},
 	)
 	s := ""

--- a/gno/p/daokit/action_spoofing_test.gno
+++ b/gno/p/daokit/action_spoofing_test.gno
@@ -1,0 +1,106 @@
+package daokit
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+)
+
+// The honest payload a handler expects.
+type realPayload struct{ amount int }
+
+func (p *realPayload) String() string { return "transfer 1 coin" }
+
+// A hostile payload that renders identically but carries different data. It
+// satisfies every interface the honest type does.
+type spoofPayload struct{ amount int }
+
+func (p *spoofPayload) String() string { return "transfer 1 coin" }
+
+// A handler that asserts a CONCRETE type rejects a spoofed payload, which is
+// what makes an action's own rendering safe to put in front of a voter.
+//
+// Both payloads render the same string, so a member reading the proposal cannot
+// tell them apart. The rejection therefore has to come from the type assertion,
+// not from anything a voter could have noticed.
+func TestAConcreteAssertionRejectsASpoofedPayload(cur realm, t *testing.T) {
+	executed := 0
+	handler := NewActionHandler("transfer", func(payload interface{}, rlm realm) {
+		p, ok := payload.(*realPayload)
+		if !ok {
+			panic("invalid action type")
+		}
+		executed = p.amount
+	})
+
+	honest := NewAction("transfer", &realPayload{amount: 1})
+	hostile := NewAction("transfer", &spoofPayload{amount: 1000000})
+
+	urequire.Equal(t, honest.String(), hostile.String(),
+		"the payloads must be indistinguishable to a voter, or this proves nothing")
+
+	handler.Execute(honest, cur)
+	urequire.Equal(t, 1, executed)
+
+	urequire.PanicsWithMessage(t, cur, "invalid action type", func() {
+		handler.Execute(hostile, cur)
+	})
+	urequire.Equal(t, 1, executed, "the spoofed payload must not have executed")
+}
+
+// And the unsafe pattern, demonstrated rather than asserted: a handler that
+// asserts to an INTERFACE admits the spoof, because the hostile payload
+// satisfies it exactly as the honest one does.
+//
+// This is why NewActionHandler's contract is a concrete assertion. Nothing in
+// daokit can enforce it — the handler decides — so it is pinned here as a fact
+// about the pattern rather than a property of any one line of library code.
+func TestAnInterfaceAssertionAdmitsTheSpoof(cur realm, t *testing.T) {
+	type renderable interface{ String() string }
+
+	admitted := ""
+	handler := NewActionHandler("transfer", func(payload interface{}, rlm realm) {
+		p, ok := payload.(renderable) // the mistake
+		if !ok {
+			panic("invalid action type")
+		}
+		admitted = p.String()
+	})
+
+	hostile := NewAction("transfer", &spoofPayload{amount: 1000000})
+
+	urequire.NotPanics(t, cur, func() {
+		handler.Execute(hostile, cur)
+	})
+	urequire.Equal(t, "transfer 1 coin", admitted,
+		"the handler accepted a payload of 1000000 that renders as 1 — exactly the spoof")
+}
+
+// An action cannot disguise its KIND, because Type() is the key its handler is
+// looked up by: claim a different kind and that kind's handler runs, and its
+// concrete assertion fails. So what a member sees an action IS comes from the
+// DAO's own resource registry, not from the proposal.
+func TestAnActionCannotDisguiseItsKind(cur realm, t *testing.T) {
+	core := NewCore()
+	transferRan := false
+	core.Resources.Set(&Resource{
+		Handler: NewActionHandler("transfer", func(payload interface{}, rlm realm) {
+			if _, ok := payload.(*realPayload); !ok {
+				panic("invalid action type")
+			}
+			transferRan = true
+		}),
+		DisplayName: "Transfer funds",
+	})
+
+	disguised := NewAction("transfer", &spoofPayload{amount: 1000000})
+
+	urequire.Equal(t, "Transfer funds",
+		core.Resources.Get(disguised.Type()).DisplayName,
+		"the name a voter sees is keyed by Type(), not supplied by the proposal")
+
+	urequire.PanicsWithMessage(t, cur, "invalid action type", func() {
+		core.Resources.Get(disguised.Type()).Handler.Execute(disguised, cur)
+	})
+	urequire.False(t, transferRan)
+}

--- a/gno/p/daokit/actions.gno
+++ b/gno/p/daokit/actions.gno
@@ -133,6 +133,10 @@ func NewInstantExecuteHandler() ActionHandler {
 	})
 }
 
+// SAME REALM ONLY, for the reason on InstantExecute: the handler forwards the
+// EXECUTING DAO's realm, so dao must be hosted by the same realm. A child DAO in
+// another realm is refused — reach it through that realm's crossing function
+// instead.
 func NewInstantExecuteAction(dao DAO, req ProposalRequest) Action {
 	return NewAction(ActionInstantExecuteKind, &actionInstantExecute{dao: dao, req: req})
 }

--- a/gno/p/daokit/actions.gno
+++ b/gno/p/daokit/actions.gno
@@ -13,6 +13,20 @@ import (
 )
 
 // Interface storing Action's data.
+//
+// SECURITY: String() is what a member reads before voting, and for an action
+// built with NewAction it is the PAYLOAD's own rendering — supplied by whoever
+// created the proposal. It is not trustworthy on its own.
+//
+// Two things keep it honest. Type() must be truthful or the wrong handler is
+// looked up and its type assertion fails, so the action's KIND cannot be
+// disguised; and the proposal view renders the Resource's registered
+// DisplayName, Description and Condition beside it, which come from the DAO's
+// own registry keyed by Type(), not from the proposal. A member therefore always
+// sees what KIND of action this is from a trusted source.
+//
+// What String() can still misrepresent is the payload's DETAIL — and only if the
+// handler lets a hostile payload through. See NewActionHandler.
 type Action interface {
 	// Returns human-readable description of the action.
 	String() string
@@ -59,6 +73,24 @@ func (g *genericAction) Type() string {
 	return g.kind
 }
 
+// SECURITY: the executor MUST type-assert the payload to a CONCRETE type, never
+// to an interface.
+//
+// The concrete assertion is what makes the action's own rendering safe to show a
+// voter: a hostile proposer can submit any payload, but one of the wrong type is
+// rejected before the executor sees it, and one of the right type renders
+// through that type's own String(). Assert to an interface instead and any
+// conforming type passes — including one whose String() understates what its
+// data does, so the proposal reads as something milder than it executes.
+//
+// Stronger still, and what the destructive built-ins do: make the payload type
+// UNEXPORTED and expose only a constructor, so a proposer cannot build one at
+// all. basedao's ChangeDAOImplementation and daokit's InstantExecute both do.
+//
+// Moving rendering onto the handler would remove this footgun rather than
+// document it, since the handler is registered by the DAO and the payload is
+// not — gnodaokit#13. That changes ActionHandler, so it belongs to a version
+// boundary rather than a patch.
 func NewActionHandler(kind string, executor func(interface{}, realm)) ActionHandler {
 	return &genericActionHandler{kind: kind, executor: executor}
 }

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -90,22 +90,29 @@ func (d *Core) Execute(proposalID uint64, rlm realm) {
 		panic("proposal not found")
 	}
 
-	if proposal.Status != ProposalStatusOpen {
-		panic("proposal is not open")
+	// Executed is the only status that disqualifies a proposal. It used to be
+	// "anything but Open", which made the status a second, weaker gate on top of
+	// the condition — and any realm holding the DAO handle could trip it by
+	// rendering, since the read paths wrote Open -> Passed as they walked.
+	// Whether a proposal may execute is decided by its condition, below, and
+	// nothing else.
+	if proposal.Status == ProposalStatusExecuted {
+		panic("proposal is already executed")
 	}
 
 	if !proposal.Condition.Eval(proposal.Ballot) {
 		panic("proposal condition is not met")
 	}
 
-	proposal.UpdateStatus()
-	if proposal.Status != ProposalStatusPassed {
-		panic("proposal does not meet the condition(s) or is already closed/executed")
-	}
-
-	d.Resources.Get(proposal.Action.Type()).Handler.Execute(proposal.Action, rlm)
+	// Marked BEFORE the handler runs, not after. The handler crosses out of the
+	// DAO, so a callee can re-enter here within the same transaction; marking
+	// afterwards would let it execute the same proposal again. The old code was
+	// protected from this only incidentally, by the "must be Open" test above —
+	// removing that test without moving this line would have opened it.
 	proposal.Status = ProposalStatusExecuted
 	proposal.ExecutedAt = time.Now()
+
+	d.Resources.Get(proposal.Action.Type()).Handler.Execute(proposal.Action, rlm)
 }
 
 // Creates a new proposal for voting and returns its ID.

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -47,7 +47,21 @@ type SetImplemFn = func(implem DAO)
 
 // Creates, votes yes, and immediately executes a proposal in one operation.
 // Useful when you have enough permission to execute an action directly.
-// Examples: migrations, adding members
+// Examples: migrations, adding members.
+//
+// SAME REALM ONLY. Every step threads rlm, and each entry point requires it to
+// be the receiving DAO's own — so d must be a DAO hosted by the realm calling
+// this. Handing it a DAO belonging to another realm is refused.
+//
+// That refusal is the point. Driving a foreign DAO by passing it your realm is
+// the donation shape: it makes the DAO act under YOUR identity, and it is what a
+// caller holding the handle could previously do to any DAO. It appeared to work
+// only because nothing checked.
+//
+// A parent DAO can still drive a child. Reach the child through the child
+// REALM's own crossing function — child.Propose(cross(cur), req) — so the child
+// mints its own realm and sees the parent as its caller. Make the parent a
+// member of the child; the child then authorises it like any other member.
 func InstantExecute(d DAO, req ProposalRequest, rlm realm) uint64 {
 	id := d.Propose(req, rlm)
 	d.Vote(id, daocond.VoteYes, rlm)

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -92,8 +92,11 @@ func (d *Core) Vote(voterID string, proposalID uint64, vote daocond.Vote) {
 		panic("proposal not found")
 	}
 
-	if proposal.Status != ProposalStatusOpen {
-		panic("proposal is not open")
+	// Same terminal state as Execute: a ballot stays open right up until the
+	// proposal executes, so support can still be withdrawn after the condition
+	// is first met. Anything narrower would let a proposal be locked in.
+	if proposal.Status == ProposalStatusExecuted {
+		panic("proposal is already executed")
 	}
 
 	proposal.Ballot.Vote(voterID, vote)
@@ -123,8 +126,14 @@ func (d *Core) Execute(proposalID uint64, rlm realm) {
 	// Marked BEFORE the handler runs, not after. The handler crosses out of the
 	// DAO, so a callee can re-enter here within the same transaction; marking
 	// afterwards would let it execute the same proposal again. The old code was
-	// protected from this only incidentally, by the "must be Open" test above —
-	// removing that test without moving this line would have opened it.
+	// protected from this only incidentally, by a "must be Open" test that also
+	// made rendering able to brick a proposal.
+	//
+	// The cost is that Execute is NOT retry-safe. gno's recover() does not roll
+	// back realm state, so a host realm that recovers around a failing Execute
+	// keeps the marker and burns the proposal permanently. Do not recover around
+	// it: let the transaction abort, which reverts the marker with everything
+	// else. Marking afterwards would trade this for re-entrancy, which is worse.
 	proposal.Status = ProposalStatusExecuted
 	proposal.ExecutedAt = time.Now()
 

--- a/gno/p/daokit/daokit.gno
+++ b/gno/p/daokit/daokit.gno
@@ -34,8 +34,10 @@ type DAO interface {
 	// Generates a web interface representation for the given path.
 	Render(path string) string
 
-	// Gets an extension by path, returns nil if not found.
-	Extension(path string) Extension
+	// Gets an extension by path, returns nil if not found. A PRIVATE extension
+	// additionally requires the DAO realm's own live realm, on the same terms
+	// as the entry points above; a public one ignores it.
+	Extension(path string, rlm realm) Extension
 	// Lists all available extensions.
 	ExtensionsList() ExtensionsList
 }

--- a/gno/p/daokit/extensions.gno
+++ b/gno/p/daokit/extensions.gno
@@ -19,7 +19,13 @@ type ExtensionInfo struct {
 	Path      string // Unique extension identifier (e.g., "gno.land/p/samcrew/basedao.MembersView")
 	Version   string // Extension version (e.g., "1", "2.0", etc.)
 	QueryPath string // Path for external queries to access this extension's data
-	Private   bool   // If true, extension is only accessible from the same realm that registered it
+	// If true, only the registering realm can obtain the extension VALUE
+	// through DAO.Extension — which is a capability, not a secret. Realm state
+	// on a public chain is world-readable over ABCI regardless, and this
+	// ExtensionInfo (including QueryPath) is listed by ExtensionsList without a
+	// check. Private restricts who can call the extension's methods under the
+	// DAO's authority; it does not hide anything.
+	Private bool
 }
 
 type ExtensionsList interface {

--- a/gno/p/daokit/proposals.gno
+++ b/gno/p/daokit/proposals.gno
@@ -88,7 +88,6 @@ func (p *ProposalsStore) GetProposals(filter func(Proposal) bool) *ProposalsStor
 		if !ok {
 			panic(errors.New("unexpected invalid proposal type"))
 		}
-		prop.UpdateStatus() // XXX: costly and probably insecure
 		if filter(*prop) {
 			proposals.Tree.Set(key, prop)
 		}
@@ -97,12 +96,27 @@ func (p *ProposalsStore) GetProposals(filter func(Proposal) bool) *ProposalsStor
 	return proposals
 }
 
-// Updates proposal status based on current voting condition results.
-func (p *Proposal) UpdateStatus() {
-	conditionsAreMet := p.Condition.Eval(p.Ballot)
-	if p.Status == ProposalStatusOpen && conditionsAreMet {
-		p.Status = ProposalStatusPassed
+// Reports the status a proposal should be displayed as, without writing it.
+//
+// Reading must never move a proposal. Render is on the cross-realm DAO
+// interface, so anything it touches is reachable by any realm holding the
+// handle: this used to be UpdateStatus, called on every proposal walked, and a
+// single Render flipped every condition-met proposal from Open to Passed.
+func (p *Proposal) DisplayStatus() ProposalStatus {
+	if p.Status == ProposalStatusOpen && p.Condition.Eval(p.Ballot) {
+		return ProposalStatusPassed
 	}
+	return p.Status
+}
+
+// Persists the status implied by the current votes.
+//
+// Nothing in this package needs it: Execute evaluates the condition itself, and
+// the render paths use DisplayStatus. It remains because persisting the passed
+// state is a legitimate thing for a realm to want. Do not call it from a read
+// path — it writes.
+func (p *Proposal) UpdateStatus() {
+	p.Status = p.DisplayStatus()
 }
 
 // Returns all proposals as a JSON string.
@@ -114,13 +128,12 @@ func (p *ProposalsStore) GetProposalsJSON() string {
 		if !ok {
 			panic(errors.New("unexpected invalid proposal type"))
 		}
-		prop.UpdateStatus()
 		props = append(props, json.ObjectNode("", map[string]*json.Node{
 			"id":          json.NumberNode("", float64(prop.ID)),
 			"title":       json.StringNode("", prop.Title),
 			"description": json.StringNode("", prop.Description),
 			"proposer":    json.StringNode("", prop.ProposerID),
-			"status":      json.StringNode("", prop.Status.String()),
+			"status":      json.StringNode("", prop.DisplayStatus().String()),
 			"startHeight": json.NumberNode("", float64(prop.CreatedHeight)),
 			"signal":      json.NumberNode("", prop.Condition.Signal(prop.Ballot)),
 		}))

--- a/gno/p/daokit/proposals.gno
+++ b/gno/p/daokit/proposals.gno
@@ -98,6 +98,12 @@ func (p *ProposalsStore) GetProposals(filter func(Proposal) bool) *ProposalsStor
 
 // Reports the status a proposal should be displayed as, without writing it.
 //
+// Status is only ever WRITTEN by Execute, so a stored proposal is Open until it
+// is Executed and Passed exists purely as a computed display state. That is
+// deliberate: an exported way to persist Passed used to exist, and it made the
+// stored status disagree with the votes — a proposal whose support was later
+// withdrawn still read Passed, and Vote refused it while Execute accepted it.
+//
 // Reading must never move a proposal. Render is on the cross-realm DAO
 // interface, so anything it touches is reachable by any realm holding the
 // handle: this used to be UpdateStatus, called on every proposal walked, and a
@@ -107,16 +113,6 @@ func (p *Proposal) DisplayStatus() ProposalStatus {
 		return ProposalStatusPassed
 	}
 	return p.Status
-}
-
-// Persists the status implied by the current votes.
-//
-// Nothing in this package needs it: Execute evaluates the condition itself, and
-// the render paths use DisplayStatus. It remains because persisting the passed
-// state is a legitimate thing for a realm to want. Do not call it from a read
-// path — it writes.
-func (p *Proposal) UpdateStatus() {
-	p.Status = p.DisplayStatus()
 }
 
 // Returns all proposals as a JSON string.

--- a/gno/p/daokit/proposals.gno
+++ b/gno/p/daokit/proposals.gno
@@ -98,21 +98,37 @@ func (p *ProposalsStore) GetProposals(filter func(Proposal) bool) *ProposalsStor
 
 // Reports the status a proposal should be displayed as, without writing it.
 //
-// Status is only ever WRITTEN by Execute, so a stored proposal is Open until it
-// is Executed and Passed exists purely as a computed display state. That is
-// deliberate: an exported way to persist Passed used to exist, and it made the
-// stored status disagree with the votes — a proposal whose support was later
-// withdrawn still read Passed, and Vote refused it while Execute accepted it.
-//
 // Reading must never move a proposal. Render is on the cross-realm DAO
 // interface, so anything it touches is reachable by any realm holding the
-// handle: this used to be UpdateStatus, called on every proposal walked, and a
-// single Render flipped every condition-met proposal from Open to Passed.
+// handle: every read path used to call UpdateStatus on each proposal it walked,
+// and a single Render flipped every condition-met proposal from Open to Passed —
+// which, back when Execute demanded Open, bricked it permanently.
 func (p *Proposal) DisplayStatus() ProposalStatus {
 	if p.Status == ProposalStatusOpen && p.Condition.Eval(p.Ballot) {
 		return ProposalStatusPassed
 	}
 	return p.Status
+}
+
+// Persists the status implied by the current votes: Open becomes Passed once the
+// condition is met.
+//
+// Nothing in this package calls it. Execute evaluates the condition itself and
+// the read paths use DisplayStatus, so a proposal that is never passed through
+// here stays Open until it is Executed. It exists for a realm that wants the
+// passed state on-chain rather than computed.
+//
+// SAFE ONLY BECAUSE Vote and Execute both key on Executed alone. When they
+// demanded Open, calling this was destructive twice over: it froze the ballot,
+// so support could not be withdrawn, and it made the proposal permanently
+// unexecutable. Do not narrow either of those checks without removing this.
+//
+// It is also a READ path hazard — do not call it while rendering. And once
+// persisted the status no longer tracks the votes: withdraw support afterwards
+// and this still reads Passed, though Execute re-evaluates the condition and
+// will refuse.
+func (p *Proposal) UpdateStatus() {
+	p.Status = p.DisplayStatus()
 }
 
 // Returns all proposals as a JSON string.

--- a/gno/r/daodemo/custom_condition/utils.gno
+++ b/gno/r/daodemo/custom_condition/utils.gno
@@ -61,6 +61,11 @@ func initDemoProposals() {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
+	// Safe here only because cur is THIS realm's own, minted by this crossing
+	// function. CallerID is not the entry-point gate: copied somewhere that
+	// passes a realm it received from elsewhere, this becomes the donation bug
+	// the DAO entry points exist to refuse. If you need the gate, go through
+	// Propose/Vote/Execute.
 	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }

--- a/gno/r/daodemo/custom_resource/utils.gno
+++ b/gno/r/daodemo/custom_resource/utils.gno
@@ -35,6 +35,11 @@ func initBlogProposals() {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
+	// Safe here only because cur is THIS realm's own, minted by this crossing
+	// function. CallerID is not the entry-point gate: copied somewhere that
+	// passes a realm it received from elsewhere, this becomes the donation bug
+	// the DAO entry points exist to refuse. If you need the gate, go through
+	// Propose/Vote/Execute.
 	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }

--- a/gno/r/daodemo/simple_dao/utils.gno
+++ b/gno/r/daodemo/simple_dao/utils.gno
@@ -80,6 +80,11 @@ func initProposals(cur realm, nb int) {
 // Bypass limitation by adding yourself to the DAO.
 // It is necessary to be part of the DAO to create a Proposal.
 func AddMember(cur realm) {
+	// Safe here only because cur is THIS realm's own, minted by this crossing
+	// function. CallerID is not the entry-point gate: copied somewhere that
+	// passes a realm it received from elsewhere, this becomes the donation bug
+	// the DAO entry points exist to refuse. If you need the gate, go through
+	// Propose/Vote/Execute.
 	id := daoPrivate.CallerID(daoPrivate, cur)
 	daoPrivate.Members.AddMember(id, make([]string, 0))
 }

--- a/gno/r/daoidentity/attacker/attacker.gno
+++ b/gno/r/daoidentity/attacker/attacker.gno
@@ -9,6 +9,7 @@
 package attacker
 
 import (
+	"gno.land/p/samcrew/basedao"
 	"gno.land/p/samcrew/daocond"
 	"gno.land/p/samcrew/daokit"
 	"gno.land/r/samcrew/daoidentity/dao"
@@ -30,4 +31,15 @@ func Vote(cur realm, id uint64, vote daocond.Vote) {
 // caller controls.
 func Execute(cur realm, id uint64) {
 	dao.Handle().Execute(id, cur)
+}
+
+// ReadSecret tries to fetch the DAO's PRIVATE extension with this realm's own
+// realm. Only the DAO realm may.
+func ReadSecret(cur realm) {
+	dao.Handle().Extension(dao.SecretPath, cur)
+}
+
+// ReadPublicExtension fetches a PUBLIC extension, which any realm may do.
+func ReadPublicExtension(cur realm) bool {
+	return dao.Handle().Extension(basedao.MembersViewExtensionPath, cur) != nil
 }

--- a/gno/r/daoidentity/callback/callback.gno
+++ b/gno/r/daoidentity/callback/callback.gno
@@ -36,3 +36,21 @@ func Reenter(cur realm, req daokit.ProposalRequest) {
 	target.Propose(req, stolen)
 	reentered = true
 }
+
+// stolenSecret records whether a private extension was read using the DAO's own
+// dead-frame realm.
+var stolenSecret string
+
+// StolenSecret reports what a re-entrant read obtained, if anything.
+func StolenSecret() string { return stolenSecret }
+
+// StealSecret is invoked by a DAO action handler, so cur.Previous() is the DAO's
+// own realm value — same pkgpath as the DAO, but a frame that is no longer live.
+// Handing that to Extension must not open a private extension.
+func StealSecret(cur realm, path string) {
+	stolen := cur.Previous()
+	ext := target.Extension(path, stolen)
+	if s, ok := ext.(interface{ Secret() string }); ok {
+		stolenSecret = s.Secret()
+	}
+}

--- a/gno/r/daoidentity/dao/dao.gno
+++ b/gno/r/daoidentity/dao/dao.gno
@@ -28,6 +28,11 @@ const (
 	// ActionCrossOut is an action whose handler crosses out of the DAO, as
 	// the built-in EditProfile action does.
 	ActionCrossOut = "gno.land/r/samcrew/daoidentity/dao.CrossOut"
+
+	// ActionReenter is an action whose handler calls back into this realm's own
+	// Execute, which is the one re-entrancy shape the realm gate cannot refuse:
+	// the realm is genuinely this one's, and genuinely live.
+	ActionReenter = "gno.land/r/samcrew/daoidentity/dao.Reenter"
 )
 
 var (
@@ -37,7 +42,27 @@ var (
 	// seenByCallerID records the realm a custom CallerIDFn was handed, so a
 	// test can show the entry gate ran before it.
 	seenByCallerID string
+
+	reenterTarget uint64
+	// ReenterAttempted records that the re-entrant handler ran at all, so a
+	// test can tell a refusal apart from the action never firing.
+	ReenterAttempted bool
+	// ReenterSucceeded records that the re-entrant Execute returned.
+	ReenterSucceeded bool
 )
+
+// NewReenterRequest builds a proposal whose execution re-enters Execute on the
+// proposal id given, through this realm's own crossing function.
+func ArmReenter(id uint64) { reenterTarget = id }
+
+// NewReenterRequest builds the re-entrant proposal.
+func NewReenterRequest() daokit.ProposalRequest {
+	return daokit.ProposalRequest{
+		Title:       "reenter",
+		Description: "calls back into Execute while executing",
+		Action:      daokit.NewAction(ActionReenter, nil),
+	}
+}
 
 // SeenByCallerID reports the realm the DAO's CallerIDFn last observed.
 func SeenByCallerID() string { return seenByCallerID }
@@ -51,6 +76,9 @@ func init(cur realm) {
 	members := basedao.NewMembersStore(nil, []basedao.Member{
 		{Address: RelayID},
 		{Address: SuiteID},
+		// The DAO is a member of itself so a re-entrant call reaches the
+		// proposal machinery instead of stopping at the membership check.
+		{Address: Self},
 	})
 
 	// Any single member can carry a proposal, so nothing in these tests turns
@@ -86,6 +114,18 @@ func init(cur realm) {
 		Description: "Crosses out of the DAO, handing a callee the DAO's realm.",
 	})
 
+	daoPrivate.Core.Resources.Set(&daokit.Resource{
+		Handler: daokit.NewActionHandler(ActionReenter, func(payload interface{}, rlm realm) {
+			ReenterAttempted = true
+			// Straight back through this realm's own crossing entry point.
+			Execute(cross(rlm), reenterTarget)
+			ReenterSucceeded = true
+		}),
+		Condition:   cond,
+		DisplayName: "Reenter",
+		Description: "Calls back into this realm's own Execute while executing.",
+	})
+
 	callback.SetTarget(cross(cur), localDAO)
 }
 
@@ -111,6 +151,12 @@ func Execute(cur realm, id uint64) {
 // crossing functions entirely.
 func Handle() daokit.DAO {
 	return localDAO
+}
+
+// PersistStatus writes the status implied by the current votes, which is what
+// UpdateStatus is for. A realm may legitimately do this.
+func PersistStatus(id uint64) {
+	daoPrivate.Core.Proposals.GetProposal(id).UpdateStatus()
 }
 
 // ProposerOf reports the identity the DAO resolved for a proposal's creator.

--- a/gno/r/daoidentity/dao/dao.gno
+++ b/gno/r/daoidentity/dao/dao.gno
@@ -193,6 +193,12 @@ func ReadPublicExtension(cur realm) bool {
 	return ext != nil
 }
 
+// PersistStatus writes the status implied by the current votes — what
+// UpdateStatus is for. Exposed so a test can prove doing it is harmless.
+func PersistStatus(id uint64) {
+	daoPrivate.Core.Proposals.GetProposal(id).UpdateStatus()
+}
+
 // ProposerOf reports the identity the DAO resolved for a proposal's creator.
 func ProposerOf(id uint64) string {
 	return daoPrivate.Core.Proposals.GetProposal(id).ProposerID

--- a/gno/r/daoidentity/dao/dao.gno
+++ b/gno/r/daoidentity/dao/dao.gno
@@ -126,6 +126,9 @@ func init(cur realm) {
 		Description: "Calls back into this realm's own Execute while executing.",
 	})
 
+	// A private extension, to show the gate does real work.
+	daoPrivate.Core.Extensions.Set(&secretExtension{})
+
 	callback.SetTarget(cross(cur), localDAO)
 }
 
@@ -151,6 +154,30 @@ func Execute(cur realm, id uint64) {
 // crossing functions entirely.
 func Handle() daokit.DAO {
 	return localDAO
+}
+
+// SecretPath is a private extension only this realm may fetch.
+const SecretPath = "gno.land/r/samcrew/daoidentity/dao.Secret"
+
+type secretExtension struct{}
+
+func (s *secretExtension) Info() daokit.ExtensionInfo {
+	return daokit.ExtensionInfo{Path: SecretPath, Version: "1", Private: true}
+}
+
+func (s *secretExtension) Secret() string { return "TOP-SECRET" }
+
+// ReadSecret fetches the private extension using this realm's own live realm,
+// which is the only thing allowed to.
+func ReadSecret(cur realm) string {
+	ext := localDAO.Extension(SecretPath, cur)
+	return ext.(*secretExtension).Secret()
+}
+
+// ReadPublicExtension shows a public extension ignores the realm.
+func ReadPublicExtension(cur realm) bool {
+	ext := localDAO.Extension(basedao.MembersViewExtensionPath, cur)
+	return ext != nil
 }
 
 // PersistStatus writes the status implied by the current votes, which is what

--- a/gno/r/daoidentity/dao/dao.gno
+++ b/gno/r/daoidentity/dao/dao.gno
@@ -29,6 +29,10 @@ const (
 	// the built-in EditProfile action does.
 	ActionCrossOut = "gno.land/r/samcrew/daoidentity/dao.CrossOut"
 
+	// ActionStealSecret crosses out to a callee and lets it try to read this
+	// DAO's private extension with the realm it was handed.
+	ActionStealSecret = "gno.land/r/samcrew/daoidentity/dao.StealSecret"
+
 	// ActionReenter is an action whose handler calls back into this realm's own
 	// Execute, which is the one re-entrancy shape the realm gate cannot refuse:
 	// the realm is genuinely this one's, and genuinely live.
@@ -129,6 +133,15 @@ func init(cur realm) {
 	// A private extension, to show the gate does real work.
 	daoPrivate.Core.Extensions.Set(&secretExtension{})
 
+	daoPrivate.Core.Resources.Set(&daokit.Resource{
+		Handler: daokit.NewActionHandler(ActionStealSecret, func(payload interface{}, rlm realm) {
+			callback.StealSecret(cross(rlm), SecretPath)
+		}),
+		Condition:   cond,
+		DisplayName: "Steal Secret",
+		Description: "Hands a callee this DAO's realm and lets it try the private extension.",
+	})
+
 	callback.SetTarget(cross(cur), localDAO)
 }
 
@@ -180,15 +193,19 @@ func ReadPublicExtension(cur realm) bool {
 	return ext != nil
 }
 
-// PersistStatus writes the status implied by the current votes, which is what
-// UpdateStatus is for. A realm may legitimately do this.
-func PersistStatus(id uint64) {
-	daoPrivate.Core.Proposals.GetProposal(id).UpdateStatus()
-}
-
 // ProposerOf reports the identity the DAO resolved for a proposal's creator.
 func ProposerOf(id uint64) string {
 	return daoPrivate.Core.Proposals.GetProposal(id).ProposerID
+}
+
+// NewStealSecretRequest builds a proposal whose execution hands a callee this
+// DAO's realm and has it attempt the private extension.
+func NewStealSecretRequest() daokit.ProposalRequest {
+	return daokit.ProposalRequest{
+		Title:       "steal secret",
+		Description: "a callee tries the private extension with a dead-frame realm",
+		Action:      daokit.NewAction(ActionStealSecret, nil),
+	}
 }
 
 // NewCrossOutRequest builds a proposal whose execution crosses out of the DAO.

--- a/gno/r/daoidentity/suite/lifecycle_test.gno
+++ b/gno/r/daoidentity/suite/lifecycle_test.gno
@@ -9,6 +9,7 @@ import (
 	"gno.land/p/samcrew/daocond"
 	"gno.land/p/samcrew/daokit"
 	"gno.land/r/samcrew/daoidentity/attacker"
+	"gno.land/r/samcrew/daoidentity/callback"
 	"gno.land/r/samcrew/daoidentity/dao"
 )
 
@@ -82,24 +83,37 @@ func TestAProposalCannotReenterItsOwnExecution(cur realm, t *testing.T) {
 	urequire.False(t, dao.ReenterSucceeded, "the re-entrant Execute must not have returned")
 }
 
-// A proposal whose Passed status has been persisted must still execute.
+// A ballot stays open until the proposal executes.
 //
-// Executed is the only status that disqualifies a proposal. Making Open the
-// requirement instead turns the status into a second gate on top of the
-// condition, and anything that can move the status can then deny execution —
-// which is exactly how rendering bricked proposals. UpdateStatus is exported and
-// writes Open -> Passed, so this is reachable without any read path at all.
-func TestAPersistedPassedProposalStillExecutes(cur realm, t *testing.T) {
+// Vote and Execute share one terminal state, Executed. Anything narrower locks a
+// proposal in: support could no longer be withdrawn once the condition was first
+// met, while execution remained available. That is what an exported way to
+// persist Passed produced, which is why the stored status is now only ever
+// written by Execute.
+func TestSupportCanBeWithdrawnUntilExecution(cur realm, t *testing.T) {
 	id := dao.Propose(cross(cur), addDistinctMemberReq("g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g3"))
 	dao.Vote(cross(cur), id, daocond.VoteYes)
+	urequire.Equal(t, "Open", dao.StatusOf(id))
 
-	dao.PersistStatus(id)
-	urequire.Equal(t, "Passed", dao.StatusOf(id), "the status really is persisted")
+	// The condition is met, but the ballot is still live: change the vote.
+	urequire.NotAborts(t, cur, func() {
+		dao.Vote(cross(cur), id, daocond.VoteNo)
+	})
+	urequire.AbortsWithMessage(t, cur, "proposal condition is not met", func() {
+		dao.Execute(cross(cur), id)
+	})
 
+	// And back again.
+	dao.Vote(cross(cur), id, daocond.VoteYes)
 	urequire.NotAborts(t, cur, func() {
 		dao.Execute(cross(cur), id)
 	})
 	urequire.Equal(t, "Executed", dao.StatusOf(id))
+
+	// Once executed, the ballot closes too.
+	urequire.AbortsWithMessage(t, cur, "proposal is already executed", func() {
+		dao.Vote(cross(cur), id, daocond.VoteNo)
+	})
 }
 
 // A private extension is readable only by the DAO's own realm.
@@ -139,4 +153,23 @@ func TestInstantExecuteIsSameRealmOnly(cur realm, t *testing.T) {
 		daokit.InstantExecute(dao.Handle(), addDistinctMemberReq(
 			"g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g4"), cur)
 	})
+}
+
+// The private-extension gate needs BOTH halves, and only IsCurrent() catches
+// this one.
+//
+// A realm the DAO crosses out into receives the DAO's own realm value as its
+// cur.Previous(). That value carries the DAO's pkgpath, so a gate comparing
+// pkgpaths alone hands it the private extension — verified: with the check
+// replaced by a pkgpath comparison, this callee read the secret. It is not the
+// live crossing frame's cur, so IsCurrent() refuses it.
+func TestAPrivateExtensionResistsADeadFrameRealm(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), dao.NewStealSecretRequest())
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.Equal(t, "", callback.StolenSecret(),
+		"the private extension must never have been opened")
 }

--- a/gno/r/daoidentity/suite/lifecycle_test.gno
+++ b/gno/r/daoidentity/suite/lifecycle_test.gno
@@ -173,3 +173,37 @@ func TestAPrivateExtensionResistsADeadFrameRealm(cur realm, t *testing.T) {
 	urequire.Equal(t, "", callback.StolenSecret(),
 		"the private extension must never have been opened")
 }
+
+// Persisting Passed must be harmless — this is the invariant that makes exported
+// UpdateStatus safe to ship at all.
+//
+// When Vote and Execute demanded status Open, calling it was destructive twice
+// over: the ballot froze, so support could not be withdrawn, and the proposal
+// became permanently unexecutable. Both now key on Executed alone, so persisting
+// the passed state changes nothing about what the proposal can still do.
+//
+// If this test ever fails, UpdateStatus has been re-armed and must come out
+// rather than be worked around.
+func TestPersistingPassedNeitherFreezesNorBricksAProposal(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addDistinctMemberReq("g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g5"))
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+
+	dao.PersistStatus(id)
+	urequire.Equal(t, "Passed", dao.StatusOf(id), "the status really is persisted")
+
+	// The ballot is still live.
+	urequire.NotAborts(t, cur, func() {
+		dao.Vote(cross(cur), id, daocond.VoteNo)
+	})
+	// And withdrawing support really does block execution, so Execute is
+	// evaluating the votes rather than trusting the stored status.
+	urequire.AbortsWithMessage(t, cur, "proposal condition is not met", func() {
+		dao.Execute(cross(cur), id)
+	})
+
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+	urequire.NotAborts(t, cur, func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.Equal(t, "Executed", dao.StatusOf(id))
+}

--- a/gno/r/daoidentity/suite/lifecycle_test.gno
+++ b/gno/r/daoidentity/suite/lifecycle_test.gno
@@ -1,0 +1,102 @@
+// Proposal lifecycle, driven across realm boundaries.
+package suite
+
+import (
+	"testing"
+
+	"gno.land/p/nt/urequire/v0"
+	"gno.land/p/samcrew/basedao"
+	"gno.land/p/samcrew/daocond"
+	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/dao"
+)
+
+// These tests actually execute their proposals, so each needs a member the DAO
+// does not already hold — AddMember refuses a duplicate.
+func addDistinctMemberReq(addr string) daokit.ProposalRequest {
+	return daokit.ProposalRequest{
+		Title:       "add " + addr,
+		Description: "a distinct member per test",
+		Action:      basedao.NewAddMemberAction(&basedao.ActionAddMember{Address: address(addr)}),
+	}
+}
+
+// Rendering must not move a proposal's status.
+//
+// Render is on the cross-realm DAO interface and reaches GetProposals, which
+// used to call UpdateStatus on every proposal it walked. A proposal that had
+// met its condition was still Open — Vote never updates status — so any realm
+// holding the handle could flip it to Passed with one cheap call. Execute then
+// refused it forever, because it required exactly Open.
+//
+// Reproduced before the fix: Open -> foreign Render -> Passed -> Execute panics
+// "proposal is not open", permanently, repeatable after every re-vote.
+func TestRenderingDoesNotBrickAPassedProposal(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addDistinctMemberReq("g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g1"))
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+	urequire.Equal(t, "Open", dao.StatusOf(id), "voting alone must not move the status")
+
+	// Anyone holding the handle, in a transaction.
+	_ = dao.Handle().Render("proposals")
+	urequire.Equal(t, "Open", dao.StatusOf(id), "rendering must not move the status")
+
+	urequire.NotAborts(t, cur, func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.Equal(t, "Executed", dao.StatusOf(id))
+}
+
+// Executing twice must be refused, and the guard has to be the executed marker
+// rather than the old "must be Open" test.
+func TestAProposalExecutesOnlyOnce(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addDistinctMemberReq("g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g2"))
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+	dao.Execute(cross(cur), id)
+
+	urequire.AbortsWithMessage(t, cur, "proposal is already executed", func() {
+		dao.Execute(cross(cur), id)
+	})
+}
+
+// A proposal cannot re-enter its own execution.
+//
+// This is the one re-entrancy shape the realm gate cannot refuse: the handler
+// calls back through the DAO realm's own crossing function, so the realm it
+// presents is genuinely the DAO's and genuinely live. Only the executed marker
+// stops it — and only because that marker is set BEFORE the handler runs.
+//
+// The old code was protected here by accident: Execute demanded status Open, and
+// UpdateStatus had already moved it to Passed. Removing that demand, which is
+// what unbricks rendering, would have opened this if the marker had stayed where
+// it was.
+func TestAProposalCannotReenterItsOwnExecution(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), dao.NewReenterRequest())
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+	dao.ArmReenter(id)
+
+	urequire.AbortsWithMessage(t, cur, "proposal is already executed", func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.True(t, dao.ReenterAttempted, "the handler must actually have run")
+	urequire.False(t, dao.ReenterSucceeded, "the re-entrant Execute must not have returned")
+}
+
+// A proposal whose Passed status has been persisted must still execute.
+//
+// Executed is the only status that disqualifies a proposal. Making Open the
+// requirement instead turns the status into a second gate on top of the
+// condition, and anything that can move the status can then deny execution —
+// which is exactly how rendering bricked proposals. UpdateStatus is exported and
+// writes Open -> Passed, so this is reachable without any read path at all.
+func TestAPersistedPassedProposalStillExecutes(cur realm, t *testing.T) {
+	id := dao.Propose(cross(cur), addDistinctMemberReq("g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g3"))
+	dao.Vote(cross(cur), id, daocond.VoteYes)
+
+	dao.PersistStatus(id)
+	urequire.Equal(t, "Passed", dao.StatusOf(id), "the status really is persisted")
+
+	urequire.NotAborts(t, cur, func() {
+		dao.Execute(cross(cur), id)
+	})
+	urequire.Equal(t, "Executed", dao.StatusOf(id))
+}

--- a/gno/r/daoidentity/suite/lifecycle_test.gno
+++ b/gno/r/daoidentity/suite/lifecycle_test.gno
@@ -8,6 +8,7 @@ import (
 	"gno.land/p/samcrew/basedao"
 	"gno.land/p/samcrew/daocond"
 	"gno.land/p/samcrew/daokit"
+	"gno.land/r/samcrew/daoidentity/attacker"
 	"gno.land/r/samcrew/daoidentity/dao"
 )
 
@@ -99,4 +100,27 @@ func TestAPersistedPassedProposalStillExecutes(cur realm, t *testing.T) {
 		dao.Execute(cross(cur), id)
 	})
 	urequire.Equal(t, "Executed", dao.StatusOf(id))
+}
+
+// A private extension is readable only by the DAO's own realm.
+//
+// The check used to be a stack walk, which answers "is a DAO frame innermost",
+// not "is my caller the DAO". That let anything the DAO invoked without crossing
+// read a private extension — including a proposer-authored ExecuteLambda
+// callback. Requiring the DAO's own live realm closes that by construction: a
+// callback given no realm cannot produce one.
+func TestAPrivateExtensionIsReadableOnlyByItsOwnRealm(cur realm, t *testing.T) {
+	urequire.Equal(t, "TOP-SECRET", dao.ReadSecret(cross(cur)),
+		"the DAO's own realm must be able to read it")
+
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		attacker.ReadSecret(cross(cur))
+	})
+}
+
+// A public extension ignores the realm, so cross-realm membership checks — the
+// documented use of MembersViewExtension — keep working.
+func TestAPublicExtensionIsReadableByAnyRealm(cur realm, t *testing.T) {
+	urequire.True(t, dao.ReadPublicExtension(cross(cur)), "own realm")
+	urequire.True(t, attacker.ReadPublicExtension(cross(cur)), "any other realm")
 }

--- a/gno/r/daoidentity/suite/lifecycle_test.gno
+++ b/gno/r/daoidentity/suite/lifecycle_test.gno
@@ -124,3 +124,19 @@ func TestAPublicExtensionIsReadableByAnyRealm(cur realm, t *testing.T) {
 	urequire.True(t, dao.ReadPublicExtension(cross(cur)), "own realm")
 	urequire.True(t, attacker.ReadPublicExtension(cross(cur)), "any other realm")
 }
+
+// InstantExecute is same-realm only, and that is deliberate.
+//
+// Every step threads the caller's realm, and each entry point requires its own,
+// so handing it a DAO belonging to another realm is refused. Before the gate
+// existed this appeared to work — by making the foreign DAO act under the
+// caller's identity, which is the donation shape itself.
+//
+// A parent DAO drives a child by going through the child REALM's crossing
+// function, so the child mints its own realm and sees the parent as its caller.
+func TestInstantExecuteIsSameRealmOnly(cur realm, t *testing.T) {
+	urequire.AbortsWithMessage(t, cur, realmMismatch, func() {
+		daokit.InstantExecute(dao.Handle(), addDistinctMemberReq(
+			"g1v9kxjcm9ta047h6lta047h6lta047h6lzd40g4"), cur)
+	})
+}


### PR DESCRIPTION
Stacked on #71. **Merge order: #69 → #70 → #71 → this.**

Implements the five recommendations left open by the security review of #69, plus the defects two further reviews found in these fixes.

## The Render-brick P0

Any realm holding the DAO handle could permanently brick a proposal that had met its condition, with one cheap call. `Render` is cross-realm and reached `GetProposals`, which called `UpdateStatus` on every proposal it walked — its own comment said *"costly and probably insecure"*. `Vote` never moves the status, so a condition-met proposal sat at `Open`; the render flipped it to `Passed`; `Execute` then refused it forever because it demanded exactly `Open`.

Reading no longer writes. `DisplayStatus()` computes what to show; `Status` is written **only** by `Execute`. `Execute` is gated on the condition and nothing else.

The executed marker moved **before** the handler. That ordering was previously irrelevant — "must be `Open`" happened to block re-entry — so removing that demand without moving the marker would have opened re-entrancy. Mutating it back does not fail the suite: **it hangs**, recursing without bound. Worth knowing as a CI failure mode.

## The extension gate

`Extension(path)` → `Extension(path, rlm)`. A **private** extension requires the DAO's own live realm; a public one ignores it, so `MembersViewExtension` — the documented cross-realm membership check — keeps working. Gating public ones too breaks it, and the suite catches that mutation as well as the reverse.

## Migration is no longer as cheap as adding a member

It shared `InitialCondition` with "Add Member", for an action that hands proposer-authored code the DAO's live realm and full private state. Now a distinct `Config.MigrationCondition`, and a required label — every migration used to render as the same fixed sentence, so a version bump and a takeover looked identical in the proposal you approved.

## Three defects the reviews found in the above

Each of these was mine, in a fix.

**`Vote` was left demanding `Open` while `Execute` was relaxed.** With `UpdateStatus` still exported, that *inverted* the bug: persisting `Passed` stopped bricking a proposal and started **locking it in** — votes frozen, support unwithdrawable, execution guaranteed. `UpdateStatus` is gone; `Vote` and `Execute` share one terminal state.

**The migration default could make migration permanently unreachable.** My first attempt replaced a role-gated condition with a members threshold, which *dropped the role gate* — measured against `And(MembersThreshold(0.4), RoleCount(1,"officer"))`, a ballot that **failed** the ordinary action **passed** the migration. Conjoining instead fixed that but broke the other direction: role-governed DAOs would need a member majority they may never assemble, unrepairably, since changing the rule needs a migration. A DAO that chose its own governance now keeps it; only default governance gets the raise to 80%.

**The `IsCurrent()` half of the extension gate had no test.** Replacing it with a pkgpath comparison survived the whole suite — and under that mutation a callee handed the DAO's dead-frame realm reads the private extension. Covered now.

## Also

- `InstantExecute` is same-realm-only, documented and tested. The cross-realm form only ever worked *because of* the vulnerability — it is the donation shape.
- `Execute` is **not retry-safe**: gno's `recover()` does not roll back realm state, so a host that recovers around a failing `Execute` burns the proposal. Documented; the ordering is worth more than the retry.
- `New` no longer writes derived defaults into the caller's `Config` — the migration condition closes over the member store, so a reused `Config` gave the second DAO the first one's membership.
- `Private` re-documented: on a public chain nothing is confidential and `ExtensionsList` is ungated by design. It restricts **capability**, not secrecy. Gating the listing would have been theatre.
- The migration label is caller-written text, not a safety control.

## Verification

10 packages ok · lint clean · `fmt -diff` clean · zero `gno: downloading` · README fixtures match.

Every guard mutation-checked. Two mutations survive and are **equivalent, not gaps**: with `Passed` never stored, filtering on the raw status is exactly "not yet executed" — so the filters use it directly, which also stops them evaluating every condition a second time.